### PR TITLE
fix/#132(task-9) - Refactor-useEffects

### DIFF
--- a/packages/react/src/index.js
+++ b/packages/react/src/index.js
@@ -41,6 +41,7 @@ export const EmbeddedChat = ({
   const [fullScreen, setFullScreen] = useState(false);
   const setToastbarPosition = useToastStore((state) => state.setPosition);
   const setShowAvatar = useUserStore((state) => state.setShowAvatar);
+  
   useEffect(() => {
     setToastbarPosition(toastBarPosition);
     setShowAvatar(showAvatar);
@@ -79,8 +80,14 @@ export const EmbeddedChat = ({
       setRCInstance(newRCInstance);
     };
 
+    const handleLogoutAndReInstantiate = () => {
+      RCInstance.close()
+        .then(reInstantiate)
+        .catch(console.error);
+    };
+
     if (RCInstance.rcClient.loggedIn()) {
-      RCInstance.close().then(reInstantiate).catch(console.error);
+      handleLogoutAndReInstantiate();
     } else {
       reInstantiate();
     }
@@ -103,8 +110,7 @@ export const EmbeddedChat = ({
   const setAuthenticatedName = useUserStore((state) => state.setName);
 
   useEffect(() => {
-    RCInstance.auth.onAuthChange((user) => {
-      // getUserEssentials();
+    const handleAuthChange = (user) => {
       if (user) {
         RCInstance.connect()
           .then(() => {
@@ -121,8 +127,10 @@ export const EmbeddedChat = ({
       } else {
         setIsUserAuthenticated(false);
       }
-    });
-  }, [RCInstance]);
+    };
+
+    RCInstance.auth.onAuthChange(handleAuthChange);
+  }, [RCInstance, setIsUserAuthenticated]);
 
   const attachmentWindowOpen = useAttachmentWindowStore((state) => state.open);
 


### PR DESCRIPTION
Refactored useEffects in `src/index.js`

## Acceptance Criteria fulfillment

- [X] Task 9 - Refactor useEffects


Fixes #132 


## Description

In this refactoring:

1. The first `useEffect` block is kept as is since it doesn't require changes.

2. The second `useEffect` block is refactored to create a separate function `handleLogoutAndReInstantiate` to handle the logic of logging out and reinstantiating the `RCInstance`. This function is called conditionally based on the user's login status.

3. The third `useEffect` block is refactored to extract the logic into a function named `handleAuthChange`, which is called when the authentication status changes.