### PR TITLE
Added markdown shortcuts for bold and italic font style (ctrl+b,ctrl+i)

### DIFF
--- a/packages/react/src/components/ChatInput/ChatInput.js
+++ b/packages/react/src/components/ChatInput/ChatInput.js
@@ -342,6 +342,30 @@ const ChatInput = () => {
                 // new line with shift enter. do nothing.
                 return;
               }
+              if (e.ctrlKey && e.key === 'i') {
+                e.preventDefault();
+                let start = e.target.selectionStart;
+                let end = e.target.selectionEnd;
+                if (end - start > 0) {
+                  const italic = ` _${messageRef.current.value.slice(start, end)}_ `;
+                  messageRef.current.value = (messageRef.current.value.slice(0, start) + italic + messageRef.current.value.slice(end));
+                } else {
+                  messageRef.current.value = "__";
+                  e.target.setSelectionRange(start + 1, start + 1);
+                }
+              }
+              if (e.ctrlKey && e.key === 'b') {
+                e.preventDefault();
+                let start = e.target.selectionStart;
+                let end = e.target.selectionEnd;
+                if (end - start > 0) {
+                  const bold = ` *${messageRef.current.value.slice(start, end)}* `;
+                  messageRef.current.value = (messageRef.current.value.slice(0, start) + bold + messageRef.current.value.slice(end));
+                } else {
+                  messageRef.current.value = "**";
+                  e.target.setSelectionRange(start + 1, start + 1);
+                }
+              }
               if ((e.ctrlKey || e.metaKey) && e.keyCode === 13) {
                 // Insert line break in text input field
                 messageRef.current.value += '\n';


### PR DESCRIPTION
Markdown shortcuts for bold and italic

The user can now style the font to bold and italic by using ctrl+b and ctrl+i shortcuts respectively.

Behavior:

Once the user presses any of the above mentioned shortcut keys after selecting some text, the text will be wrapped around "* *" or "_ _" to ensure that the text gets styled accordingly when the message is actually sent.
If the shortcut keys are pressed while no text is selected, the symbols will still appear but with the cursor between them.

The video below depicts the actual behavior:

https://github.com/RocketChat/EmbeddedChat/assets/98230836/86b34b9f-323d-43fe-955a-1df347edf8d0


