### PR TITLE
[IMPROVE] shift+enter adds a newline in chat input

### DIFF
--- a/src/components/ChatInput/ChatInput.js
+++ b/src/components/ChatInput/ChatInput.js
@@ -115,6 +115,10 @@ const ChatInput = () => {
             }
           }}
           onKeyDown={(e) => {
+            if (e.shiftKey && e.keyCode === 13) {
+              // new line with shift enter. do nothing.
+              return;
+            }
             if (e.ctrlKey && e.keyCode === 13) {
               // Insert line break in text input field
               messageRef.current.value += '\n';


### PR DESCRIPTION
# Shift+Enter adds a new line
Currently, only ctrl+enter adds a newline instead of rocket.chat in which both shift+enter and ctrl+enter add a newline. many users including me are used to the shift+enter way of adding new lines.