### PR TITLE
Fix text alignment inside message-body.

### DIFF
--- a/packages/react/src/components/Markdown/Markdown.css
+++ b/packages/react/src/components/Markdown/Markdown.css
@@ -1,0 +1,6 @@
+p {
+    margin: 0;
+    padding: 0;
+    display: flex;
+    align-items: center;
+}

--- a/packages/react/src/components/Markdown/Markdown.js
+++ b/packages/react/src/components/Markdown/Markdown.js
@@ -5,6 +5,7 @@ import { Box } from '../Box';
 import { css } from '@emotion/react'; // Import Emotion's css function
 import { markdownStyles } from './Markdown.styles'; // Import Emotion styles
 import MessageEmoji from '../MessageEmoji/MessageEmoji';
+import {} from './Markdown.css'
 
 const Markdown = ({ body, isReaction = false }) => {
   if (isReaction) {


### PR DESCRIPTION
# Fix wrong text alignment inside message-bodys

## Acceptance Criteria fulfillment

- [x]  Text is aligned in the center of the message body.


Fixes #273

## Video/Screenshots
![Fix](https://github.com/RocketChat/EmbeddedChat/assets/135323978/81236489-2e90-4d12-91b3-651487e01493)

## Important note
The error could initially only be fixed by creating a new CSS file. It seems that the CSS attributes in the "Markdown.styles.js" file are not applied correctly to the HTML objects. Someone should take a closer look here and fix it if necessary.