### PR TITLE
Fix/#265 added RC_HOST as env variable

### DIFF
--- a/README.md
+++ b/README.md
@@ -106,6 +106,12 @@ yarn storybook
 
 Till now, storybook should be up and running. You can play around with EmbeddedChat and it's component and see changes in storybook in real-time.
 
+By default, the Rocket Chat server host is http://localhost:3000, in case you have Rocket Chat server running on any other port/server you can try set up custome url as ```STORYBOOK_RC_HOST=<your-custom-url>``` variable by creating a ``.env`` file in ```packages/react``` directory or simply run this commmand:
+
+```bash
+STORYBOOK_RC_HOST=<your-custom-url> yarn storybook
+```
+
 ### Working with api and auth packages.
 
 #### Starting auth dev environment

--- a/README.md
+++ b/README.md
@@ -106,7 +106,7 @@ yarn storybook
 
 Till now, storybook should be up and running. You can play around with EmbeddedChat and it's component and see changes in storybook in real-time.
 
-By default, the Rocket Chat server host is http://localhost:3000, in case you have Rocket Chat server running on any other port/server you can try set up custome url as ```STORYBOOK_RC_HOST=<your-custom-url>``` variable by creating a ``.env`` file in ```packages/react``` directory or simply run this commmand:
+By default, the Rocket Chat server host is http://localhost:3000, in case you have Rocket Chat server running on any other port/server you can try set up custom url as ```STORYBOOK_RC_HOST=<your-custom-url>``` variable by creating a ``.env`` file in ```packages/react``` directory or simply run this commmand in ```packages/react```:
 
 ```bash
 STORYBOOK_RC_HOST=<your-custom-url> yarn storybook

--- a/packages/react/src/index.js
+++ b/packages/react/src/index.js
@@ -20,7 +20,7 @@ export const EmbeddedChat = ({
   moreOpts = false,
   width = '100%',
   height = '50vh',
-  host = 'http://localhost:3000',
+  host = process.env.STORYBOOK_RC_HOST || 'http://localhost:3000',
   roomId = 'GENERAL',
   channelName,
   anonymousMode = false,

--- a/packages/react/src/stories/EmbeddedChat.stories.js
+++ b/packages/react/src/stories/EmbeddedChat.stories.js
@@ -9,7 +9,7 @@ export default {
 // More on writing stories with args: https://storybook.js.org/docs/react/writing-stories/args
 export const Simple = {
   args: {
-    host: 'http://localhost:3000',
+    host: process.env.STORYBOOK_RC_HOST || 'http://localhost:3000',
     roomId: 'GENERAL',
     GOOGLE_CLIENT_ID: '',
     isClosable: true,

--- a/packages/react/src/stories/EmbeddedChatAuthToken.stories.js
+++ b/packages/react/src/stories/EmbeddedChatAuthToken.stories.js
@@ -9,7 +9,7 @@ export default {
 // More on writing stories with args: https://storybook.js.org/docs/react/writing-stories/args
 export const Simple = {
   args: {
-    host: 'http://localhost:3000',
+    host: process.env.STORYBOOK_RC_HOST || 'http://localhost:3000',
     roomId: 'GENERAL',
     GOOGLE_CLIENT_ID: '',
     isClosable: true,

--- a/packages/react/src/stories/EmbeddedChatTheme.stories.js
+++ b/packages/react/src/stories/EmbeddedChatTheme.stories.js
@@ -9,7 +9,7 @@ export default {
 // More on writing stories with args: https://storybook.js.org/docs/react/writing-stories/args
 export const WithTheme = {
   args: {
-    host: 'http://localhost:3000',
+    host: process.env.STORYBOOK_RC_HOST || 'http://localhost:3000',
     roomId: 'GENERAL',
     GOOGLE_CLIENT_ID: '',
     isClosable: true,

--- a/packages/react/src/stories/EmbeddedChatWithoutHeader.stories.js
+++ b/packages/react/src/stories/EmbeddedChatWithoutHeader.stories.js
@@ -9,7 +9,7 @@ export default {
 // More on writing stories with args: https://storybook.js.org/docs/react/writing-stories/args
 export const Simple = {
   args: {
-    host: 'http://localhost:3000',
+    host: process.env.STORYBOOK_RC_HOST || 'http://localhost:3000',
     roomId: 'GENERAL',
     GOOGLE_CLIENT_ID: '',
     isClosable: true,


### PR DESCRIPTION
# Added RC_HOST variable to set up custom host for Rocket Chat Server

## Acceptance Criteria fulfillment

- [x] Added STORYBOOK_RC_HOST as an environment variable to set up a custom host.
- [x] Updated README.md accordingly.

Fixes #265

## Screenshot
![running-with-custom-rc-host-2](https://github.com/RocketChat/EmbeddedChat/assets/117712672/a8978935-6d49-480a-9fff-00ac9b9d388a)

In the screenshot using the host as 4000