### PR TITLE
[FIX] Contributor Widget Not Updating

### DIFF
--- a/README.md
+++ b/README.md
@@ -7,8 +7,8 @@ _EmbeddedChat is a full-stack React component node module of the RocketChat appl
 ![embeddedchatwall](https://user-images.githubusercontent.com/73601258/178119162-ecabb9b7-e3ae-4c70-8ab2-f6c02856f4c6.png)
 
 <div align='center' width='100%'>
-<a href="https://www.middlewarehq.com/">
-<img src="https://open-source-assets.middlewarehq.com/svgs/RocketChat-EmbeddedChat-contributor-metrics-dark-widget.svg?metrics=true"></img>
+<a href="https://github.com/monoclehq">
+<img src="https://open-source-assets.middlewarehq.com/svgs/RocketChat-EmbeddedChat-contributor-metrics-dark-widget.svg?caching=true"></img>
 </a>
 </div>
 


### PR DESCRIPTION
# Update Contributor Widget Headers to Allow Auto Updation

## Acceptance Criteria fulfillment

- [x] Update Contributor Widget CacheControl max-age header to allow the GitHub caching  mechanism to update the widget on relevant changes.
- [x] Updated Widget rendering URL to disable cached image and allow new headers. 


Fixes # (issue)

#208 

## Video/Screenshots

![image](https://user-images.githubusercontent.com/70485812/229663078-0a6dd054-b66d-47ed-ab39-38811521772a.png)

