### PR TITLE
Updated peer dependency for React.js

### DIFF
--- a/package.json
+++ b/package.json
@@ -32,8 +32,8 @@
   "author": "",
   "license": "ISC",
   "peerDependencies": {
-    "react": "^17.0.2",
-    "react-dom": "^17.0.2"
+    "react": "^17.0.2 || ^18",
+    "react-dom": "^17.0.2 || ^18"
   },
   "devDependencies": {
     "@babel/core": "^7.17.7",

--- a/playground/package-lock.json
+++ b/playground/package-lock.json
@@ -72,8 +72,8 @@
         "rollup-plugin-terser": "^7.0.2"
       },
       "peerDependencies": {
-        "react": "^17.0.2",
-        "react-dom": "^17.0.2"
+        "react": "^17.0.2 || ^18",
+        "react-dom": "^17.0.2 || ^18"
       }
     },
     "../node_modules/react": {


### PR DESCRIPTION
# Update Peer Dependency

 Before the EmbeddedChat only supports node with version ^17.0.2 which throws error when added to the project. Now the support of ^18 has been added

- [x] Added ^18 to react and react-dom

Fixes #52 
