### PR TITLE
Fix Message Display after clicking on Go Back from starred/pinned message 

### DIFF
--- a/src/components/ChatBody/ChatBody.js
+++ b/src/components/ChatBody/ChatBody.js
@@ -18,17 +18,22 @@ const ChatBody = ({ height, anonymousMode }) => {
     (state) => state.isUserAuthenticated
   );
 
-  const handleGoBack = async () => {
+  async function getMessages(anonymousMode) {
     const { messages } = await RCInstance.getMessages(anonymousMode);
+    setMessages(messages);
+  }
+
+  const handleGoBack = async () => {
+    if (isUserAuthenticated) {
+      getMessages();
+    } else {
+      getMessages(anonymousMode);
+    }
     setFilter(false);
     setMessages(messages);
   };
 
   useEffect(() => {
-    async function getMessages(anonymousMode) {
-      const { messages } = await RCInstance.getMessages(anonymousMode);
-      setMessages(messages);
-    }
     if (isUserAuthenticated) {
       RCInstance.realtime(() => getMessages());
       getMessages();

--- a/src/components/ChatBody/ChatBody.js
+++ b/src/components/ChatBody/ChatBody.js
@@ -1,6 +1,6 @@
 /* eslint-disable no-shadow */
 import { Box } from '@rocket.chat/fuselage';
-import React, { useContext, useEffect } from 'react';
+import React, { useCallback, useContext, useEffect } from 'react';
 import PropTypes from 'prop-types';
 import styles from './ChatBody.module.css';
 import RCContext from '../../context/RCInstance';
@@ -18,10 +18,10 @@ const ChatBody = ({ height, anonymousMode }) => {
     (state) => state.isUserAuthenticated
   );
 
-  const getMessages = async (anonymousMode) => {
+  const getMessages = useCallback(async (anonymousMode) => {
     const { messages } = await RCInstance.getMessages(anonymousMode);
     setMessages(messages);
-  };
+  }, []);
 
   const handleGoBack = async () => {
     if (isUserAuthenticated) {

--- a/src/components/ChatBody/ChatBody.js
+++ b/src/components/ChatBody/ChatBody.js
@@ -18,10 +18,10 @@ const ChatBody = ({ height, anonymousMode }) => {
     (state) => state.isUserAuthenticated
   );
 
-  async function getMessages(anonymousMode) {
+  const getMessages = async (anonymousMode) => {
     const { messages } = await RCInstance.getMessages(anonymousMode);
     setMessages(messages);
-  }
+  };
 
   const handleGoBack = async () => {
     if (isUserAuthenticated) {
@@ -30,7 +30,6 @@ const ChatBody = ({ height, anonymousMode }) => {
       getMessages(anonymousMode);
     }
     setFilter(false);
-    setMessages(messages);
   };
 
   useEffect(() => {

--- a/src/components/ChatBody/ChatBody.js
+++ b/src/components/ChatBody/ChatBody.js
@@ -41,7 +41,7 @@ const ChatBody = ({ height, anonymousMode }) => {
     }
 
     return () => RCInstance.close();
-  }, [isUserAuthenticated]);
+  }, [isUserAuthenticated, getMessages]);
 
   return (
     <Box


### PR DESCRIPTION
### Description:

Messages does not display after we click back oprion from starred or pinned messages.

### Steps to reproduce:

1. Click on pinned/starred messages at the chat header
2. Once the pinned/starred messages come, click on `Go Back`
3. All the messages should come successfully on clicking back

### Expected behavior:
All the messages should display on clicking Go back.

### Actual behavior:
Empty chat body
[screen-capture (1).webm](https://user-images.githubusercontent.com/42451210/213522801-36c805b7-ae27-49a7-9330-99e41ec2670a.webm)


Fix #93 