### PR TITLE
[NEW] Using ddp to get messages.

### DIFF
--- a/src/lib/cloneArray.js
+++ b/src/lib/cloneArray.js
@@ -1,0 +1,12 @@
+/**
+ * Deep Cloning upto 2 levels
+ * @param {*} array
+ * @returns
+ */
+const cloneArray = (array) => {
+  const newArray = [...array].map((item) =>
+    typeof item === 'object' ? { ...item } : item
+  );
+  return newArray;
+};
+export default cloneArray;

--- a/src/store/messageStore.js
+++ b/src/store/messageStore.js
@@ -1,4 +1,38 @@
 import create from 'zustand';
+import cloneArray from '../lib/cloneArray';
+
+// Caution: Not a pure function
+const insertMessage = (messages, message) => {
+  const idx = messages.findIndex((m) => new Date(m.ts) < new Date(message.ts));
+  if (idx === -1) {
+    // all the messages are newer than the current message, insert at last
+    messages.push(message);
+  } else if (idx === 0) {
+    // the message is the latest one, insert at front
+    messages.unshift(message);
+  } else {
+    messages.splice(idx, 0, message);
+  }
+  return messages;
+};
+
+/**
+ * Inserts the message or updates if already present in the list. Makes a copy of the messages[].
+ * @param {*} messages
+ * @param {*} message
+ * @returns newMessageList
+ */
+const upsertMessage = (messages, message) => {
+  const newMessages = cloneArray(messages);
+  const idx = newMessages.findIndex((m) => m._id === message._id);
+  if (idx === -1) {
+    // the message is new, insert it.
+    return insertMessage(newMessages, message);
+  }
+  // message with the given id is present. update it.
+  newMessages[idx] = message;
+  return newMessages;
+};
 
 const useMessageStore = create((set) => ({
   messages: [],
@@ -7,17 +41,24 @@ const useMessageStore = create((set) => ({
   messageToReport: NaN,
   showReportMessage: false,
   isRecordingMessage: false,
-  setFilter: (filter) => set((state) => ({ ...state, filtered: filter })),
-  setMessages: (messages) => set((state) => ({ ...state, messages })),
+  setFilter: (filter) => set(() => ({ filtered: filter })),
+  setMessages: (messages) => set(() => ({ messages })),
+  upsertMessage: (message) =>
+    set((state) => ({
+      messages: upsertMessage(state.messages, message),
+    })),
+  removeMessage: (messageId) =>
+    set((state) => ({
+      messages: cloneArray(state.messages).filter((m) => m._id !== messageId),
+    })),
   setEditMessage: (editMessage) => set(() => ({ editMessage })),
   setMessageToReport: (messageId) =>
-    set((state) => ({ ...state, messageToReport: messageId })),
+    set(() => ({ messageToReport: messageId })),
   toggleShowReportMessage: () => {
-    set((state) => ({ ...state, showReportMessage: !state.showReportMessage }));
+    set((state) => ({ showReportMessage: !state.showReportMessage }));
   },
   toogleRecordingMessage: () => {
     set((state) => ({
-      ...state,
       isRecordingMessage: !state.isRecordingMessage,
     }));
   },


### PR DESCRIPTION
# Brief Title
Currently, we are polling all the messages each time we receive the stream-notify-room message. I have made a few changes to use DDP and API calls together for efficient real-time functionality.
1. On the first load HTTP call is made to fetch messages.
2. A DDP subscription is made to receive new messages and updates about the messages.
3. Currently DDP is enabled for:
- Case 1: New messages are inserted into the message list
- Case 2: Updates on already loaded message
- Case 3: handling delete message event
### API Changes
Now, listening to new messages has been made a lot easier. To listen for messages. One needs to call `await RCInstance.connect()` then one can add as many listeners as he sees fit by using `RCInstance.addMessageListener(callback);`
For example:
```
useEffect(() => {
    if (isUserAuthenticated) {
      RCInstance.connect().then(() => {
        RCInstance.addMessageListener(upsertMessage);
        RCInstance.addMessageDeleteListener(removeMessage);
      });
      getMessagesAndRoles();
    } else {
      getMessagesAndRoles(anonymousMode);
    }

    return () => {
      RCInstance.close();
      RCInstance.removeMessageListener(upsertMessage);
      RCInstance.removeMessageDeleteListener(removeMessage);
    };
  }, [isUserAuthenticated, getMessagesAndRoles, upsertMessage, removeMessage]);
```
### MessageStore changes
Added `upsertMessage(message)` action that will insert a new message or update it if it is already present. Proper care has been taken to insert the message in the right position.
## Acceptance Criteria fulfillment

- [x] DDP connection for real-time messages
- [x] Listening to messages using `addMessagelistener`, `addMessageDeleteListener`
- [x] upsertMessage in `messageStore` for insert/update message. `removeMessage` to remove message by id from the list

## Video/Screenshots

https://user-images.githubusercontent.com/15830206/222566420-d995232c-79ec-4845-94fd-3ed301b255e5.mp4

