### PR TITLE
FIX: when cookies are there assume user present

### DIFF
--- a/src/index.js
+++ b/src/index.js
@@ -6,6 +6,7 @@ import RocketChatInstance from './lib/api';
 import { RCInstanceProvider } from './context/RCInstance';
 import { ToastBarProvider } from '@rocket.chat/fuselage-toastbar';
 import { useToastStore, useUserStore } from './store';
+import Cookies from 'js-cookie';
 
 export const RCComponent = ({
   isClosable = false,
@@ -41,8 +42,7 @@ export const RCComponent = ({
   );
 
   useEffect(() => {
-    const cookiesPresent =
-      RCInstance.getCookies().rc_token && RCInstance.getCookies().rc_uid;
+    const cookiesPresent = Cookies.get('rc_token') && Cookies.get('rc_uid');
     if (cookiesPresent) {
       setIsUserAuthenticated(true);
     }


### PR DESCRIPTION
- use `js-cookie` instead of an instance (RCInstance) to get the cookies so that if cookies are present then the user is assumed to be logged in using some source