### PR TITLE
fix:tagging user section not closing

### DIFF
--- a/src/lib/searchToMentionUser.js
+++ b/src/lib/searchToMentionUser.js
@@ -7,39 +7,44 @@ export const searchToMentionUser = (
   setmentionIndex,
   setshowMembersList
 ) => {
-  if (message.length === 0) return;
-  let lastChar = message[message.length - 1];
+  const lastChar = message[message.length - 1];
+  if (message.length === 0) {
+    setshowMembersList(false);
+    setStartReading(false);
+    setFilteredMembers([]);
+    setmentionIndex(-1);
+    return;
+  }
 
   if (lastChar === '@') {
+    if (message.length > 1 && message[message.length - 2] !== ' ') return;
     setStartReading(true);
     setFilteredMembers(roomMembers);
     setmentionIndex(0);
     setshowMembersList(true);
-  } else {
-    if (startReading) {
-      if (lastChar === ' ') {
-        setStartReading(false);
-        setFilteredMembers([]);
-        setmentionIndex(-1);
-        setshowMembersList(false);
-      } else {
-        let c = message.lastIndexOf('@');
+  } else if (startReading) {
+    if (lastChar === ' ') {
+      setStartReading(false);
+      setFilteredMembers([]);
+      setmentionIndex(-1);
+      setshowMembersList(false);
+    } else {
+      const c = message.lastIndexOf('@');
 
-        setFilteredMembers(
-          roomMembers.filter(
-            (member) =>
-              member.name
-                .toLowerCase()
-                .includes(message.substring(c + 1).toLowerCase()) ||
-              member.username
-                .toLowerCase()
-                .includes(message.substring(c + 1).toLowerCase())
-          )
-        );
+      setFilteredMembers(
+        roomMembers.filter(
+          (member) =>
+            member.name
+              .toLowerCase()
+              .includes(message.substring(c + 1).toLowerCase()) ||
+            member.username
+              .toLowerCase()
+              .includes(message.substring(c + 1).toLowerCase())
+        )
+      );
 
-        setshowMembersList(true);
-        setmentionIndex(0);
-      }
+      setshowMembersList(true);
+      setmentionIndex(0);
     }
   }
 };


### PR DESCRIPTION
# Brief Title
Whenever we type @ in empty textArea and erase it the list of the user to be mentioned still remains there.
The mention box should not be active when the user type @ after the text without the space

## Acceptance Criteria fulfilment

- [x] handling when textarea is empty
- [x] handling when @ is typed after the text without the space (in this case there should be no suggestion)


Fixes # (issue)
#163 
## Video/Screenshots

https://user-images.githubusercontent.com/67755128/222644141-828aa4bb-620e-4b1d-87d6-559195af1359.mp4

