### PR TITLE
Remove unused packages and fuselage

### DIFF
--- a/packages/api/package.json
+++ b/packages/api/package.json
@@ -14,6 +14,7 @@
 	"author": "",
 	"license": "ISC",
 	"devDependencies": {
+		"parcel": "^2.10.3",
 		"rollup": "^3.23.0",
 		"rollup-plugin-dts": "^6.0.1",
 		"rollup-plugin-esbuild": "^5.0.0",

--- a/packages/react/package.json
+++ b/packages/react/package.json
@@ -83,10 +83,7 @@
   "dependencies": {
     "@embeddedchat/api": "1.0.0",
     "@emotion/babel-preset-css-prop": "^11.11.0",
-    "@rocket.chat/fuselage": "^0.31.23",
     "@rocket.chat/fuselage-hooks": "^0.31.23",
-    "@rocket.chat/fuselage-polyfills": "^0.31.23",
-    "@rocket.chat/fuselage-toastbar": "^0.31.23",
     "@rocket.chat/icons": "^0.31.23",
     "@rocket.chat/message-parser": "^0.31.25",
     "@rocket.chat/sdk": "^1.0.0-alpha.42",
@@ -95,21 +92,17 @@
     "color": "^4.2.3",
     "color-alpha": "^1.1.3",
     "date-fns": "^2.30.0",
-    "dompurify": "^3.0.3",
     "emoji-picker-react": "^4.4.9",
     "emoji-toolkit": "^7.0.1",
     "gapi-cjs": "^1.0.3",
     "he": "^1.2.0",
     "js-cookie": "^3.0.5",
-    "marked": "^4.0.17",
     "normalize.css": "^8.0.1",
     "prop-types": "^15.8.1",
     "react": "^17.0.2 || ^18",
     "react-dom": "^17.0.2 || ^18",
     "react-virtuoso": "^4.3.10",
     "reactjs-popup": "^2.0.5",
-    "scheduler": "^0.23.0",
-    "stylis": "^4.2.0",
     "zustand": "^4.3.8"
   }
 }

--- a/packages/react/src/components/uiKit/blocks/PreviewBlock.js
+++ b/packages/react/src/components/uiKit/blocks/PreviewBlock.js
@@ -1,84 +1,84 @@
-import {
-  MessageGenericPreview,
-  MessageGenericPreviewContent,
-  MessageGenericPreviewDescription,
-  MessageGenericPreviewCoverImage,
-  MessageGenericPreviewTitle,
-  MessageGenericPreviewFooter,
-  MessageGenericPreviewThumb,
-  Box,
-} from '@rocket.chat/fuselage';
-import * as UiKit from '@rocket.chat/ui-kit';
-import {
-  isPreviewBlockWithThumb,
-  isPreviewBlockWithPreview,
-} from '@rocket.chat/ui-kit';
-import React, { memo } from 'react';
+// import {
+//   MessageGenericPreview,
+//   MessageGenericPreviewContent,
+//   MessageGenericPreviewDescription,
+//   MessageGenericPreviewCoverImage,
+//   MessageGenericPreviewTitle,
+//   MessageGenericPreviewFooter,
+//   MessageGenericPreviewThumb,
+//   Box,
+// } from '@rocket.chat/fuselage';
+// import * as UiKit from '@rocket.chat/ui-kit';
+// import {
+//   isPreviewBlockWithThumb,
+//   isPreviewBlockWithPreview,
+// } from '@rocket.chat/ui-kit';
+// import React, { memo } from 'react';
 
-import ContextBlock from './ContextBlock';
+// import ContextBlock from './ContextBlock';
 
-const PreviewBlock = ({ block, surfaceRenderer }) => (
-  <Box>
-    <MessageGenericPreview>
-      {isPreviewBlockWithPreview(block) && block.preview?.dimensions && (
-        <MessageGenericPreviewCoverImage
-          width={block.preview.dimensions.width}
-          height={block.preview.dimensions.height}
-          url={block.preview.url}
-        />
-      )}
-      <MessageGenericPreviewContent
-        thumb={
-          isPreviewBlockWithThumb(block) ? (
-            <MessageGenericPreviewThumb>
-              <MessageGenericPreviewCoverImage
-                height={192}
-                width={368}
-                url={block.thumb.url}
-              />
-            </MessageGenericPreviewThumb>
-          ) : undefined
-        }
-      >
-        {Array.isArray(block.title) ? (
-          <MessageGenericPreviewTitle
-            externalUrl={
-              isPreviewBlockWithPreview(block) ? block.externalUrl : undefined
-            }
-          >
-            {block.title.map((title) =>
-              surfaceRenderer.renderTextObject(
-                title,
-                0,
-                UiKit.BlockContext.NONE
-              )
-            )}
-          </MessageGenericPreviewTitle>
-        ) : null}
-        {Array.isArray(block.description) ? (
-          <MessageGenericPreviewDescription clamp>
-            {block.description.map((description) =>
-              surfaceRenderer.renderTextObject(
-                description,
-                0,
-                UiKit.BlockContext.NONE
-              )
-            )}
-          </MessageGenericPreviewDescription>
-        ) : null}
-        {block.footer && (
-          <MessageGenericPreviewFooter>
-            <ContextBlock
-              block={block.footer}
-              surfaceRenderer={surfaceRenderer}
-              context={UiKit.BlockContext.BLOCK}
-              index={0}
-            />
-          </MessageGenericPreviewFooter>
-        )}
-      </MessageGenericPreviewContent>
-    </MessageGenericPreview>
-  </Box>
-);
+// const PreviewBlock = ({ block, surfaceRenderer }) => (
+//   <Box>
+//     <MessageGenericPreview>
+//       {isPreviewBlockWithPreview(block) && block.preview?.dimensions && (
+//         <MessageGenericPreviewCoverImage
+//           width={block.preview.dimensions.width}
+//           height={block.preview.dimensions.height}
+//           url={block.preview.url}
+//         />
+//       )}
+//       <MessageGenericPreviewContent
+//         thumb={
+//           isPreviewBlockWithThumb(block) ? (
+//             <MessageGenericPreviewThumb>
+//               <MessageGenericPreviewCoverImage
+//                 height={192}
+//                 width={368}
+//                 url={block.thumb.url}
+//               />
+//             </MessageGenericPreviewThumb>
+//           ) : undefined
+//         }
+//       >
+//         {Array.isArray(block.title) ? (
+//           <MessageGenericPreviewTitle
+//             externalUrl={
+//               isPreviewBlockWithPreview(block) ? block.externalUrl : undefined
+//             }
+//           >
+//             {block.title.map((title) =>
+//               surfaceRenderer.renderTextObject(
+//                 title,
+//                 0,
+//                 UiKit.BlockContext.NONE
+//               )
+//             )}
+//           </MessageGenericPreviewTitle>
+//         ) : null}
+//         {Array.isArray(block.description) ? (
+//           <MessageGenericPreviewDescription clamp>
+//             {block.description.map((description) =>
+//               surfaceRenderer.renderTextObject(
+//                 description,
+//                 0,
+//                 UiKit.BlockContext.NONE
+//               )
+//             )}
+//           </MessageGenericPreviewDescription>
+//         ) : null}
+//         {block.footer && (
+//           <MessageGenericPreviewFooter>
+//             <ContextBlock
+//               block={block.footer}
+//               surfaceRenderer={surfaceRenderer}
+//               context={UiKit.BlockContext.BLOCK}
+//               index={0}
+//             />
+//           </MessageGenericPreviewFooter>
+//         )}
+//       </MessageGenericPreviewContent>
+//     </MessageGenericPreview>
+//   </Box>
+// );
 
-export default memo(PreviewBlock);
+// export default memo(PreviewBlock);

--- a/packages/react/src/components/uiKit/elements/MultiStaticSelectElement.js
+++ b/packages/react/src/components/uiKit/elements/MultiStaticSelectElement.js
@@ -1,44 +1,44 @@
-import { MultiSelectFiltered } from '@rocket.chat/fuselage';
-import React, { memo, useCallback, useMemo } from 'react';
+// import { MultiSelectFiltered } from '@rocket.chat/fuselage';
+// import React, { memo, useCallback, useMemo } from 'react';
 
-import { useUiKitState } from '../hooks/useUiKitState';
-import { fromTextObjectToString } from '../utils/fromTextObjectToString';
+// import { useUiKitState } from '../hooks/useUiKitState';
+// import { fromTextObjectToString } from '../utils/fromTextObjectToString';
 
-const MultiStaticSelectElement = ({ block, context, surfaceRenderer }) => {
-  const [{ loading, value, error }, action] = useUiKitState(block, context);
+// const MultiStaticSelectElement = ({ block, context, surfaceRenderer }) => {
+//   const [{ loading, value, error }, action] = useUiKitState(block, context);
 
-  const options = useMemo(
-    () =>
-      // eslint-disable-next-line no-shadow
-      block.options.map(({ value, text }, i) => [
-        value,
-        fromTextObjectToString(surfaceRenderer, text, i) ?? '',
-      ]),
-    [block.options, surfaceRenderer]
-  );
+//   const options = useMemo(
+//     () =>
+//       // eslint-disable-next-line no-shadow
+//       block.options.map(({ value, text }, i) => [
+//         value,
+//         fromTextObjectToString(surfaceRenderer, text, i) ?? '',
+//       ]),
+//     [block.options, surfaceRenderer]
+//   );
 
-  const handleChange = useCallback(
-    // eslint-disable-next-line no-shadow
-    (value) => {
-      action({ target: { value } });
-    },
-    [action]
-  );
+//   const handleChange = useCallback(
+//     // eslint-disable-next-line no-shadow
+//     (value) => {
+//       action({ target: { value } });
+//     },
+//     [action]
+//   );
 
-  return (
-    <MultiSelectFiltered
-      value={value}
-      disabled={loading}
-      error={error}
-      options={options}
-      placeholder={fromTextObjectToString(
-        surfaceRenderer,
-        block.placeholder,
-        0
-      )}
-      onChange={handleChange}
-    />
-  );
-};
+//   return (
+//     <MultiSelectFiltered
+//       value={value}
+//       disabled={loading}
+//       error={error}
+//       options={options}
+//       placeholder={fromTextObjectToString(
+//         surfaceRenderer,
+//         block.placeholder,
+//         0
+//       )}
+//       onChange={handleChange}
+//     />
+//   );
+// };
 
-export default memo(MultiStaticSelectElement);
+// export default memo(MultiStaticSelectElement);

--- a/packages/react/src/components/uiKit/elements/OverflowElement.js
+++ b/packages/react/src/components/uiKit/elements/OverflowElement.js
@@ -1,83 +1,83 @@
-import {
-  IconButton,
-  PositionAnimated,
-  Options,
-  useCursor,
-} from '@rocket.chat/fuselage';
-import React, { useRef, useCallback, useMemo } from 'react';
+// import {
+//   IconButton,
+//   PositionAnimated,
+//   Options,
+//   useCursor,
+// } from '@rocket.chat/fuselage';
+// import React, { useRef, useCallback, useMemo } from 'react';
 
-import { useUiKitState } from '../hooks/useUiKitState';
-import { fromTextObjectToString } from '../utils/fromTextObjectToString';
+// import { useUiKitState } from '../hooks/useUiKitState';
+// import { fromTextObjectToString } from '../utils/fromTextObjectToString';
 
-const OverflowElement = ({ block, context, surfaceRenderer }) => {
-  const [{ loading }, action] = useUiKitState(block, context);
+// const OverflowElement = ({ block, context, surfaceRenderer }) => {
+//   const [{ loading }, action] = useUiKitState(block, context);
 
-  const fireChange = useCallback(
-    ([value]) => action({ target: { value } }),
-    [action]
-  );
+//   const fireChange = useCallback(
+//     ([value]) => action({ target: { value } }),
+//     [action]
+//   );
 
-  const options = useMemo(
-    () =>
-      block.options.map(({ value, text, url }, i) => [
-        value,
-        fromTextObjectToString(surfaceRenderer, text, i) ?? '',
-        undefined,
-        undefined,
-        undefined,
-        url,
-      ]),
-    [block.options, surfaceRenderer]
-  );
+//   const options = useMemo(
+//     () =>
+//       block.options.map(({ value, text, url }, i) => [
+//         value,
+//         fromTextObjectToString(surfaceRenderer, text, i) ?? '',
+//         undefined,
+//         undefined,
+//         undefined,
+//         url,
+//       ]),
+//     [block.options, surfaceRenderer]
+//   );
 
-  const [cursor, handleKeyDown, handleKeyUp, reset, [visible, hide, show]] =
-    // eslint-disable-next-line no-shadow
-    useCursor(-1, options, (selectedOption, [, hide]) => {
-      fireChange([selectedOption[0], selectedOption[1]]);
-      reset();
-      hide();
-    });
+//   const [cursor, handleKeyDown, handleKeyUp, reset, [visible, hide, show]] =
+//     // eslint-disable-next-line no-shadow
+//     useCursor(-1, options, (selectedOption, [, hide]) => {
+//       fireChange([selectedOption[0], selectedOption[1]]);
+//       reset();
+//       hide();
+//     });
 
-  const ref = useRef(null);
-  const onClick = useCallback(() => {
-    ref.current?.focus();
-    show();
-  }, [show]);
+//   const ref = useRef(null);
+//   const onClick = useCallback(() => {
+//     ref.current?.focus();
+//     show();
+//   }, [show]);
 
-  const handleSelection = useCallback(
-    ([value, _label, _selected, _type, url]) => {
-      if (url) {
-        window.open(url);
-      }
-      action({ target: { value: String(value) } });
-      reset();
-      hide();
-    },
-    [action, hide, reset]
-  );
+//   const handleSelection = useCallback(
+//     ([value, _label, _selected, _type, url]) => {
+//       if (url) {
+//         window.open(url);
+//       }
+//       action({ target: { value: String(value) } });
+//       reset();
+//       hide();
+//     },
+//     [action, hide, reset]
+//   );
 
-  return (
-    <>
-      <IconButton
-        ref={ref}
-        small
-        onClick={onClick}
-        onBlur={hide}
-        onKeyUp={handleKeyUp}
-        onKeyDown={handleKeyDown}
-        disabled={loading}
-        icon="kebab"
-      />
-      <PositionAnimated
-        width="auto"
-        visible={visible}
-        anchor={ref}
-        placement="bottom-start"
-      >
-        <Options onSelect={handleSelection} options={options} cursor={cursor} />
-      </PositionAnimated>
-    </>
-  );
-};
+//   return (
+//     <>
+//       <IconButton
+//         ref={ref}
+//         small
+//         onClick={onClick}
+//         onBlur={hide}
+//         onKeyUp={handleKeyUp}
+//         onKeyDown={handleKeyDown}
+//         disabled={loading}
+//         icon="kebab"
+//       />
+//       <PositionAnimated
+//         width="auto"
+//         visible={visible}
+//         anchor={ref}
+//         placement="bottom-start"
+//       >
+//         <Options onSelect={handleSelection} options={options} cursor={cursor} />
+//       </PositionAnimated>
+//     </>
+//   );
+// };
 
-export default OverflowElement;
+// export default OverflowElement;

--- a/packages/react/src/components/uiKit/elements/StaticSelectElement.js
+++ b/packages/react/src/components/uiKit/elements/StaticSelectElement.js
@@ -1,43 +1,43 @@
-import { SelectFiltered } from '@rocket.chat/fuselage';
-import React, { memo, useCallback, useMemo } from 'react';
+// import { SelectFiltered } from '@rocket.chat/fuselage';
+// import React, { memo, useCallback, useMemo } from 'react';
 
-import { useUiKitState } from '../hooks/useUiKitState';
-import { fromTextObjectToString } from '../utils/fromTextObjectToString';
+// import { useUiKitState } from '../hooks/useUiKitState';
+// import { fromTextObjectToString } from '../utils/fromTextObjectToString';
 
-const StaticSelectElement = ({ block, context, surfaceRenderer }) => {
-  const [{ loading, value, error }, action] = useUiKitState(block, context);
+// const StaticSelectElement = ({ block, context, surfaceRenderer }) => {
+//   const [{ loading, value, error }, action] = useUiKitState(block, context);
 
-  const options = useMemo(
-    () =>
-      block.options.map((option, i) => [
-        option.value,
-        fromTextObjectToString(surfaceRenderer, option.text, i) ?? '',
-      ]),
-    [block.options, surfaceRenderer]
-  );
+//   const options = useMemo(
+//     () =>
+//       block.options.map((option, i) => [
+//         option.value,
+//         fromTextObjectToString(surfaceRenderer, option.text, i) ?? '',
+//       ]),
+//     [block.options, surfaceRenderer]
+//   );
 
-  const handleChange = useCallback(
-    // eslint-disable-next-line no-shadow
-    (value) => {
-      action({ target: { value } });
-    },
-    [action]
-  );
+//   const handleChange = useCallback(
+//     // eslint-disable-next-line no-shadow
+//     (value) => {
+//       action({ target: { value } });
+//     },
+//     [action]
+//   );
 
-  return (
-    <SelectFiltered
-      value={value}
-      disabled={loading}
-      error={error}
-      options={options}
-      placeholder={fromTextObjectToString(
-        surfaceRenderer,
-        block.placeholder,
-        0
-      )}
-      onChange={handleChange}
-    />
-  );
-};
+//   return (
+//     <SelectFiltered
+//       value={value}
+//       disabled={loading}
+//       error={error}
+//       options={options}
+//       placeholder={fromTextObjectToString(
+//         surfaceRenderer,
+//         block.placeholder,
+//         0
+//       )}
+//       onChange={handleChange}
+//     />
+//   );
+// };
 
-export default memo(StaticSelectElement);
+// export default memo(StaticSelectElement);

--- a/packages/react/src/components/uiKit/surfaces/BannerSurface.js
+++ b/packages/react/src/components/uiKit/surfaces/BannerSurface.js
@@ -1,10 +1,10 @@
-import { Margins } from '@rocket.chat/fuselage';
 import React from 'react';
 import { Surface } from './Surface';
+import { Box } from '../../Box';
 
 const BannerSurface = ({ children }) => (
   <Surface type="banner">
-    <Margins block="x8">{children}</Margins>
+    <Box style={{ marginBlock: '0.5rem' }}>{children}</Box>
   </Surface>
 );
 

--- a/packages/react/src/components/uiKit/surfaces/FuselageSurfaceRenderer.js
+++ b/packages/react/src/components/uiKit/surfaces/FuselageSurfaceRenderer.js
@@ -6,16 +6,16 @@ import ContextBlock from '../blocks/ContextBlock';
 import DividerBlock from '../blocks/DividerBlock';
 import ImageBlock from '../blocks/ImageBlock';
 import InputBlock from '../blocks/InputBlock';
-import PreviewBlock from '../blocks/PreviewBlock';
+// import PreviewBlock from '../blocks/PreviewBlock';
 import SectionBlock from '../blocks/SectionBlock';
 import ButtonElement from '../elements/ButtonElement';
 import DatePickerElement from '../elements/DatePickerElement';
 import ImageElement from '../elements/ImageElement';
 import LinearScaleElement from '../elements/LinearScaleElement';
-import MultiStaticSelectElement from '../elements/MultiStaticSelectElement';
-import OverflowElement from '../elements/OverflowElement';
+// import MultiStaticSelectElement from '../elements/MultiStaticSelectElement';
+// import OverflowElement from '../elements/OverflowElement';
 import PlainTextInputElement from '../elements/PlainTextInputElement';
-import StaticSelectElement from '../elements/StaticSelectElement';
+// import StaticSelectElement from '../elements/StaticSelectElement';
 import { Markup } from '../../Markup';
 
 export class FuselageSurfaceRenderer extends UiKit.SurfaceRenderer {
@@ -79,15 +79,18 @@ export class FuselageSurfaceRenderer extends UiKit.SurfaceRenderer {
     if (context !== UiKit.BlockContext.BLOCK) {
       return null;
     }
-    return (
-      <PreviewBlock
-        key={index}
-        block={block}
-        context={context}
-        index={index}
-        surfaceRenderer={this}
-      />
-    );
+    return null;
+
+    // TODO: Implement this without fuselage.
+    // return (
+    //   <PreviewBlock
+    //     key={index}
+    //     block={block}
+    //     context={context}
+    //     index={index}
+    //     surfaceRenderer={this}
+    //   />
+    // );
   }
 
   context(block, context, index) {
@@ -215,15 +218,17 @@ export class FuselageSurfaceRenderer extends UiKit.SurfaceRenderer {
       return null;
     }
 
-    return (
-      <StaticSelectElement
-        key={block.actionId || index}
-        block={block}
-        context={context}
-        index={index}
-        surfaceRenderer={this}
-      />
-    );
+    return null;
+    // implement this without fuselage
+    // return (
+    //   <StaticSelectElement
+    //     key={block.actionId || index}
+    //     block={block}
+    //     context={context}
+    //     index={index}
+    //     surfaceRenderer={this}
+    //   />
+    // );
   }
 
   multi_static_select(block, context, index) {
@@ -231,15 +236,17 @@ export class FuselageSurfaceRenderer extends UiKit.SurfaceRenderer {
       return null;
     }
 
-    return (
-      <MultiStaticSelectElement
-        key={block.actionId || index}
-        block={block}
-        context={context}
-        index={index}
-        surfaceRenderer={this}
-      />
-    );
+    return null;
+    // implement this without fuselage
+    // return (
+    //   <MultiStaticSelectElement
+    //     key={block.actionId || index}
+    //     block={block}
+    //     context={context}
+    //     index={index}
+    //     surfaceRenderer={this}
+    //   />
+    // );
   }
 
   overflow(block, context, index) {
@@ -247,15 +254,17 @@ export class FuselageSurfaceRenderer extends UiKit.SurfaceRenderer {
       return null;
     }
 
-    return (
-      <OverflowElement
-        key={index}
-        block={block}
-        context={context}
-        index={index}
-        surfaceRenderer={this}
-      />
-    );
+    return null;
+    // implement this without fuselage
+    // return (
+    //   <OverflowElement
+    //     key={index}
+    //     block={block}
+    //     context={context}
+    //     index={index}
+    //     surfaceRenderer={this}
+    //   />
+    // );
   }
 
   plain_text_input(block, context, index) {

--- a/packages/react/src/components/uiKit/surfaces/MessageSurface.js
+++ b/packages/react/src/components/uiKit/surfaces/MessageSurface.js
@@ -1,10 +1,10 @@
-import { Margins } from '@rocket.chat/fuselage';
 import React from 'react';
 import { Surface } from './Surface';
+import { Box } from '../../Box';
 
 const MessageSurface = ({ children }) => (
   <Surface type="message">
-    <Margins blockEnd="x16">{children}</Margins>
+    <Box style={{ marginBlock: '1rem' }}>{children}</Box>
   </Surface>
 );
 

--- a/packages/react/src/components/uiKit/surfaces/ModalSurface.js
+++ b/packages/react/src/components/uiKit/surfaces/ModalSurface.js
@@ -1,10 +1,10 @@
-import { Margins } from '@rocket.chat/fuselage';
 import React from 'react';
 import { Surface } from './Surface';
+import { Box } from '../../Box';
 
 const ModalSurface = ({ children }) => (
   <Surface type="modal">
-    <Margins blockEnd="x16">{children}</Margins>
+    <Box style={{ marginBlock: '1rem' }}>{children}</Box>
   </Surface>
 );
 

--- a/yarn.lock
+++ b/yarn.lock
@@ -2029,6 +2029,7 @@ __metadata:
   dependencies:
     "@embeddedchat/auth": 1.0.0
     "@rocket.chat/sdk": ^1.0.0-alpha.42
+    parcel: ^2.10.3
     rollup: ^3.23.0
     rollup-plugin-dts: ^6.0.1
     rollup-plugin-esbuild: ^5.0.0
@@ -2120,10 +2121,7 @@ __metadata:
     "@emotion/babel-preset-css-prop": ^11.11.0
     "@emotion/react": ^11.11.1
     "@open-wc/building-rollup": ^3.0.2
-    "@rocket.chat/fuselage": ^0.31.23
     "@rocket.chat/fuselage-hooks": ^0.31.23
-    "@rocket.chat/fuselage-polyfills": ^0.31.23
-    "@rocket.chat/fuselage-toastbar": ^0.31.23
     "@rocket.chat/icons": ^0.31.23
     "@rocket.chat/message-parser": ^0.31.25
     "@rocket.chat/sdk": ^1.0.0-alpha.42
@@ -2149,7 +2147,6 @@ __metadata:
     cross-env: ^7.0.3
     date-fns: ^2.30.0
     deepmerge: ^4.3.1
-    dompurify: ^3.0.3
     emoji-picker-react: ^4.4.9
     emoji-toolkit: ^7.0.1
     eslint: ^8.30.0
@@ -2168,7 +2165,6 @@ __metadata:
     jest: ^27.5.1
     js-cookie: ^3.0.5
     lint-staged: ^12.4.2
-    marked: ^4.0.17
     normalize.css: ^8.0.1
     npm-run-all: ^4.1.5
     prettier: ^2.8.1
@@ -2187,9 +2183,7 @@ __metadata:
     rollup-plugin-terser: ^7.0.2
     sass: ^1.66.1
     schedule: ^0.4.0
-    scheduler: ^0.23.0
     storybook: ^7.0.26
-    stylis: ^4.2.0
     zustand: ^4.3.8
   peerDependencies:
     react: ^17.0.2 || ^18
@@ -2254,7 +2248,7 @@ __metadata:
   languageName: node
   linkType: hard
 
-"@emotion/hash@npm:^0.9.0, @emotion/hash@npm:^0.9.1":
+"@emotion/hash@npm:^0.9.1":
   version: 0.9.1
   resolution: "@emotion/hash@npm:0.9.1"
   checksum: 716e17e48bf9047bf9383982c071de49f2615310fb4e986738931776f5a823bc1f29c84501abe0d3df91a3803c80122d24e28b57351bca9e01356ebb33d89876
@@ -3114,55 +3108,6 @@ __metadata:
   languageName: node
   linkType: hard
 
-"@formatjs/ecma402-abstract@npm:1.17.2":
-  version: 1.17.2
-  resolution: "@formatjs/ecma402-abstract@npm:1.17.2"
-  dependencies:
-    "@formatjs/intl-localematcher": 0.4.2
-    tslib: ^2.4.0
-  checksum: 026382b1fb295cef4387b2f2a34dace107b12fb7607793093b26595b0d639a30e5f4539665730897eb77eefabee2bb35c156896c63925b0ec03b746751e3fb00
-  languageName: node
-  linkType: hard
-
-"@formatjs/fast-memoize@npm:2.2.0":
-  version: 2.2.0
-  resolution: "@formatjs/fast-memoize@npm:2.2.0"
-  dependencies:
-    tslib: ^2.4.0
-  checksum: 8697fe72a7ece252d600a7d08105f2a2f758e2dd96f54ac0a4c508b1205a559fc08835635e1f8e5ca9dcc3ee61ce1fca4a0e7047b402f29fc96051e293a280ff
-  languageName: node
-  linkType: hard
-
-"@formatjs/icu-messageformat-parser@npm:2.7.0":
-  version: 2.7.0
-  resolution: "@formatjs/icu-messageformat-parser@npm:2.7.0"
-  dependencies:
-    "@formatjs/ecma402-abstract": 1.17.2
-    "@formatjs/icu-skeleton-parser": 1.6.2
-    tslib: ^2.4.0
-  checksum: 5c289b0090a3549fdeb5ee4c382666cf085be77c8a10abcee879e12e064126ec803a48d7f564a3cb5baf4529ef5fde3a61b30f9c54481279f0fb2cf2e9be1e7e
-  languageName: node
-  linkType: hard
-
-"@formatjs/icu-skeleton-parser@npm:1.6.2":
-  version: 1.6.2
-  resolution: "@formatjs/icu-skeleton-parser@npm:1.6.2"
-  dependencies:
-    "@formatjs/ecma402-abstract": 1.17.2
-    tslib: ^2.4.0
-  checksum: f51658d0b086579a2173b91beb692822f08db1180c81fa41e62bef4236a0de98f9d6e46087d77c5e46fa4286f77b4b52a2467f3d8b81a4cf8dd817edb138d68b
-  languageName: node
-  linkType: hard
-
-"@formatjs/intl-localematcher@npm:0.4.2":
-  version: 0.4.2
-  resolution: "@formatjs/intl-localematcher@npm:0.4.2"
-  dependencies:
-    tslib: ^2.4.0
-  checksum: df579d8c453a11eed1ec55604f8dda121d728fc5109ed885892347a126089caef95a0edf71f1f6db3134bb9e73787062995baf7746a2577e8ca2980dcd6590cb
-  languageName: node
-  linkType: hard
-
 "@gar/promisify@npm:^1.0.1, @gar/promisify@npm:^1.1.3":
   version: 1.1.3
   resolution: "@gar/promisify@npm:1.1.3"
@@ -3258,43 +3203,6 @@ __metadata:
   version: 3.0.2
   resolution: "@hutson/parse-repository-url@npm:3.0.2"
   checksum: 39992c5f183c5ca3d761d6ed9dfabcb79b5f3750bf1b7f3532e1dc439ca370138bbd426ee250fdaba460bc948e6761fbefd484b8f4f36885d71ded96138340d1
-  languageName: node
-  linkType: hard
-
-"@internationalized/date@npm:^3.5.0":
-  version: 3.5.0
-  resolution: "@internationalized/date@npm:3.5.0"
-  dependencies:
-    "@swc/helpers": ^0.5.0
-  checksum: 621298a1686bad64212b1f2a497492dcc9d657a3789ea62a1a5ee1cb37719fa7a54944d4bb318bf22f709eccfcb6627e6d1aad9825aaa67c2150973ccca8c15d
-  languageName: node
-  linkType: hard
-
-"@internationalized/message@npm:^3.1.1":
-  version: 3.1.1
-  resolution: "@internationalized/message@npm:3.1.1"
-  dependencies:
-    "@swc/helpers": ^0.5.0
-    intl-messageformat: ^10.1.0
-  checksum: c8658847e80a2dd6f5a253bdc20ce45d304ffa2147248e6422d72714ac501edd0d4cce09e4baf7753cd393e4df7014df747425ff9658728cd1f892d71c3d591b
-  languageName: node
-  linkType: hard
-
-"@internationalized/number@npm:^3.3.0":
-  version: 3.3.0
-  resolution: "@internationalized/number@npm:3.3.0"
-  dependencies:
-    "@swc/helpers": ^0.5.0
-  checksum: 76e5bd0e7713d8010be90b2d3427371a0ee97e34e6d81da2c10587986503be308ab8bfd8f590e1d88977800f5d79f9e2d91e7ac1d6d34006575216027125f302
-  languageName: node
-  linkType: hard
-
-"@internationalized/string@npm:^3.1.1":
-  version: 3.1.1
-  resolution: "@internationalized/string@npm:3.1.1"
-  dependencies:
-    "@swc/helpers": ^0.5.0
-  checksum: 686b4d443dbf6794b5f32e0c3a0ee9333a64bfe2a01aec705fb71f5721f5c9e8aa25b380bdae85e21be0dc72103843642363efcaed437ebad3e7169e478b91ae
   languageName: node
   linkType: hard
 
@@ -3735,7 +3643,7 @@ __metadata:
   languageName: node
   linkType: hard
 
-"@juggle/resize-observer@npm:^3.3.1, @juggle/resize-observer@npm:^3.4.0":
+"@juggle/resize-observer@npm:^3.3.1":
   version: 3.4.0
   resolution: "@juggle/resize-observer@npm:3.4.0"
   checksum: 2505028c05cc2e17639fcad06218b1c4b60f932a4ebb4b41ab546ef8c157031ae377e3f560903801f6d01706dbefd4943b6c4704bf19ed86dfa1c62f1473a570
@@ -4600,6 +4508,20 @@ __metadata:
   languageName: node
   linkType: hard
 
+"@parcel/bundler-default@npm:2.10.3":
+  version: 2.10.3
+  resolution: "@parcel/bundler-default@npm:2.10.3"
+  dependencies:
+    "@parcel/diagnostic": 2.10.3
+    "@parcel/graph": 3.0.3
+    "@parcel/plugin": 2.10.3
+    "@parcel/rust": 2.10.3
+    "@parcel/utils": 2.10.3
+    nullthrows: ^1.1.1
+  checksum: 2fd80acec4aeb4306b6ad29d381e8c77003576efc9c057a24fac80c363b3a8ba0c4b7bbea1587312fe3f88ab1fbcac085dbb90cfee5759d33fa085bc550d7191
+  languageName: node
+  linkType: hard
+
 "@parcel/cache@npm:2.10.0":
   version: 2.10.0
   resolution: "@parcel/cache@npm:2.10.0"
@@ -4614,6 +4536,20 @@ __metadata:
   languageName: node
   linkType: hard
 
+"@parcel/cache@npm:2.10.3":
+  version: 2.10.3
+  resolution: "@parcel/cache@npm:2.10.3"
+  dependencies:
+    "@parcel/fs": 2.10.3
+    "@parcel/logger": 2.10.3
+    "@parcel/utils": 2.10.3
+    lmdb: 2.8.5
+  peerDependencies:
+    "@parcel/core": ^2.10.3
+  checksum: b7e9a000a78786c1adda97d23f29d5c35695637db5de305d7fb6d4f8e88bed9c98065f4d0b094a131b2deb392451b897635fd2234fa4cf3a8a6667ae0b6af5db
+  languageName: node
+  linkType: hard
+
 "@parcel/codeframe@npm:2.10.0":
   version: 2.10.0
   resolution: "@parcel/codeframe@npm:2.10.0"
@@ -4623,12 +4559,30 @@ __metadata:
   languageName: node
   linkType: hard
 
+"@parcel/codeframe@npm:2.10.3":
+  version: 2.10.3
+  resolution: "@parcel/codeframe@npm:2.10.3"
+  dependencies:
+    chalk: ^4.1.0
+  checksum: b8808789dc452079ce9a9d93b14e39713e4dc831ddec5a3bc69284632e347d6fb5714e3e4890de081f3cad2c3905643f9f95d88b1262744bb1967e3278b85842
+  languageName: node
+  linkType: hard
+
 "@parcel/compressor-raw@npm:2.10.0":
   version: 2.10.0
   resolution: "@parcel/compressor-raw@npm:2.10.0"
   dependencies:
     "@parcel/plugin": 2.10.0
   checksum: 043fca0ecb9e574300045dce5b5a91d604e19682329a6be8e7e6c9365fa58f28415fd1a8353adcb98140395d789c3c1f764c092f717d4795df8de02b597cf57d
+  languageName: node
+  linkType: hard
+
+"@parcel/compressor-raw@npm:2.10.3":
+  version: 2.10.3
+  resolution: "@parcel/compressor-raw@npm:2.10.3"
+  dependencies:
+    "@parcel/plugin": 2.10.3
+  checksum: bf92cd0690ff8858bb5fea7b70bb659a77c091aa95a399ce09b67345ab87db74e6974b6ab9faad18c0deb12416da981f59e171e346291cb2a55fc3830dc0153e
   languageName: node
   linkType: hard
 
@@ -4673,6 +4627,47 @@ __metadata:
   languageName: node
   linkType: hard
 
+"@parcel/config-default@npm:2.10.3":
+  version: 2.10.3
+  resolution: "@parcel/config-default@npm:2.10.3"
+  dependencies:
+    "@parcel/bundler-default": 2.10.3
+    "@parcel/compressor-raw": 2.10.3
+    "@parcel/namer-default": 2.10.3
+    "@parcel/optimizer-css": 2.10.3
+    "@parcel/optimizer-htmlnano": 2.10.3
+    "@parcel/optimizer-image": 2.10.3
+    "@parcel/optimizer-svgo": 2.10.3
+    "@parcel/optimizer-swc": 2.10.3
+    "@parcel/packager-css": 2.10.3
+    "@parcel/packager-html": 2.10.3
+    "@parcel/packager-js": 2.10.3
+    "@parcel/packager-raw": 2.10.3
+    "@parcel/packager-svg": 2.10.3
+    "@parcel/packager-wasm": 2.10.3
+    "@parcel/reporter-dev-server": 2.10.3
+    "@parcel/resolver-default": 2.10.3
+    "@parcel/runtime-browser-hmr": 2.10.3
+    "@parcel/runtime-js": 2.10.3
+    "@parcel/runtime-react-refresh": 2.10.3
+    "@parcel/runtime-service-worker": 2.10.3
+    "@parcel/transformer-babel": 2.10.3
+    "@parcel/transformer-css": 2.10.3
+    "@parcel/transformer-html": 2.10.3
+    "@parcel/transformer-image": 2.10.3
+    "@parcel/transformer-js": 2.10.3
+    "@parcel/transformer-json": 2.10.3
+    "@parcel/transformer-postcss": 2.10.3
+    "@parcel/transformer-posthtml": 2.10.3
+    "@parcel/transformer-raw": 2.10.3
+    "@parcel/transformer-react-refresh-wrap": 2.10.3
+    "@parcel/transformer-svg": 2.10.3
+  peerDependencies:
+    "@parcel/core": ^2.10.3
+  checksum: 7dc834abfe81fecfa582ffeb37471328382bae1f7b3d1a45229766cdafd780b349d6b598ef2a550f72e5877726c759866b83c5b4d494a2723e8bd46910bb4b8c
+  languageName: node
+  linkType: hard
+
 "@parcel/core@npm:2.10.0":
   version: 2.10.0
   resolution: "@parcel/core@npm:2.10.0"
@@ -4706,6 +4701,39 @@ __metadata:
   languageName: node
   linkType: hard
 
+"@parcel/core@npm:2.10.3":
+  version: 2.10.3
+  resolution: "@parcel/core@npm:2.10.3"
+  dependencies:
+    "@mischnic/json-sourcemap": ^0.1.0
+    "@parcel/cache": 2.10.3
+    "@parcel/diagnostic": 2.10.3
+    "@parcel/events": 2.10.3
+    "@parcel/fs": 2.10.3
+    "@parcel/graph": 3.0.3
+    "@parcel/logger": 2.10.3
+    "@parcel/package-manager": 2.10.3
+    "@parcel/plugin": 2.10.3
+    "@parcel/profiler": 2.10.3
+    "@parcel/rust": 2.10.3
+    "@parcel/source-map": ^2.1.1
+    "@parcel/types": 2.10.3
+    "@parcel/utils": 2.10.3
+    "@parcel/workers": 2.10.3
+    abortcontroller-polyfill: ^1.1.9
+    base-x: ^3.0.8
+    browserslist: ^4.6.6
+    clone: ^2.1.1
+    dotenv: ^7.0.0
+    dotenv-expand: ^5.1.0
+    json5: ^2.2.0
+    msgpackr: ^1.9.9
+    nullthrows: ^1.1.1
+    semver: ^7.5.2
+  checksum: 9d9def613a19b893c56a6fbf09df07a5abd483a545c4643d8584337c828d2da2e32e56b3a1962b81719da7f384160f1383b911383860755951475a59369efa24
+  languageName: node
+  linkType: hard
+
 "@parcel/diagnostic@npm:2.10.0":
   version: 2.10.0
   resolution: "@parcel/diagnostic@npm:2.10.0"
@@ -4716,10 +4744,27 @@ __metadata:
   languageName: node
   linkType: hard
 
+"@parcel/diagnostic@npm:2.10.3":
+  version: 2.10.3
+  resolution: "@parcel/diagnostic@npm:2.10.3"
+  dependencies:
+    "@mischnic/json-sourcemap": ^0.1.0
+    nullthrows: ^1.1.1
+  checksum: 4223a534db21a18fb47c79a9a10ca49b84bddb1135bef8772808af9f36b695d789460d103f0566902df849c8e419ef60f66ab538c597fc38e5643e717c3eb042
+  languageName: node
+  linkType: hard
+
 "@parcel/events@npm:2.10.0":
   version: 2.10.0
   resolution: "@parcel/events@npm:2.10.0"
   checksum: 1d21cd41862de2f21f2ab754b1d949fe17b062fbb8009a23d4d42f6836df7e1d37c2c8ca71304dce18d1168dedf0fcaa88c7c3eacc20611215b00700df0c9c73
+  languageName: node
+  linkType: hard
+
+"@parcel/events@npm:2.10.3":
+  version: 2.10.3
+  resolution: "@parcel/events@npm:2.10.3"
+  checksum: f8b6c53a24378f02ccb8e5beb7f47d70a2b1e25f12541cf0e49be6daf998001806f9da862e908be291e9b44d880b387eee8b2790a7abf22bbefaafc07bd1664d
   languageName: node
   linkType: hard
 
@@ -4738,12 +4783,36 @@ __metadata:
   languageName: node
   linkType: hard
 
+"@parcel/fs@npm:2.10.3":
+  version: 2.10.3
+  resolution: "@parcel/fs@npm:2.10.3"
+  dependencies:
+    "@parcel/rust": 2.10.3
+    "@parcel/types": 2.10.3
+    "@parcel/utils": 2.10.3
+    "@parcel/watcher": ^2.0.7
+    "@parcel/workers": 2.10.3
+  peerDependencies:
+    "@parcel/core": ^2.10.3
+  checksum: 916a7a0d6b3c98aa089d85445971f4fb6bf90ef94fb5d941e0c27d4cb775309027a537b5c144352299eadc516fe30f681c3843a24a4e518a24074c25830819c0
+  languageName: node
+  linkType: hard
+
 "@parcel/graph@npm:3.0.0":
   version: 3.0.0
   resolution: "@parcel/graph@npm:3.0.0"
   dependencies:
     nullthrows: ^1.1.1
   checksum: 0a9d5017f6179d3a35a9f97060d24486efe045277e831550e2885b8afc05288a2a898da3ec1f920cb89c02cce8941642b4522e67194a773d50062dadb36f4567
+  languageName: node
+  linkType: hard
+
+"@parcel/graph@npm:3.0.3":
+  version: 3.0.3
+  resolution: "@parcel/graph@npm:3.0.3"
+  dependencies:
+    nullthrows: ^1.1.1
+  checksum: f906c7709b37abb5e8fb47919de2a1b763a0ee2851fe42f924d16a27f98435a92f0520c1c9990d31d9c835cbd25e9eeb57447ee4b9e8b56556857ad1fb28495a
   languageName: node
   linkType: hard
 
@@ -4757,12 +4826,31 @@ __metadata:
   languageName: node
   linkType: hard
 
+"@parcel/logger@npm:2.10.3":
+  version: 2.10.3
+  resolution: "@parcel/logger@npm:2.10.3"
+  dependencies:
+    "@parcel/diagnostic": 2.10.3
+    "@parcel/events": 2.10.3
+  checksum: f67f4010122b6b2e65d9789d328e0672cb250d7e0bf66528c317ddd8d95a771c67c87d75d049b5ed6b0b5858c860052301e9418faeee0c7f3d27e79d688874f5
+  languageName: node
+  linkType: hard
+
 "@parcel/markdown-ansi@npm:2.10.0":
   version: 2.10.0
   resolution: "@parcel/markdown-ansi@npm:2.10.0"
   dependencies:
     chalk: ^4.1.0
   checksum: 35e2d07ec81e271144fc0f7b5f00913dce787e8a6f4a308eb59269fbc50d751cae939fedfd03e30b4aeef0c7f1210af2d1990a5551f1d39eeb80c977feb72b04
+  languageName: node
+  linkType: hard
+
+"@parcel/markdown-ansi@npm:2.10.3":
+  version: 2.10.3
+  resolution: "@parcel/markdown-ansi@npm:2.10.3"
+  dependencies:
+    chalk: ^4.1.0
+  checksum: e683f8ce1dd12f2a414e3f7840de3a46f0477c4dbf603dfa9b49372367bf248d115b2c73fbba85ad0dff27bd156a55761aa22d12afba098197dc3c7a4f9e6730
   languageName: node
   linkType: hard
 
@@ -4774,6 +4862,17 @@ __metadata:
     "@parcel/plugin": 2.10.0
     nullthrows: ^1.1.1
   checksum: f2a32096d1574b0c871770622d20c619c35d77da8206bc0f74c1ab1d9107001cbb60771133da80b8ca2c927d65de58e6940a049de023f5cbc6e3131b80eea3fb
+  languageName: node
+  linkType: hard
+
+"@parcel/namer-default@npm:2.10.3":
+  version: 2.10.3
+  resolution: "@parcel/namer-default@npm:2.10.3"
+  dependencies:
+    "@parcel/diagnostic": 2.10.3
+    "@parcel/plugin": 2.10.3
+    nullthrows: ^1.1.1
+  checksum: ea6adf6c5cb44d97ce929b967b6ebf5d383c907284166ee57554a8d3815b7da42a867202e8f69ee190de35287639e2ed74f8cd540ecf232232dcc8423a3a613a
   languageName: node
   linkType: hard
 
@@ -4792,6 +4891,21 @@ __metadata:
   languageName: node
   linkType: hard
 
+"@parcel/node-resolver-core@npm:3.1.3":
+  version: 3.1.3
+  resolution: "@parcel/node-resolver-core@npm:3.1.3"
+  dependencies:
+    "@mischnic/json-sourcemap": ^0.1.0
+    "@parcel/diagnostic": 2.10.3
+    "@parcel/fs": 2.10.3
+    "@parcel/rust": 2.10.3
+    "@parcel/utils": 2.10.3
+    nullthrows: ^1.1.1
+    semver: ^7.5.2
+  checksum: 7daa061d8170eee165005686b9ac82823a5fda5465246226bd8ca163b9434ebfa70163bf64b103f56e0fe7d6b72f10ebf24e0bcc2f832e258876484d0707636e
+  languageName: node
+  linkType: hard
+
 "@parcel/optimizer-css@npm:2.10.0":
   version: 2.10.0
   resolution: "@parcel/optimizer-css@npm:2.10.0"
@@ -4807,6 +4921,21 @@ __metadata:
   languageName: node
   linkType: hard
 
+"@parcel/optimizer-css@npm:2.10.3":
+  version: 2.10.3
+  resolution: "@parcel/optimizer-css@npm:2.10.3"
+  dependencies:
+    "@parcel/diagnostic": 2.10.3
+    "@parcel/plugin": 2.10.3
+    "@parcel/source-map": ^2.1.1
+    "@parcel/utils": 2.10.3
+    browserslist: ^4.6.6
+    lightningcss: ^1.16.1
+    nullthrows: ^1.1.1
+  checksum: f157c14136b24bace773d721d29192dd913770dea3b65348993ce0bd6dbdeb186c4a4bfc42b6912a4674814d4ed73761568bd976e09f1d988a66095d8da83920
+  languageName: node
+  linkType: hard
+
 "@parcel/optimizer-htmlnano@npm:2.10.0":
   version: 2.10.0
   resolution: "@parcel/optimizer-htmlnano@npm:2.10.0"
@@ -4817,6 +4946,19 @@ __metadata:
     posthtml: ^0.16.5
     svgo: ^2.4.0
   checksum: 1f6de13022437a49b2c9350deac8b193e950e090bc73409254dae99bbafb9f8f54b2bcb4d97e423ddf914925589f6809f7f63edc22c22e6828398fa58a17f621
+  languageName: node
+  linkType: hard
+
+"@parcel/optimizer-htmlnano@npm:2.10.3":
+  version: 2.10.3
+  resolution: "@parcel/optimizer-htmlnano@npm:2.10.3"
+  dependencies:
+    "@parcel/plugin": 2.10.3
+    htmlnano: ^2.0.0
+    nullthrows: ^1.1.1
+    posthtml: ^0.16.5
+    svgo: ^2.4.0
+  checksum: d2d7c4d5596e64b5a1ee81824aabb132853fbd065e2e8816e061702872ec4cec3527d9f63206d20d78176a4d1e075f25d5f90590b6540b8aa57f0295c59c687b
   languageName: node
   linkType: hard
 
@@ -4835,6 +4977,21 @@ __metadata:
   languageName: node
   linkType: hard
 
+"@parcel/optimizer-image@npm:2.10.3":
+  version: 2.10.3
+  resolution: "@parcel/optimizer-image@npm:2.10.3"
+  dependencies:
+    "@parcel/diagnostic": 2.10.3
+    "@parcel/plugin": 2.10.3
+    "@parcel/rust": 2.10.3
+    "@parcel/utils": 2.10.3
+    "@parcel/workers": 2.10.3
+  peerDependencies:
+    "@parcel/core": ^2.10.3
+  checksum: 40a4132b9edc344fcab6607b69a3b05743ad1478319183b5eb54c3ee21d676eb9ecdd78ada676998a7cd3a1daaf0cb02c65504cbe9343001e10fd7fff7d1b03d
+  languageName: node
+  linkType: hard
+
 "@parcel/optimizer-svgo@npm:2.10.0":
   version: 2.10.0
   resolution: "@parcel/optimizer-svgo@npm:2.10.0"
@@ -4844,6 +5001,18 @@ __metadata:
     "@parcel/utils": 2.10.0
     svgo: ^2.4.0
   checksum: 7201c632228e2ff6d9db681f5109a5df8239b0f33585c6648ebdd89822d46ae1bb37292cd9c5b4cd1173aa80a0850f7976b8c4317f7548b8fcc127b7bf68be04
+  languageName: node
+  linkType: hard
+
+"@parcel/optimizer-svgo@npm:2.10.3":
+  version: 2.10.3
+  resolution: "@parcel/optimizer-svgo@npm:2.10.3"
+  dependencies:
+    "@parcel/diagnostic": 2.10.3
+    "@parcel/plugin": 2.10.3
+    "@parcel/utils": 2.10.3
+    svgo: ^2.4.0
+  checksum: f26c8c931f0648b6c908e6d9639be010cb3f0551eaaf46f205bba39fcdb5190a20a094847f91036734a0b9749bf607ae22b0bedbecaebe30fa198965523fc228
   languageName: node
   linkType: hard
 
@@ -4858,6 +5027,20 @@ __metadata:
     "@swc/core": ^1.3.36
     nullthrows: ^1.1.1
   checksum: 1fe68ee6ff8843a33de953eddd6cf2b1061f8017677ee2f4924efcb4a24f0cac517ff4a508b899ce268cf983542b0406c8dfb9af190f30164f4ce6de6b32f9fb
+  languageName: node
+  linkType: hard
+
+"@parcel/optimizer-swc@npm:2.10.3":
+  version: 2.10.3
+  resolution: "@parcel/optimizer-swc@npm:2.10.3"
+  dependencies:
+    "@parcel/diagnostic": 2.10.3
+    "@parcel/plugin": 2.10.3
+    "@parcel/source-map": ^2.1.1
+    "@parcel/utils": 2.10.3
+    "@swc/core": ^1.3.36
+    nullthrows: ^1.1.1
+  checksum: 6eb1e2c923cff94f71a3d5a8218f826440ac7c0162cc45d9b27ae20ad62f1ab0dcd5efea4cbabebb3cbfe0d6d56b26693754e5daca8469ab36914d7ece1be3ba
   languageName: node
   linkType: hard
 
@@ -4879,6 +5062,24 @@ __metadata:
   languageName: node
   linkType: hard
 
+"@parcel/package-manager@npm:2.10.3":
+  version: 2.10.3
+  resolution: "@parcel/package-manager@npm:2.10.3"
+  dependencies:
+    "@parcel/diagnostic": 2.10.3
+    "@parcel/fs": 2.10.3
+    "@parcel/logger": 2.10.3
+    "@parcel/node-resolver-core": 3.1.3
+    "@parcel/types": 2.10.3
+    "@parcel/utils": 2.10.3
+    "@parcel/workers": 2.10.3
+    semver: ^7.5.2
+  peerDependencies:
+    "@parcel/core": ^2.10.3
+  checksum: d25958e342cd6886b7d92b12100f8f58dadc80c925a28e25b8a7aa7349955d701c927b42e97ecff8b078452ff92dd4b976782b47fda7268533e9412de86c710f
+  languageName: node
+  linkType: hard
+
 "@parcel/packager-css@npm:2.10.0":
   version: 2.10.0
   resolution: "@parcel/packager-css@npm:2.10.0"
@@ -4892,6 +5093,19 @@ __metadata:
   languageName: node
   linkType: hard
 
+"@parcel/packager-css@npm:2.10.3":
+  version: 2.10.3
+  resolution: "@parcel/packager-css@npm:2.10.3"
+  dependencies:
+    "@parcel/diagnostic": 2.10.3
+    "@parcel/plugin": 2.10.3
+    "@parcel/source-map": ^2.1.1
+    "@parcel/utils": 2.10.3
+    nullthrows: ^1.1.1
+  checksum: 5da9263a0fcf233c0793029518220a8bbcc4f8707196c1a85acfbf96ebfb821fdc4da2ce01af92b16178e6db4e214d627fc61902fecd65910c1dcecb6af60273
+  languageName: node
+  linkType: hard
+
 "@parcel/packager-html@npm:2.10.0":
   version: 2.10.0
   resolution: "@parcel/packager-html@npm:2.10.0"
@@ -4902,6 +5116,19 @@ __metadata:
     nullthrows: ^1.1.1
     posthtml: ^0.16.5
   checksum: 8dfd86e7d68417d52625817532b9f1aa7a68686345379b339c00e0d079a7922eaf5c23db2661602e80e8a3207090b5f7d1fed20b7ec5b6811c830ba9467c9060
+  languageName: node
+  linkType: hard
+
+"@parcel/packager-html@npm:2.10.3":
+  version: 2.10.3
+  resolution: "@parcel/packager-html@npm:2.10.3"
+  dependencies:
+    "@parcel/plugin": 2.10.3
+    "@parcel/types": 2.10.3
+    "@parcel/utils": 2.10.3
+    nullthrows: ^1.1.1
+    posthtml: ^0.16.5
+  checksum: 85bfdba8be5be33f37c520cc6b770151ab7ad263032aff1126a64a1df9676f25478f7d3e67ea76374362287bbed3419939ae0e6d576b2a20f60f51a23f24fa58
   languageName: node
   linkType: hard
 
@@ -4921,12 +5148,37 @@ __metadata:
   languageName: node
   linkType: hard
 
+"@parcel/packager-js@npm:2.10.3":
+  version: 2.10.3
+  resolution: "@parcel/packager-js@npm:2.10.3"
+  dependencies:
+    "@parcel/diagnostic": 2.10.3
+    "@parcel/plugin": 2.10.3
+    "@parcel/rust": 2.10.3
+    "@parcel/source-map": ^2.1.1
+    "@parcel/types": 2.10.3
+    "@parcel/utils": 2.10.3
+    globals: ^13.2.0
+    nullthrows: ^1.1.1
+  checksum: 1e383bdf39c495d23ac52acb4a821ef9d405ae4eee160a9571dee005faa60e1404046c59250c99898691da6fffa18e9dee5e317b6d06ee7503717ebbb4f7e59f
+  languageName: node
+  linkType: hard
+
 "@parcel/packager-raw@npm:2.10.0":
   version: 2.10.0
   resolution: "@parcel/packager-raw@npm:2.10.0"
   dependencies:
     "@parcel/plugin": 2.10.0
   checksum: 492fe07ae58e55b6fb492cccd12a0eb6733134ae93c1381a516c0e24b1e11c9f1fa0e88dc626f30c07100adaf2b6c1d299255734e9becaebe8e4bcdc8c118074
+  languageName: node
+  linkType: hard
+
+"@parcel/packager-raw@npm:2.10.3":
+  version: 2.10.3
+  resolution: "@parcel/packager-raw@npm:2.10.3"
+  dependencies:
+    "@parcel/plugin": 2.10.3
+  checksum: 7f6615fa93c18e14014de07e677587ccfd1e275972d577c3ef4359969f8fca4ec12351be04a0d34e6287b63041259a0b31bc239555b7cdff7cfec734667f6e4f
   languageName: node
   linkType: hard
 
@@ -4942,12 +5194,33 @@ __metadata:
   languageName: node
   linkType: hard
 
+"@parcel/packager-svg@npm:2.10.3":
+  version: 2.10.3
+  resolution: "@parcel/packager-svg@npm:2.10.3"
+  dependencies:
+    "@parcel/plugin": 2.10.3
+    "@parcel/types": 2.10.3
+    "@parcel/utils": 2.10.3
+    posthtml: ^0.16.4
+  checksum: fcc64795be57a3c32e7861d424d3aaaa585cda126a0f7e03d28ffb4cd2105218ae4d1ce8ac68cb986a8fe5b77adf80722de18b6af4d094f368c810aff346f58c
+  languageName: node
+  linkType: hard
+
 "@parcel/packager-wasm@npm:2.10.0":
   version: 2.10.0
   resolution: "@parcel/packager-wasm@npm:2.10.0"
   dependencies:
     "@parcel/plugin": 2.10.0
   checksum: d9a13eb838b6bcaa1dd58af6b58f40daa4d3634a28b0b259983e8d8fb7e83f5cb8be3441135bd2ce55a7a459d818ddb77bee44cc52c8fb5169da215ca85341cd
+  languageName: node
+  linkType: hard
+
+"@parcel/packager-wasm@npm:2.10.3":
+  version: 2.10.3
+  resolution: "@parcel/packager-wasm@npm:2.10.3"
+  dependencies:
+    "@parcel/plugin": 2.10.3
+  checksum: 971a8b1ef763fb593d80536b7728545bc471208fecb05344fb5b4af7f38dc9f5f5faad8047388d4bfcff8bba7b96cf1437789e017e40b0fd95a6da99b03db942
   languageName: node
   linkType: hard
 
@@ -4960,6 +5233,15 @@ __metadata:
   languageName: node
   linkType: hard
 
+"@parcel/plugin@npm:2.10.3":
+  version: 2.10.3
+  resolution: "@parcel/plugin@npm:2.10.3"
+  dependencies:
+    "@parcel/types": 2.10.3
+  checksum: d5d18e815856bf76d4e5a6b3daaefa21030a67e46b38cebb9ee4d4aa98b352bce3f54d8c3fc4136692c31e85ca23f1366bd86f77c78cd0daeacbad82a59068d0
+  languageName: node
+  linkType: hard
+
 "@parcel/profiler@npm:2.10.0":
   version: 2.10.0
   resolution: "@parcel/profiler@npm:2.10.0"
@@ -4968,6 +5250,17 @@ __metadata:
     "@parcel/events": 2.10.0
     chrome-trace-event: ^1.0.2
   checksum: 78d545edb76d72f962769df8964a3a19fe3d0b2b8c47a929eeafd9d71b3f00f2733428a649804057fce153a7fb71fa8bfdd25cc3102b32ea542b69af35f7ce4a
+  languageName: node
+  linkType: hard
+
+"@parcel/profiler@npm:2.10.3":
+  version: 2.10.3
+  resolution: "@parcel/profiler@npm:2.10.3"
+  dependencies:
+    "@parcel/diagnostic": 2.10.3
+    "@parcel/events": 2.10.3
+    chrome-trace-event: ^1.0.2
+  checksum: b6d797c7abddb2e8861a77fc3f8e11d329a41e3257ba6d5eddfb5cb158d3299d380d49114dfccac54ce73c9ba82e779a39fe3f0e62b40aae4eb8ade5ed3e8726
   languageName: node
   linkType: hard
 
@@ -4984,6 +5277,19 @@ __metadata:
   languageName: node
   linkType: hard
 
+"@parcel/reporter-cli@npm:2.10.3":
+  version: 2.10.3
+  resolution: "@parcel/reporter-cli@npm:2.10.3"
+  dependencies:
+    "@parcel/plugin": 2.10.3
+    "@parcel/types": 2.10.3
+    "@parcel/utils": 2.10.3
+    chalk: ^4.1.0
+    term-size: ^2.2.1
+  checksum: 7b6f4c0e964955422a20936ca53bb864fe0e1a9729a68e303ab9daa6ead8fabb48b695614852549357a881734a230980967d7e1c76f2f78b279e14e28725f2ed
+  languageName: node
+  linkType: hard
+
 "@parcel/reporter-dev-server@npm:2.10.0":
   version: 2.10.0
   resolution: "@parcel/reporter-dev-server@npm:2.10.0"
@@ -4991,6 +5297,16 @@ __metadata:
     "@parcel/plugin": 2.10.0
     "@parcel/utils": 2.10.0
   checksum: e72fd6ec095e36fb3c758b5a043c4c2038c464dad8528b12f57df83f19d6c138ce045c5897c88fd307fd03a2ffb0c53a1a799aec9e74e7de82261e32c031ff89
+  languageName: node
+  linkType: hard
+
+"@parcel/reporter-dev-server@npm:2.10.3":
+  version: 2.10.3
+  resolution: "@parcel/reporter-dev-server@npm:2.10.3"
+  dependencies:
+    "@parcel/plugin": 2.10.3
+    "@parcel/utils": 2.10.3
+  checksum: 0dd35076154e705ea0f00ffbb7fd452a7fd98d0c13cf9af2b72a8762509dfe87594c00e0cfd886ee6d2a4134379581eb281f5e1fde4eb4b4360fb547bc1f3db9
   languageName: node
   linkType: hard
 
@@ -5006,6 +5322,18 @@ __metadata:
   languageName: node
   linkType: hard
 
+"@parcel/reporter-tracer@npm:2.10.3":
+  version: 2.10.3
+  resolution: "@parcel/reporter-tracer@npm:2.10.3"
+  dependencies:
+    "@parcel/plugin": 2.10.3
+    "@parcel/utils": 2.10.3
+    chrome-trace-event: ^1.0.3
+    nullthrows: ^1.1.1
+  checksum: 818ff5a49c836fc965ebd21373c0924453ae9b5fe2f9bde5e4735cb1bdd16db81af65f2f48235a95e34c9bacec6081b29bf612dc0e3e4d1db7811bec91ac1b2d
+  languageName: node
+  linkType: hard
+
 "@parcel/resolver-default@npm:2.10.0":
   version: 2.10.0
   resolution: "@parcel/resolver-default@npm:2.10.0"
@@ -5016,6 +5344,16 @@ __metadata:
   languageName: node
   linkType: hard
 
+"@parcel/resolver-default@npm:2.10.3":
+  version: 2.10.3
+  resolution: "@parcel/resolver-default@npm:2.10.3"
+  dependencies:
+    "@parcel/node-resolver-core": 3.1.3
+    "@parcel/plugin": 2.10.3
+  checksum: 4c6025a129fbdb42964c84e58df3dc555bb77dae2d134a6e98de652e14de1c1b600766add5e95ccaffb3c7bfc006111fdb9aabeb96f815c875c9e3846d66e484
+  languageName: node
+  linkType: hard
+
 "@parcel/runtime-browser-hmr@npm:2.10.0":
   version: 2.10.0
   resolution: "@parcel/runtime-browser-hmr@npm:2.10.0"
@@ -5023,6 +5361,16 @@ __metadata:
     "@parcel/plugin": 2.10.0
     "@parcel/utils": 2.10.0
   checksum: 12928462c812253a6ceb2338e7f3a1db1745f2102060804b144854c1788dd48fb753b2c5ce8ad59027ad44aa7aad803d0521f9823cf7c3bf913715157a35849e
+  languageName: node
+  linkType: hard
+
+"@parcel/runtime-browser-hmr@npm:2.10.3":
+  version: 2.10.3
+  resolution: "@parcel/runtime-browser-hmr@npm:2.10.3"
+  dependencies:
+    "@parcel/plugin": 2.10.3
+    "@parcel/utils": 2.10.3
+  checksum: 6977acaf7797e070626667bef7849cfaebad89323c2da718c690f05f44b778bba7045469d704e7995fe06fd4e4f77194a8059218c85bcb186a05c753c0cf4c7c
   languageName: node
   linkType: hard
 
@@ -5038,6 +5386,18 @@ __metadata:
   languageName: node
   linkType: hard
 
+"@parcel/runtime-js@npm:2.10.3":
+  version: 2.10.3
+  resolution: "@parcel/runtime-js@npm:2.10.3"
+  dependencies:
+    "@parcel/diagnostic": 2.10.3
+    "@parcel/plugin": 2.10.3
+    "@parcel/utils": 2.10.3
+    nullthrows: ^1.1.1
+  checksum: a0c3f95eefbd9e6a9678d838bedac997ef4ebb797c1aef25d2e72217a70fdf54ae44a1ef0ff4c0161e0df004ee6a44b66958edfd5df9f95cd2017f049f0be2f0
+  languageName: node
+  linkType: hard
+
 "@parcel/runtime-react-refresh@npm:2.10.0":
   version: 2.10.0
   resolution: "@parcel/runtime-react-refresh@npm:2.10.0"
@@ -5047,6 +5407,18 @@ __metadata:
     react-error-overlay: 6.0.9
     react-refresh: ^0.9.0
   checksum: dc567474a154a73c90041b51b1122d9cb8c677ae2ebdacf534325ab3cf18b506aa6477b8c4005438a6b86c2bac88025d78407d84b5904fe035b2191d829ac98a
+  languageName: node
+  linkType: hard
+
+"@parcel/runtime-react-refresh@npm:2.10.3":
+  version: 2.10.3
+  resolution: "@parcel/runtime-react-refresh@npm:2.10.3"
+  dependencies:
+    "@parcel/plugin": 2.10.3
+    "@parcel/utils": 2.10.3
+    react-error-overlay: 6.0.9
+    react-refresh: ^0.9.0
+  checksum: 00f69e6a57918c628fdd4ee2dc4b65e81bdc0be15074d32ffdd6db3aa6d00b0ce0a4e005aba028fc0deaccf38f8b319bf0b5900999cbca5530ad29ab7a0a4074
   languageName: node
   linkType: hard
 
@@ -5061,10 +5433,28 @@ __metadata:
   languageName: node
   linkType: hard
 
+"@parcel/runtime-service-worker@npm:2.10.3":
+  version: 2.10.3
+  resolution: "@parcel/runtime-service-worker@npm:2.10.3"
+  dependencies:
+    "@parcel/plugin": 2.10.3
+    "@parcel/utils": 2.10.3
+    nullthrows: ^1.1.1
+  checksum: 01370853dfc535804353169f349b1d7a8291f4daa0b7728c052c1d9759e4b338fced1801490d8dd6aa12816135f475124daa9c747f7ba68c7c899064b3abb88f
+  languageName: node
+  linkType: hard
+
 "@parcel/rust@npm:2.10.0":
   version: 2.10.0
   resolution: "@parcel/rust@npm:2.10.0"
   checksum: 466a78d27db445780593a6a5a1ce39406daabf3661b81aa8a714ba647d0e3b08532a23b86508a7e8b9cb95f8aa4f755c6e33148ba961f173283b96b72cc51ee6
+  languageName: node
+  linkType: hard
+
+"@parcel/rust@npm:2.10.3":
+  version: 2.10.3
+  resolution: "@parcel/rust@npm:2.10.3"
+  checksum: 5c1a086742b0a53c935bc992a71cadc8fc3f5bd7ce7fce5dcf13a4079a867ef6df09422cd668e44c3cec0be19630441ca11c95081fc922287312893c5c0ebe1a
   languageName: node
   linkType: hard
 
@@ -5093,6 +5483,22 @@ __metadata:
   languageName: node
   linkType: hard
 
+"@parcel/transformer-babel@npm:2.10.3":
+  version: 2.10.3
+  resolution: "@parcel/transformer-babel@npm:2.10.3"
+  dependencies:
+    "@parcel/diagnostic": 2.10.3
+    "@parcel/plugin": 2.10.3
+    "@parcel/source-map": ^2.1.1
+    "@parcel/utils": 2.10.3
+    browserslist: ^4.6.6
+    json5: ^2.2.0
+    nullthrows: ^1.1.1
+    semver: ^7.5.2
+  checksum: 5dc31a9ff4b4f7a1400a16c2f2d44badcf330dfc98ff935ece813ce9efd926d34bc230a60c146bd3bb43b2da675f1289b3b55b8386f2739abb521e5c34970d59
+  languageName: node
+  linkType: hard
+
 "@parcel/transformer-css@npm:2.10.0":
   version: 2.10.0
   resolution: "@parcel/transformer-css@npm:2.10.0"
@@ -5105,6 +5511,21 @@ __metadata:
     lightningcss: ^1.16.1
     nullthrows: ^1.1.1
   checksum: acc26e9b3df28b45e89dcb71c6e29ab6c8507e44fde1d7f2b3aa6b8230dc17fbd043a4e2afd33b6cadd284842fd2582d937b16c4f43f10568fba839ce520ef94
+  languageName: node
+  linkType: hard
+
+"@parcel/transformer-css@npm:2.10.3":
+  version: 2.10.3
+  resolution: "@parcel/transformer-css@npm:2.10.3"
+  dependencies:
+    "@parcel/diagnostic": 2.10.3
+    "@parcel/plugin": 2.10.3
+    "@parcel/source-map": ^2.1.1
+    "@parcel/utils": 2.10.3
+    browserslist: ^4.6.6
+    lightningcss: ^1.16.1
+    nullthrows: ^1.1.1
+  checksum: f9cf5f04ceae726cf8a5c95ba326a73125423245fe34317593dde9956bead1e48021254ffffd0b5b41cd8f71a953580e1216d0897557c7d0999f360a7797ad43
   languageName: node
   linkType: hard
 
@@ -5125,6 +5546,23 @@ __metadata:
   languageName: node
   linkType: hard
 
+"@parcel/transformer-html@npm:2.10.3":
+  version: 2.10.3
+  resolution: "@parcel/transformer-html@npm:2.10.3"
+  dependencies:
+    "@parcel/diagnostic": 2.10.3
+    "@parcel/plugin": 2.10.3
+    "@parcel/rust": 2.10.3
+    nullthrows: ^1.1.1
+    posthtml: ^0.16.5
+    posthtml-parser: ^0.10.1
+    posthtml-render: ^3.0.0
+    semver: ^7.5.2
+    srcset: 4
+  checksum: ecf9f0c18791bdb1b2c65abbe8ef1fd0fe6bb33d4831c294efc78cf8094e7444e1746b86ad82e2cb7fec02c7c94fd8c0a6190201a12ff83e22b6d243cd665ece
+  languageName: node
+  linkType: hard
+
 "@parcel/transformer-image@npm:2.10.0":
   version: 2.10.0
   resolution: "@parcel/transformer-image@npm:2.10.0"
@@ -5136,6 +5574,20 @@ __metadata:
   peerDependencies:
     "@parcel/core": ^2.10.0
   checksum: 61a47d7d8e97a1874adf15f92410715c95a1b3747e0466299cb1a28cc1835855c758d7c3ebe40389b651bc1d7de2e942d0747e2787b63db5b6fff62803f6f900
+  languageName: node
+  linkType: hard
+
+"@parcel/transformer-image@npm:2.10.3":
+  version: 2.10.3
+  resolution: "@parcel/transformer-image@npm:2.10.3"
+  dependencies:
+    "@parcel/plugin": 2.10.3
+    "@parcel/utils": 2.10.3
+    "@parcel/workers": 2.10.3
+    nullthrows: ^1.1.1
+  peerDependencies:
+    "@parcel/core": ^2.10.3
+  checksum: 5e1fc73ca2e38f0fcb67cc0851e27a2d0f1bcb01c5b6f6e0ba8195987c32a26111cd27ba26d6d9f0374773c04f98dd88e1e4fcec770a596f0618b4a9bae3e46f
   languageName: node
   linkType: hard
 
@@ -5160,6 +5612,27 @@ __metadata:
   languageName: node
   linkType: hard
 
+"@parcel/transformer-js@npm:2.10.3":
+  version: 2.10.3
+  resolution: "@parcel/transformer-js@npm:2.10.3"
+  dependencies:
+    "@parcel/diagnostic": 2.10.3
+    "@parcel/plugin": 2.10.3
+    "@parcel/rust": 2.10.3
+    "@parcel/source-map": ^2.1.1
+    "@parcel/utils": 2.10.3
+    "@parcel/workers": 2.10.3
+    "@swc/helpers": ^0.5.0
+    browserslist: ^4.6.6
+    nullthrows: ^1.1.1
+    regenerator-runtime: ^0.13.7
+    semver: ^7.5.2
+  peerDependencies:
+    "@parcel/core": ^2.10.3
+  checksum: 7d534ea520808a3f12fa0751f88034a6212e0ec876934b570a48bd905ddea20d1fd8d543e23fd6fa4674591ccad476f1495e7b9732209a22d287674b82df6b02
+  languageName: node
+  linkType: hard
+
 "@parcel/transformer-json@npm:2.10.0":
   version: 2.10.0
   resolution: "@parcel/transformer-json@npm:2.10.0"
@@ -5167,6 +5640,16 @@ __metadata:
     "@parcel/plugin": 2.10.0
     json5: ^2.2.0
   checksum: 9c7aceb8e6372035ebd49dfd16f656f8c631c80c6750a2a2a51444e55013caa2d0bdef6b868a42c149c0500c988440ddf3f4a9a565dd15bf2a1c80571e9f21e9
+  languageName: node
+  linkType: hard
+
+"@parcel/transformer-json@npm:2.10.3":
+  version: 2.10.3
+  resolution: "@parcel/transformer-json@npm:2.10.3"
+  dependencies:
+    "@parcel/plugin": 2.10.3
+    json5: ^2.2.0
+  checksum: f08d2a13b284484e4d062b6650d65329d0da1da04dadd770da9911a44b40a051e745f80b5b61e82ad74d99816c7cb10e0094144b5b033cb17c85d38a916f4714
   languageName: node
   linkType: hard
 
@@ -5186,6 +5669,22 @@ __metadata:
   languageName: node
   linkType: hard
 
+"@parcel/transformer-postcss@npm:2.10.3":
+  version: 2.10.3
+  resolution: "@parcel/transformer-postcss@npm:2.10.3"
+  dependencies:
+    "@parcel/diagnostic": 2.10.3
+    "@parcel/plugin": 2.10.3
+    "@parcel/rust": 2.10.3
+    "@parcel/utils": 2.10.3
+    clone: ^2.1.1
+    nullthrows: ^1.1.1
+    postcss-value-parser: ^4.2.0
+    semver: ^7.5.2
+  checksum: bcea34678d39231cd91cebdc8790b4b9f6e56b9a8c94cadd54ab90b43d282505fe17c8b5414b0fdf82d7b66620bffc587c21f2613356085cba7e7dfc5badea77
+  languageName: node
+  linkType: hard
+
 "@parcel/transformer-posthtml@npm:2.10.0":
   version: 2.10.0
   resolution: "@parcel/transformer-posthtml@npm:2.10.0"
@@ -5201,12 +5700,36 @@ __metadata:
   languageName: node
   linkType: hard
 
+"@parcel/transformer-posthtml@npm:2.10.3":
+  version: 2.10.3
+  resolution: "@parcel/transformer-posthtml@npm:2.10.3"
+  dependencies:
+    "@parcel/plugin": 2.10.3
+    "@parcel/utils": 2.10.3
+    nullthrows: ^1.1.1
+    posthtml: ^0.16.5
+    posthtml-parser: ^0.10.1
+    posthtml-render: ^3.0.0
+    semver: ^7.5.2
+  checksum: afa94afee4b0e1769227bbd6a8928bd5ce8c38711bc8164cb9a76af2134643d28c3b1887a8237b9c2572f0a30f7181aaeb3ed3c1a4882b064a3f30e2f145b77d
+  languageName: node
+  linkType: hard
+
 "@parcel/transformer-raw@npm:2.10.0":
   version: 2.10.0
   resolution: "@parcel/transformer-raw@npm:2.10.0"
   dependencies:
     "@parcel/plugin": 2.10.0
   checksum: c7b1b9c6f7fbcfc51dd7360ae9551fa4611ef96990df954e057eeeb44f3915c84da7bb6bea10eb4e246ec4e217c387db8cd8fe3fbf999bf0bfb2e91979092dc3
+  languageName: node
+  linkType: hard
+
+"@parcel/transformer-raw@npm:2.10.3":
+  version: 2.10.3
+  resolution: "@parcel/transformer-raw@npm:2.10.3"
+  dependencies:
+    "@parcel/plugin": 2.10.3
+  checksum: 26f5b5c1f80f60b6ea404cce9372591f643accc3357b7164b208888d47e7b9731433d3ef4e62034cadbc998ef84cfa0d9e6b63a842e0f09157d3f5d46324342f
   languageName: node
   linkType: hard
 
@@ -5218,6 +5741,17 @@ __metadata:
     "@parcel/utils": 2.10.0
     react-refresh: ^0.9.0
   checksum: fc3163bcb03a16a0581d23f2373d87b2b9d10dc49e48297b60a87b5a555ba0cd7e4d3ab1787cac0974c2871ddd9ada0fa0551685037cf4dce518d96e1a371917
+  languageName: node
+  linkType: hard
+
+"@parcel/transformer-react-refresh-wrap@npm:2.10.3":
+  version: 2.10.3
+  resolution: "@parcel/transformer-react-refresh-wrap@npm:2.10.3"
+  dependencies:
+    "@parcel/plugin": 2.10.3
+    "@parcel/utils": 2.10.3
+    react-refresh: ^0.9.0
+  checksum: 5959b5860d1ac342bd3eaf9fcbde2065c84ef4347100f36ae29cc322a87aea5b1175142fe6c181f9fddbc858384755787f5b9398da2078d5881f2b2f94caf19b
   languageName: node
   linkType: hard
 
@@ -5237,6 +5771,22 @@ __metadata:
   languageName: node
   linkType: hard
 
+"@parcel/transformer-svg@npm:2.10.3":
+  version: 2.10.3
+  resolution: "@parcel/transformer-svg@npm:2.10.3"
+  dependencies:
+    "@parcel/diagnostic": 2.10.3
+    "@parcel/plugin": 2.10.3
+    "@parcel/rust": 2.10.3
+    nullthrows: ^1.1.1
+    posthtml: ^0.16.5
+    posthtml-parser: ^0.10.1
+    posthtml-render: ^3.0.0
+    semver: ^7.5.2
+  checksum: aa1c3378fc4b809cca9dd90804030d204a587e3a4bebf5f0cf3853eaf6eff0cf82b47e304df2b532831eaabe48143a996a789d3d199f156de534ff03c68a3c8e
+  languageName: node
+  linkType: hard
+
 "@parcel/types@npm:2.10.0":
   version: 2.10.0
   resolution: "@parcel/types@npm:2.10.0"
@@ -5249,6 +5799,21 @@ __metadata:
     "@parcel/workers": 2.10.0
     utility-types: ^3.10.0
   checksum: 387aa079020ffec27f92d9496e0abd5e71e4b8e0ca1c9cf5b692737dd172d037302dd2c9d3cc32143813707050eb9de23e4e4eca32a65c402f6564a08da61e6f
+  languageName: node
+  linkType: hard
+
+"@parcel/types@npm:2.10.3":
+  version: 2.10.3
+  resolution: "@parcel/types@npm:2.10.3"
+  dependencies:
+    "@parcel/cache": 2.10.3
+    "@parcel/diagnostic": 2.10.3
+    "@parcel/fs": 2.10.3
+    "@parcel/package-manager": 2.10.3
+    "@parcel/source-map": ^2.1.1
+    "@parcel/workers": 2.10.3
+    utility-types: ^3.10.0
+  checksum: ffc6d24df95b5458e02e2a841fac6bee6ba9f78f3f0c3ae9e465a546a3a05e91ab2781850785a6e153ce20f456b9d4427ea0754cdc8efaabf2fee5823ac5f89b
   languageName: node
   linkType: hard
 
@@ -5265,6 +5830,22 @@ __metadata:
     chalk: ^4.1.0
     nullthrows: ^1.1.1
   checksum: 9f4953ff9af730b59abbaa6f5f0c452a26848fc52d6f04a0facdc9ebfabb4434fd548ae38a7f882a4a5cd2db5a0b389b540fe7d2ffc6c286323062a764d2cc43
+  languageName: node
+  linkType: hard
+
+"@parcel/utils@npm:2.10.3":
+  version: 2.10.3
+  resolution: "@parcel/utils@npm:2.10.3"
+  dependencies:
+    "@parcel/codeframe": 2.10.3
+    "@parcel/diagnostic": 2.10.3
+    "@parcel/logger": 2.10.3
+    "@parcel/markdown-ansi": 2.10.3
+    "@parcel/rust": 2.10.3
+    "@parcel/source-map": ^2.1.1
+    chalk: ^4.1.0
+    nullthrows: ^1.1.1
+  checksum: fb9aa1ee1a9de81a917a58e4f0960440597accdd68d00e775d69b5ddcf6c82ceb348f412301cfaa78560f36786283cab6105d647cd6442c6be2693b2afec61f3
   languageName: node
   linkType: hard
 
@@ -5426,6 +6007,22 @@ __metadata:
   peerDependencies:
     "@parcel/core": ^2.10.0
   checksum: e8b1701b53b2f3e913eee98e1e16def38a67d08b4835d25e1dd610505edc2f38c23729ec9b264ccd3c6ea3221814a314b657a3a3c41feebbdb01dcc34e69741c
+  languageName: node
+  linkType: hard
+
+"@parcel/workers@npm:2.10.3":
+  version: 2.10.3
+  resolution: "@parcel/workers@npm:2.10.3"
+  dependencies:
+    "@parcel/diagnostic": 2.10.3
+    "@parcel/logger": 2.10.3
+    "@parcel/profiler": 2.10.3
+    "@parcel/types": 2.10.3
+    "@parcel/utils": 2.10.3
+    nullthrows: ^1.1.1
+  peerDependencies:
+    "@parcel/core": ^2.10.3
+  checksum: 5418cfa25d22b1d786d754c20030b4aa081b62e96daf247459549df7f4971229635fa5ecb2860ee500af08a172f0eed689654ed867148c18ae0dae9aac1e68f2
   languageName: node
   linkType: hard
 
@@ -6043,712 +6640,6 @@ __metadata:
   languageName: node
   linkType: hard
 
-"@react-aria/breadcrumbs@npm:^3.5.0":
-  version: 3.5.7
-  resolution: "@react-aria/breadcrumbs@npm:3.5.7"
-  dependencies:
-    "@react-aria/i18n": ^3.8.4
-    "@react-aria/interactions": ^3.19.1
-    "@react-aria/link": ^3.6.1
-    "@react-aria/utils": ^3.21.1
-    "@react-types/breadcrumbs": ^3.7.1
-    "@react-types/shared": ^3.21.0
-    "@swc/helpers": ^0.5.0
-  peerDependencies:
-    react: ^16.8.0 || ^17.0.0-rc.1 || ^18.0.0
-  checksum: e32eaaf421de6cf118f8ebca9a406d67b49a8cbd7bf73a40dd1028994fae488135329442ab7c3ddb78fa02acc1695def5b6ac2faeeee626c6a6b9a04b26dca55
-  languageName: node
-  linkType: hard
-
-"@react-aria/button@npm:^3.7.0":
-  version: 3.8.4
-  resolution: "@react-aria/button@npm:3.8.4"
-  dependencies:
-    "@react-aria/focus": ^3.14.3
-    "@react-aria/interactions": ^3.19.1
-    "@react-aria/utils": ^3.21.1
-    "@react-stately/toggle": ^3.6.3
-    "@react-types/button": ^3.9.0
-    "@react-types/shared": ^3.21.0
-    "@swc/helpers": ^0.5.0
-  peerDependencies:
-    react: ^16.8.0 || ^17.0.0-rc.1 || ^18.0.0
-  checksum: bf17ca3ef3aa8d5d0bce6a1a32f9447b88f14935bae310f1e32665fddc24d6f0240f397e8f80d320f7dfdfd958bffec6111939ad61d8b3822bcfc88468282a64
-  languageName: node
-  linkType: hard
-
-"@react-aria/calendar@npm:^3.1.0":
-  version: 3.5.2
-  resolution: "@react-aria/calendar@npm:3.5.2"
-  dependencies:
-    "@internationalized/date": ^3.5.0
-    "@react-aria/i18n": ^3.8.4
-    "@react-aria/interactions": ^3.19.1
-    "@react-aria/live-announcer": ^3.3.1
-    "@react-aria/utils": ^3.21.1
-    "@react-stately/calendar": ^3.4.1
-    "@react-types/button": ^3.9.0
-    "@react-types/calendar": ^3.4.1
-    "@react-types/shared": ^3.21.0
-    "@swc/helpers": ^0.5.0
-  peerDependencies:
-    react: ^16.8.0 || ^17.0.0-rc.1 || ^18.0.0
-    react-dom: ^16.8.0 || ^17.0.0-rc.1 || ^18.0.0
-  checksum: 3351b5e689d8d9263c635c91c995d6b53cc593dea1a7f26f22ab6b5dc2af574bb918de0e94fc5fc134cdf20474d0d99b388e11b0caf83af3cb35be071a00b0ce
-  languageName: node
-  linkType: hard
-
-"@react-aria/checkbox@npm:^3.8.0":
-  version: 3.11.2
-  resolution: "@react-aria/checkbox@npm:3.11.2"
-  dependencies:
-    "@react-aria/label": ^3.7.2
-    "@react-aria/toggle": ^3.8.2
-    "@react-aria/utils": ^3.21.1
-    "@react-stately/checkbox": ^3.5.1
-    "@react-stately/toggle": ^3.6.3
-    "@react-types/checkbox": ^3.5.2
-    "@react-types/shared": ^3.21.0
-    "@swc/helpers": ^0.5.0
-  peerDependencies:
-    react: ^16.8.0 || ^17.0.0-rc.1 || ^18.0.0
-  checksum: a17ceba3b120e810800e05fcb668812dd57880086457263f5202de43ac91c49560735d8297c39c7b2f5021f9c118393bc2e1baf11312265f688896253d8a3bf5
-  languageName: node
-  linkType: hard
-
-"@react-aria/combobox@npm:^3.5.1":
-  version: 3.7.1
-  resolution: "@react-aria/combobox@npm:3.7.1"
-  dependencies:
-    "@react-aria/i18n": ^3.8.4
-    "@react-aria/interactions": ^3.19.1
-    "@react-aria/listbox": ^3.11.1
-    "@react-aria/live-announcer": ^3.3.1
-    "@react-aria/menu": ^3.11.1
-    "@react-aria/overlays": ^3.18.1
-    "@react-aria/selection": ^3.17.1
-    "@react-aria/textfield": ^3.12.2
-    "@react-aria/utils": ^3.21.1
-    "@react-stately/collections": ^3.10.2
-    "@react-stately/combobox": ^3.7.1
-    "@react-stately/layout": ^3.13.3
-    "@react-types/button": ^3.9.0
-    "@react-types/combobox": ^3.8.1
-    "@react-types/shared": ^3.21.0
-    "@swc/helpers": ^0.5.0
-  peerDependencies:
-    react: ^16.8.0 || ^17.0.0-rc.1 || ^18.0.0
-    react-dom: ^16.8.0 || ^17.0.0-rc.1 || ^18.0.0
-  checksum: f8f427c2232bb2671920d1c459f4f2c4d17a834dad4b3379a6253bf9c40f6481ec1f6744f5c45f11e30d1f4e808a94d0604b45237bbab989850f1ce26422be6e
-  languageName: node
-  linkType: hard
-
-"@react-aria/datepicker@npm:^3.3.0":
-  version: 3.8.1
-  resolution: "@react-aria/datepicker@npm:3.8.1"
-  dependencies:
-    "@internationalized/date": ^3.5.0
-    "@internationalized/number": ^3.3.0
-    "@internationalized/string": ^3.1.1
-    "@react-aria/focus": ^3.14.3
-    "@react-aria/i18n": ^3.8.4
-    "@react-aria/interactions": ^3.19.1
-    "@react-aria/label": ^3.7.2
-    "@react-aria/spinbutton": ^3.5.4
-    "@react-aria/utils": ^3.21.1
-    "@react-stately/datepicker": ^3.8.0
-    "@react-types/button": ^3.9.0
-    "@react-types/calendar": ^3.4.1
-    "@react-types/datepicker": ^3.6.1
-    "@react-types/dialog": ^3.5.6
-    "@react-types/shared": ^3.21.0
-    "@swc/helpers": ^0.5.0
-  peerDependencies:
-    react: ^16.8.0 || ^17.0.0-rc.1 || ^18.0.0
-    react-dom: ^16.8.0 || ^17.0.0-rc.1 || ^18.0.0
-  checksum: 9ac978a29843c68361a894e1d85937edd5c4268d3ebf341316fced9b6ed772f89bfcb5697852658a21b51e49fda1185baea722673dc33a3474625b86ba63fcf4
-  languageName: node
-  linkType: hard
-
-"@react-aria/dialog@npm:^3.5.0":
-  version: 3.5.7
-  resolution: "@react-aria/dialog@npm:3.5.7"
-  dependencies:
-    "@react-aria/focus": ^3.14.3
-    "@react-aria/overlays": ^3.18.1
-    "@react-aria/utils": ^3.21.1
-    "@react-stately/overlays": ^3.6.3
-    "@react-types/dialog": ^3.5.6
-    "@react-types/shared": ^3.21.0
-    "@swc/helpers": ^0.5.0
-  peerDependencies:
-    react: ^16.8.0 || ^17.0.0-rc.1 || ^18.0.0
-    react-dom: ^16.8.0 || ^17.0.0-rc.1 || ^18.0.0
-  checksum: f05501fd01b6aea715dace095828631fb6e4e4ab6b8784ec2e9268018ae2fce7f06bef5d0ebd34cb0ba81fd30854a9e4bc770ac0c5efadd841e281fc4eba4946
-  languageName: node
-  linkType: hard
-
-"@react-aria/dnd@npm:^3.1.0":
-  version: 3.4.3
-  resolution: "@react-aria/dnd@npm:3.4.3"
-  dependencies:
-    "@internationalized/string": ^3.1.1
-    "@react-aria/i18n": ^3.8.4
-    "@react-aria/interactions": ^3.19.1
-    "@react-aria/live-announcer": ^3.3.1
-    "@react-aria/overlays": ^3.18.1
-    "@react-aria/utils": ^3.21.1
-    "@react-aria/visually-hidden": ^3.8.6
-    "@react-stately/dnd": ^3.2.5
-    "@react-types/button": ^3.9.0
-    "@react-types/shared": ^3.21.0
-    "@swc/helpers": ^0.5.0
-  peerDependencies:
-    react: ^16.8.0 || ^17.0.0-rc.1 || ^18.0.0
-    react-dom: ^16.8.0 || ^17.0.0-rc.1 || ^18.0.0
-  checksum: c376383b0a2bbf65d95868506a31ce40e8bca395b92b5048b34b668e020bbe56a0f3d8d1d041284bdc241e051140e809c4826aab36dc4646de34f054736b83a6
-  languageName: node
-  linkType: hard
-
-"@react-aria/focus@npm:^3.11.0, @react-aria/focus@npm:^3.14.3":
-  version: 3.14.3
-  resolution: "@react-aria/focus@npm:3.14.3"
-  dependencies:
-    "@react-aria/interactions": ^3.19.1
-    "@react-aria/utils": ^3.21.1
-    "@react-types/shared": ^3.21.0
-    "@swc/helpers": ^0.5.0
-    clsx: ^1.1.1
-  peerDependencies:
-    react: ^16.8.0 || ^17.0.0-rc.1 || ^18.0.0
-  checksum: 3db33bd8f767d8a9ba06d3eac42c86b146f12691bd0ff72a62e9124674a8e23e7b0cbf9b4fcb6e85d8bc3c35c89b8d6c1739b15e101990ad72bfdc42d4b307af
-  languageName: node
-  linkType: hard
-
-"@react-aria/grid@npm:^3.8.4":
-  version: 3.8.4
-  resolution: "@react-aria/grid@npm:3.8.4"
-  dependencies:
-    "@react-aria/focus": ^3.14.3
-    "@react-aria/i18n": ^3.8.4
-    "@react-aria/interactions": ^3.19.1
-    "@react-aria/live-announcer": ^3.3.1
-    "@react-aria/selection": ^3.17.1
-    "@react-aria/utils": ^3.21.1
-    "@react-stately/collections": ^3.10.2
-    "@react-stately/grid": ^3.8.2
-    "@react-stately/selection": ^3.14.0
-    "@react-stately/virtualizer": ^3.6.4
-    "@react-types/checkbox": ^3.5.2
-    "@react-types/grid": ^3.2.2
-    "@react-types/shared": ^3.21.0
-    "@swc/helpers": ^0.5.0
-  peerDependencies:
-    react: ^16.8.0 || ^17.0.0-rc.1 || ^18.0.0
-    react-dom: ^16.8.0 || ^17.0.0-rc.1 || ^18.0.0
-  checksum: 9dcbff1a6e45d73cb5287262db054c67b8e66c147d1801e91794477f97ca4823e84591149645c9001913788ae5450f0dd8154085ab8c8f1c90ef9b0916e5af92
-  languageName: node
-  linkType: hard
-
-"@react-aria/gridlist@npm:^3.2.1":
-  version: 3.7.1
-  resolution: "@react-aria/gridlist@npm:3.7.1"
-  dependencies:
-    "@react-aria/focus": ^3.14.3
-    "@react-aria/grid": ^3.8.4
-    "@react-aria/i18n": ^3.8.4
-    "@react-aria/interactions": ^3.19.1
-    "@react-aria/selection": ^3.17.1
-    "@react-aria/utils": ^3.21.1
-    "@react-stately/list": ^3.10.0
-    "@react-types/checkbox": ^3.5.2
-    "@react-types/shared": ^3.21.0
-    "@swc/helpers": ^0.5.0
-  peerDependencies:
-    react: ^16.8.0 || ^17.0.0-rc.1 || ^18.0.0
-    react-dom: ^16.8.0 || ^17.0.0-rc.1 || ^18.0.0
-  checksum: 509a60a4dc5d395e413f17a9322fbe205635d52e3bffa6b37463b0f5614c899a6080c139fec84548fb5d0ce7c6914efe528d7b8beddb69ba161b03e6bde579af
-  languageName: node
-  linkType: hard
-
-"@react-aria/i18n@npm:^3.7.0, @react-aria/i18n@npm:^3.8.4":
-  version: 3.8.4
-  resolution: "@react-aria/i18n@npm:3.8.4"
-  dependencies:
-    "@internationalized/date": ^3.5.0
-    "@internationalized/message": ^3.1.1
-    "@internationalized/number": ^3.3.0
-    "@internationalized/string": ^3.1.1
-    "@react-aria/ssr": ^3.8.0
-    "@react-aria/utils": ^3.21.1
-    "@react-types/shared": ^3.21.0
-    "@swc/helpers": ^0.5.0
-  peerDependencies:
-    react: ^16.8.0 || ^17.0.0-rc.1 || ^18.0.0
-  checksum: 6539c6c548fbe4ee22a40acc55018d469c1f72c2160a35006f16d6a920936db63d3b6b9055e1251a8a588c09e6c392b0e1a6a6da1b78dc02ee990e54a365b099
-  languageName: node
-  linkType: hard
-
-"@react-aria/interactions@npm:^3.14.0, @react-aria/interactions@npm:^3.19.1":
-  version: 3.19.1
-  resolution: "@react-aria/interactions@npm:3.19.1"
-  dependencies:
-    "@react-aria/ssr": ^3.8.0
-    "@react-aria/utils": ^3.21.1
-    "@react-types/shared": ^3.21.0
-    "@swc/helpers": ^0.5.0
-  peerDependencies:
-    react: ^16.8.0 || ^17.0.0-rc.1 || ^18.0.0
-  checksum: 7d2b059d2af75e8f847c2c01acf2ae1c7721a206098a2c4d056bb746513c710aaf46951774807e3aa18dee2f8311cb754b838162631d86a00d392216df2e5fcd
-  languageName: node
-  linkType: hard
-
-"@react-aria/label@npm:^3.5.0, @react-aria/label@npm:^3.7.2":
-  version: 3.7.2
-  resolution: "@react-aria/label@npm:3.7.2"
-  dependencies:
-    "@react-aria/utils": ^3.21.1
-    "@react-types/label": ^3.8.1
-    "@react-types/shared": ^3.21.0
-    "@swc/helpers": ^0.5.0
-  peerDependencies:
-    react: ^16.8.0 || ^17.0.0-rc.1 || ^18.0.0
-  checksum: dc6455b04f88a0b9bed7098ddd1c92d003643c4a97de8f3c430a57c5a221382ad0cafc776f3e07dab55c8588978fb0e367041f3eb46d30b4e53c634aec32999a
-  languageName: node
-  linkType: hard
-
-"@react-aria/link@npm:^3.4.0, @react-aria/link@npm:^3.6.1":
-  version: 3.6.1
-  resolution: "@react-aria/link@npm:3.6.1"
-  dependencies:
-    "@react-aria/focus": ^3.14.3
-    "@react-aria/interactions": ^3.19.1
-    "@react-aria/utils": ^3.21.1
-    "@react-types/link": ^3.5.1
-    "@react-types/shared": ^3.21.0
-    "@swc/helpers": ^0.5.0
-  peerDependencies:
-    react: ^16.8.0 || ^17.0.0-rc.1 || ^18.0.0
-  checksum: 02682b73e4f29ac9afb6b3be5ed06a5a8e6fc69283a674bd0879182ac4bce06a5edb17cf41f9ad7fb63a6ace76a06371448de5dcca2965d87dff2897f477779e
-  languageName: node
-  linkType: hard
-
-"@react-aria/listbox@npm:^3.11.1, @react-aria/listbox@npm:^3.8.1":
-  version: 3.11.1
-  resolution: "@react-aria/listbox@npm:3.11.1"
-  dependencies:
-    "@react-aria/focus": ^3.14.3
-    "@react-aria/interactions": ^3.19.1
-    "@react-aria/label": ^3.7.2
-    "@react-aria/selection": ^3.17.1
-    "@react-aria/utils": ^3.21.1
-    "@react-stately/collections": ^3.10.2
-    "@react-stately/list": ^3.10.0
-    "@react-types/listbox": ^3.4.5
-    "@react-types/shared": ^3.21.0
-    "@swc/helpers": ^0.5.0
-  peerDependencies:
-    react: ^16.8.0 || ^17.0.0-rc.1 || ^18.0.0
-    react-dom: ^16.8.0 || ^17.0.0-rc.1 || ^18.0.0
-  checksum: 0f3bbb2a74a4b3fcabce5e64ccaa235c87e8f4af035e75aa5a29fe2a7633871a4fec710596c801606a34e822e36ec7ee3fa6849829d97f006ba61bf17831f72e
-  languageName: node
-  linkType: hard
-
-"@react-aria/live-announcer@npm:^3.3.1":
-  version: 3.3.1
-  resolution: "@react-aria/live-announcer@npm:3.3.1"
-  dependencies:
-    "@swc/helpers": ^0.5.0
-  checksum: df4e161247c87038eabf3f623a3ce18ef486f6c8a3e136b9c91bf3585312f48759cbd5d8ba6d0236231ee3070343798b9865a15a07afd9dabebafc0249a1fda7
-  languageName: node
-  linkType: hard
-
-"@react-aria/menu@npm:^3.11.1, @react-aria/menu@npm:^3.8.1":
-  version: 3.11.1
-  resolution: "@react-aria/menu@npm:3.11.1"
-  dependencies:
-    "@react-aria/focus": ^3.14.3
-    "@react-aria/i18n": ^3.8.4
-    "@react-aria/interactions": ^3.19.1
-    "@react-aria/overlays": ^3.18.1
-    "@react-aria/selection": ^3.17.1
-    "@react-aria/utils": ^3.21.1
-    "@react-stately/collections": ^3.10.2
-    "@react-stately/menu": ^3.5.6
-    "@react-stately/tree": ^3.7.3
-    "@react-types/button": ^3.9.0
-    "@react-types/menu": ^3.9.5
-    "@react-types/shared": ^3.21.0
-    "@swc/helpers": ^0.5.0
-  peerDependencies:
-    react: ^16.8.0 || ^17.0.0-rc.1 || ^18.0.0
-    react-dom: ^16.8.0 || ^17.0.0-rc.1 || ^18.0.0
-  checksum: 330a9c09b53e870fb5c79d73ebd2595b0237a794ad445ff11601da48c7a8379427aedffc1f45046e98e01aa1188227e54714eba2103cf86b61bce3ac2c96503f
-  languageName: node
-  linkType: hard
-
-"@react-aria/meter@npm:^3.4.0":
-  version: 3.4.7
-  resolution: "@react-aria/meter@npm:3.4.7"
-  dependencies:
-    "@react-aria/progress": ^3.4.7
-    "@react-types/meter": ^3.3.5
-    "@react-types/shared": ^3.21.0
-    "@swc/helpers": ^0.5.0
-  peerDependencies:
-    react: ^16.8.0 || ^17.0.0-rc.1 || ^18.0.0
-  checksum: 74a21685dcc61cd988dbaec442239a644cd3f29efa965644b35e071472f8e5a1bc64c1daf66a20d6c80c446f337f7db1b26318984e37861c5f4bd992e4bed841
-  languageName: node
-  linkType: hard
-
-"@react-aria/numberfield@npm:^3.4.0":
-  version: 3.9.1
-  resolution: "@react-aria/numberfield@npm:3.9.1"
-  dependencies:
-    "@react-aria/i18n": ^3.8.4
-    "@react-aria/interactions": ^3.19.1
-    "@react-aria/live-announcer": ^3.3.1
-    "@react-aria/spinbutton": ^3.5.4
-    "@react-aria/textfield": ^3.12.2
-    "@react-aria/utils": ^3.21.1
-    "@react-stately/numberfield": ^3.6.2
-    "@react-types/button": ^3.9.0
-    "@react-types/numberfield": ^3.6.1
-    "@react-types/shared": ^3.21.0
-    "@react-types/textfield": ^3.8.1
-    "@swc/helpers": ^0.5.0
-  peerDependencies:
-    react: ^16.8.0 || ^17.0.0-rc.1 || ^18.0.0
-    react-dom: ^16.8.0 || ^17.0.0-rc.1 || ^18.0.0
-  checksum: ff6d0f58245aea598babce22d45e54333e6709a8c8b593787c8e9fff755c2512f0c9ddc843d7aeffb7691058fe24ef4f1bb0374726446745fb47ac2a40e7c613
-  languageName: node
-  linkType: hard
-
-"@react-aria/overlays@npm:^3.13.0, @react-aria/overlays@npm:^3.18.1":
-  version: 3.18.1
-  resolution: "@react-aria/overlays@npm:3.18.1"
-  dependencies:
-    "@react-aria/focus": ^3.14.3
-    "@react-aria/i18n": ^3.8.4
-    "@react-aria/interactions": ^3.19.1
-    "@react-aria/ssr": ^3.8.0
-    "@react-aria/utils": ^3.21.1
-    "@react-aria/visually-hidden": ^3.8.6
-    "@react-stately/overlays": ^3.6.3
-    "@react-types/button": ^3.9.0
-    "@react-types/overlays": ^3.8.3
-    "@react-types/shared": ^3.21.0
-    "@swc/helpers": ^0.5.0
-  peerDependencies:
-    react: ^16.8.0 || ^17.0.0-rc.1 || ^18.0.0
-    react-dom: ^16.8.0 || ^17.0.0-rc.1 || ^18.0.0
-  checksum: d8169db1de37cf5b5301666a853bd98f841237075650d35ed22b813f72742f6e4b893fc8084ab10290b00608f36492b75b5915ca1360654ec06121b9768aa6b2
-  languageName: node
-  linkType: hard
-
-"@react-aria/progress@npm:^3.4.0, @react-aria/progress@npm:^3.4.7":
-  version: 3.4.7
-  resolution: "@react-aria/progress@npm:3.4.7"
-  dependencies:
-    "@react-aria/i18n": ^3.8.4
-    "@react-aria/label": ^3.7.2
-    "@react-aria/utils": ^3.21.1
-    "@react-types/progress": ^3.5.0
-    "@react-types/shared": ^3.21.0
-    "@swc/helpers": ^0.5.0
-  peerDependencies:
-    react: ^16.8.0 || ^17.0.0-rc.1 || ^18.0.0
-  checksum: 5704d050ebe90661e6de3c7ba889b4c0e7c03b7a44f2d78f6f4391757ec07303248ee08e701fd90a783a7aac068ecf5b0153c8266c8f2a8881e479f3927b0245
-  languageName: node
-  linkType: hard
-
-"@react-aria/radio@npm:^3.5.0":
-  version: 3.8.2
-  resolution: "@react-aria/radio@npm:3.8.2"
-  dependencies:
-    "@react-aria/focus": ^3.14.3
-    "@react-aria/i18n": ^3.8.4
-    "@react-aria/interactions": ^3.19.1
-    "@react-aria/label": ^3.7.2
-    "@react-aria/utils": ^3.21.1
-    "@react-stately/radio": ^3.9.1
-    "@react-types/radio": ^3.5.2
-    "@react-types/shared": ^3.21.0
-    "@swc/helpers": ^0.5.0
-  peerDependencies:
-    react: ^16.8.0 || ^17.0.0-rc.1 || ^18.0.0
-  checksum: cfb589d6f3de1b22eacd79b343b2819df49d0f691956bb79f4bfe616b1ef633079f314ae888a33c55afad91166edb0bf43599824254119573801c92039a04c52
-  languageName: node
-  linkType: hard
-
-"@react-aria/searchfield@npm:^3.5.0":
-  version: 3.5.7
-  resolution: "@react-aria/searchfield@npm:3.5.7"
-  dependencies:
-    "@react-aria/i18n": ^3.8.4
-    "@react-aria/interactions": ^3.19.1
-    "@react-aria/textfield": ^3.12.2
-    "@react-aria/utils": ^3.21.1
-    "@react-stately/searchfield": ^3.4.6
-    "@react-types/button": ^3.9.0
-    "@react-types/searchfield": ^3.5.1
-    "@react-types/shared": ^3.21.0
-    "@swc/helpers": ^0.5.0
-  peerDependencies:
-    react: ^16.8.0 || ^17.0.0-rc.1 || ^18.0.0
-  checksum: d7e94654dd8c5f5d7b31340f313be222e2e7e4c3de11a33c169995839bf179c2a77398379f0ed94d1fe22a7fcbdc563e8a0b5354ce74289ac6c3b638a4ee7414
-  languageName: node
-  linkType: hard
-
-"@react-aria/select@npm:^3.9.1":
-  version: 3.13.1
-  resolution: "@react-aria/select@npm:3.13.1"
-  dependencies:
-    "@react-aria/i18n": ^3.8.4
-    "@react-aria/interactions": ^3.19.1
-    "@react-aria/label": ^3.7.2
-    "@react-aria/listbox": ^3.11.1
-    "@react-aria/menu": ^3.11.1
-    "@react-aria/selection": ^3.17.1
-    "@react-aria/utils": ^3.21.1
-    "@react-aria/visually-hidden": ^3.8.6
-    "@react-stately/select": ^3.5.5
-    "@react-types/button": ^3.9.0
-    "@react-types/select": ^3.8.4
-    "@react-types/shared": ^3.21.0
-    "@swc/helpers": ^0.5.0
-  peerDependencies:
-    react: ^16.8.0 || ^17.0.0-rc.1 || ^18.0.0
-    react-dom: ^16.8.0 || ^17.0.0-rc.1 || ^18.0.0
-  checksum: 986d3bc454c83fe878290f039d1f459392760eb8c9245867e33c03fa53226fddca659e7ff8a6721c9ae7cf0d1ab391c7355d6828d356e9ce1cebf7e58762cd22
-  languageName: node
-  linkType: hard
-
-"@react-aria/selection@npm:^3.13.1, @react-aria/selection@npm:^3.17.1":
-  version: 3.17.1
-  resolution: "@react-aria/selection@npm:3.17.1"
-  dependencies:
-    "@react-aria/focus": ^3.14.3
-    "@react-aria/i18n": ^3.8.4
-    "@react-aria/interactions": ^3.19.1
-    "@react-aria/utils": ^3.21.1
-    "@react-stately/collections": ^3.10.2
-    "@react-stately/selection": ^3.14.0
-    "@react-types/shared": ^3.21.0
-    "@swc/helpers": ^0.5.0
-  peerDependencies:
-    react: ^16.8.0 || ^17.0.0-rc.1 || ^18.0.0
-    react-dom: ^16.8.0 || ^17.0.0-rc.1 || ^18.0.0
-  checksum: 124ab12edcd3712dc581566c73946a5c46735fd32e37d3ace5c2351bc7876a423141943661041ee6a6f198098a1a7a4d67491e560c9b0a132bc81e351c252c56
-  languageName: node
-  linkType: hard
-
-"@react-aria/separator@npm:^3.3.0":
-  version: 3.3.7
-  resolution: "@react-aria/separator@npm:3.3.7"
-  dependencies:
-    "@react-aria/utils": ^3.21.1
-    "@react-types/shared": ^3.21.0
-    "@swc/helpers": ^0.5.0
-  peerDependencies:
-    react: ^16.8.0 || ^17.0.0-rc.1 || ^18.0.0
-  checksum: b268e1893626fc92d5a5a3e8dfefc0366a79ef8bd25f55fa4d09caac098215ea7abbca3c8b9ee59b5c07cf3aefdc85f6981ef3484f6509c5963bd1f056f385ec
-  languageName: node
-  linkType: hard
-
-"@react-aria/slider@npm:^3.3.0":
-  version: 3.7.2
-  resolution: "@react-aria/slider@npm:3.7.2"
-  dependencies:
-    "@react-aria/focus": ^3.14.3
-    "@react-aria/i18n": ^3.8.4
-    "@react-aria/interactions": ^3.19.1
-    "@react-aria/label": ^3.7.2
-    "@react-aria/utils": ^3.21.1
-    "@react-stately/radio": ^3.9.1
-    "@react-stately/slider": ^3.4.4
-    "@react-types/radio": ^3.5.2
-    "@react-types/shared": ^3.21.0
-    "@react-types/slider": ^3.6.2
-    "@swc/helpers": ^0.5.0
-  peerDependencies:
-    react: ^16.8.0 || ^17.0.0-rc.1 || ^18.0.0
-  checksum: 35fd12b5a8458927d3e3c5ca8ddf9c4ef954d06f87784d828e69d7a1cbc08b7e15aee68c5716da31c495bf01fae1607917771e30a89b464b4382b7e3f5bc1c36
-  languageName: node
-  linkType: hard
-
-"@react-aria/spinbutton@npm:^3.5.4":
-  version: 3.5.4
-  resolution: "@react-aria/spinbutton@npm:3.5.4"
-  dependencies:
-    "@react-aria/i18n": ^3.8.4
-    "@react-aria/live-announcer": ^3.3.1
-    "@react-aria/utils": ^3.21.1
-    "@react-types/button": ^3.9.0
-    "@react-types/shared": ^3.21.0
-    "@swc/helpers": ^0.5.0
-  peerDependencies:
-    react: ^16.8.0 || ^17.0.0-rc.1 || ^18.0.0
-    react-dom: ^16.8.0 || ^17.0.0-rc.1 || ^18.0.0
-  checksum: 1f094b6ad70f5788a2d10775935b990f319dd30a0a59c2a32c891bdd3837a124daf07b126996625bafc67026c7b8c26046c5bc857b03ea55c58e6a4e62842293
-  languageName: node
-  linkType: hard
-
-"@react-aria/ssr@npm:^3.5.0, @react-aria/ssr@npm:^3.8.0":
-  version: 3.8.0
-  resolution: "@react-aria/ssr@npm:3.8.0"
-  dependencies:
-    "@swc/helpers": ^0.5.0
-  peerDependencies:
-    react: ^16.8.0 || ^17.0.0-rc.1 || ^18.0.0
-  checksum: bdcd16da76d9af75dab0c44907963d9367562bc3261c6871a8ee15754e92f929dcd886e5553e08d6193ddb174d78382c10fb7b9b8c7b0cf470bc18c2ed34b106
-  languageName: node
-  linkType: hard
-
-"@react-aria/switch@npm:^3.4.0":
-  version: 3.5.6
-  resolution: "@react-aria/switch@npm:3.5.6"
-  dependencies:
-    "@react-aria/toggle": ^3.8.2
-    "@react-stately/toggle": ^3.6.3
-    "@react-types/switch": ^3.4.2
-    "@swc/helpers": ^0.5.0
-  peerDependencies:
-    react: ^16.8.0 || ^17.0.0-rc.1 || ^18.0.0
-  checksum: e9f65c8627f039d4ba7d8337dcd0c16c130cf7365f4c71271384146dd46b7f2ef990c4b00b8db7f3308d19015c36e2f122527a08ab1ad38d969087902e2966f7
-  languageName: node
-  linkType: hard
-
-"@react-aria/table@npm:^3.8.1":
-  version: 3.13.1
-  resolution: "@react-aria/table@npm:3.13.1"
-  dependencies:
-    "@react-aria/focus": ^3.14.3
-    "@react-aria/grid": ^3.8.4
-    "@react-aria/i18n": ^3.8.4
-    "@react-aria/interactions": ^3.19.1
-    "@react-aria/live-announcer": ^3.3.1
-    "@react-aria/selection": ^3.17.1
-    "@react-aria/utils": ^3.21.1
-    "@react-aria/visually-hidden": ^3.8.6
-    "@react-stately/collections": ^3.10.2
-    "@react-stately/flags": ^3.0.0
-    "@react-stately/table": ^3.11.2
-    "@react-stately/virtualizer": ^3.6.4
-    "@react-types/checkbox": ^3.5.2
-    "@react-types/grid": ^3.2.2
-    "@react-types/shared": ^3.21.0
-    "@react-types/table": ^3.9.0
-    "@swc/helpers": ^0.5.0
-  peerDependencies:
-    react: ^16.8.0 || ^17.0.0-rc.1 || ^18.0.0
-    react-dom: ^16.8.0 || ^17.0.0-rc.1 || ^18.0.0
-  checksum: 19481518308509b3db141f219f66ad6e95a4713feec00a1ab9014cb6e007bb21f8e7286b95c3cf4a450dfceb75a4401cd4499c0e7cf3fd1a0b6306794cfdca3f
-  languageName: node
-  linkType: hard
-
-"@react-aria/tabs@npm:^3.4.1":
-  version: 3.8.1
-  resolution: "@react-aria/tabs@npm:3.8.1"
-  dependencies:
-    "@react-aria/focus": ^3.14.3
-    "@react-aria/i18n": ^3.8.4
-    "@react-aria/interactions": ^3.19.1
-    "@react-aria/selection": ^3.17.1
-    "@react-aria/utils": ^3.21.1
-    "@react-stately/list": ^3.10.0
-    "@react-stately/tabs": ^3.6.1
-    "@react-types/shared": ^3.21.0
-    "@react-types/tabs": ^3.3.3
-    "@swc/helpers": ^0.5.0
-  peerDependencies:
-    react: ^16.8.0 || ^17.0.0-rc.1 || ^18.0.0
-    react-dom: ^16.8.0 || ^17.0.0-rc.1 || ^18.0.0
-  checksum: 8d22f534d5ec5d555c38c0e4c4fb62d5e446f08aa3dc7ba84115aab8dd678259eaa930342e66928c6d75669a7e04676d6b8c118cfc1e7edffd857afb81adb7e3
-  languageName: node
-  linkType: hard
-
-"@react-aria/textfield@npm:^3.12.2, @react-aria/textfield@npm:^3.9.0":
-  version: 3.12.2
-  resolution: "@react-aria/textfield@npm:3.12.2"
-  dependencies:
-    "@react-aria/focus": ^3.14.3
-    "@react-aria/label": ^3.7.2
-    "@react-aria/utils": ^3.21.1
-    "@react-types/shared": ^3.21.0
-    "@react-types/textfield": ^3.8.1
-    "@swc/helpers": ^0.5.0
-  peerDependencies:
-    react: ^16.8.0 || ^17.0.0-rc.1 || ^18.0.0
-  checksum: 28d4413eb3d8c1552e913517da1ed5e545b714d7905eb634016408101a4b9f45f10a8ac9a57c79ad9633d83ef82bb92caf771ec28ed737b6ad3035f3a72a7abb
-  languageName: node
-  linkType: hard
-
-"@react-aria/toggle@npm:^3.8.2":
-  version: 3.8.2
-  resolution: "@react-aria/toggle@npm:3.8.2"
-  dependencies:
-    "@react-aria/focus": ^3.14.3
-    "@react-aria/interactions": ^3.19.1
-    "@react-aria/utils": ^3.21.1
-    "@react-stately/toggle": ^3.6.3
-    "@react-types/checkbox": ^3.5.2
-    "@react-types/shared": ^3.21.0
-    "@react-types/switch": ^3.4.2
-    "@swc/helpers": ^0.5.0
-  peerDependencies:
-    react: ^16.8.0 || ^17.0.0-rc.1 || ^18.0.0
-  checksum: 90cd83cfab8dba0b7466882e5cd15a1599233fc08a250faca140a558e0bcb1e3a4a95af91b2646fde5dbfa510331b5ce23aa44761cc7efa11eb7b92e371147b3
-  languageName: node
-  linkType: hard
-
-"@react-aria/tooltip@npm:^3.4.0":
-  version: 3.6.4
-  resolution: "@react-aria/tooltip@npm:3.6.4"
-  dependencies:
-    "@react-aria/focus": ^3.14.3
-    "@react-aria/interactions": ^3.19.1
-    "@react-aria/utils": ^3.21.1
-    "@react-stately/tooltip": ^3.4.5
-    "@react-types/shared": ^3.21.0
-    "@react-types/tooltip": ^3.4.5
-    "@swc/helpers": ^0.5.0
-  peerDependencies:
-    react: ^16.8.0 || ^17.0.0-rc.1 || ^18.0.0
-  checksum: 5f62f927ab9de0b986ce18b01ddbbf8369564999d514224fe3e8c78e1787902ae70fe6aecc237647cc85df28eb97cee0659c9147c79f849e6e4df56134f14ebb
-  languageName: node
-  linkType: hard
-
-"@react-aria/utils@npm:^3.15.0, @react-aria/utils@npm:^3.21.1":
-  version: 3.21.1
-  resolution: "@react-aria/utils@npm:3.21.1"
-  dependencies:
-    "@react-aria/ssr": ^3.8.0
-    "@react-stately/utils": ^3.8.0
-    "@react-types/shared": ^3.21.0
-    "@swc/helpers": ^0.5.0
-    clsx: ^1.1.1
-  peerDependencies:
-    react: ^16.8.0 || ^17.0.0-rc.1 || ^18.0.0
-  checksum: 8e461ca8cd8d6ec57d4eb194627454255dbb9f855eb827665708072cc284146801838106fda4324eb98822cf4e0157fefc0123524fa9b2bb9fc92c643dfbf725
-  languageName: node
-  linkType: hard
-
-"@react-aria/visually-hidden@npm:^3.7.0, @react-aria/visually-hidden@npm:^3.8.6":
-  version: 3.8.6
-  resolution: "@react-aria/visually-hidden@npm:3.8.6"
-  dependencies:
-    "@react-aria/interactions": ^3.19.1
-    "@react-aria/utils": ^3.21.1
-    "@react-types/shared": ^3.21.0
-    "@swc/helpers": ^0.5.0
-    clsx: ^1.1.1
-  peerDependencies:
-    react: ^16.8.0 || ^17.0.0-rc.1 || ^18.0.0
-  checksum: b80a92432e51892729b7e0ac461a647d935b788767a55f17a400073340067131268ca23a0130d40ee9500b20290c2a8f3572b8826b7e1782116fb37c53874952
-  languageName: node
-  linkType: hard
-
 "@react-native-async-storage/async-storage@npm:1.17.11":
   version: 1.17.11
   resolution: "@react-native-async-storage/async-storage@npm:1.17.11"
@@ -6999,704 +6890,6 @@ __metadata:
   languageName: node
   linkType: hard
 
-"@react-stately/calendar@npm:^3.0.2, @react-stately/calendar@npm:^3.4.1":
-  version: 3.4.1
-  resolution: "@react-stately/calendar@npm:3.4.1"
-  dependencies:
-    "@internationalized/date": ^3.5.0
-    "@react-stately/utils": ^3.8.0
-    "@react-types/calendar": ^3.4.1
-    "@react-types/datepicker": ^3.6.1
-    "@react-types/shared": ^3.21.0
-    "@swc/helpers": ^0.5.0
-  peerDependencies:
-    react: ^16.8.0 || ^17.0.0-rc.1 || ^18.0.0
-  checksum: 49d1fc4bf6cb06b2bda97e39211cf7de7f8983d0245e6a770718cb85a6d13682d0e4ab830fd3e53b09e3ac4925d818a08a26fc8733923fc108be9cb4044a5d45
-  languageName: node
-  linkType: hard
-
-"@react-stately/checkbox@npm:^3.2.1, @react-stately/checkbox@npm:^3.5.1":
-  version: 3.5.1
-  resolution: "@react-stately/checkbox@npm:3.5.1"
-  dependencies:
-    "@react-stately/toggle": ^3.6.3
-    "@react-stately/utils": ^3.8.0
-    "@react-types/checkbox": ^3.5.2
-    "@react-types/shared": ^3.21.0
-    "@swc/helpers": ^0.5.0
-  peerDependencies:
-    react: ^16.8.0 || ^17.0.0-rc.1 || ^18.0.0
-  checksum: bc9be8427c02bce427f559d1a57b77f04f533abfb3e52c4eae8ac9e4aabbf91ff923b811865d8e722c082a5aec68794d65fe5de09ff94813defd34a7f002bfdf
-  languageName: node
-  linkType: hard
-
-"@react-stately/collections@npm:^3.10.2, @react-stately/collections@npm:^3.4.3":
-  version: 3.10.2
-  resolution: "@react-stately/collections@npm:3.10.2"
-  dependencies:
-    "@react-types/shared": ^3.21.0
-    "@swc/helpers": ^0.5.0
-  peerDependencies:
-    react: ^16.8.0 || ^17.0.0-rc.1 || ^18.0.0
-  checksum: 0093ae3e0527459f6147c292d103675329bbfaed2bcc04a05035320202f7957ce2668e91b86ac427055b9af7ca1badd11569233e79ecb32b4d289116c4e19ef9
-  languageName: node
-  linkType: hard
-
-"@react-stately/combobox@npm:^3.2.1, @react-stately/combobox@npm:^3.7.1":
-  version: 3.7.1
-  resolution: "@react-stately/combobox@npm:3.7.1"
-  dependencies:
-    "@react-stately/collections": ^3.10.2
-    "@react-stately/list": ^3.10.0
-    "@react-stately/menu": ^3.5.6
-    "@react-stately/select": ^3.5.5
-    "@react-stately/utils": ^3.8.0
-    "@react-types/combobox": ^3.8.1
-    "@react-types/shared": ^3.21.0
-    "@swc/helpers": ^0.5.0
-  peerDependencies:
-    react: ^16.8.0 || ^17.0.0-rc.1 || ^18.0.0
-  checksum: 6394ce92972d6d3cfde20abe30757e60cfe4845f3677153c094e7de521b1e7114668ebf59070ab38ef82812ec5344b1d5b527f6c3e8b2ed9954279b43246aa00
-  languageName: node
-  linkType: hard
-
-"@react-stately/data@npm:^3.6.1":
-  version: 3.10.3
-  resolution: "@react-stately/data@npm:3.10.3"
-  dependencies:
-    "@react-types/shared": ^3.21.0
-    "@swc/helpers": ^0.5.0
-  peerDependencies:
-    react: ^16.8.0 || ^17.0.0-rc.1 || ^18.0.0
-  checksum: 7274a21442f0f1cf54fadd5d50b98b948c1b74519d71d928d46b30efdadc0e77962ec2b1eabef6ed8c45058d116f73b1547c2fd632a1a2752545a053ba382cb0
-  languageName: node
-  linkType: hard
-
-"@react-stately/datepicker@npm:^3.0.2, @react-stately/datepicker@npm:^3.8.0":
-  version: 3.8.0
-  resolution: "@react-stately/datepicker@npm:3.8.0"
-  dependencies:
-    "@internationalized/date": ^3.5.0
-    "@internationalized/string": ^3.1.1
-    "@react-stately/overlays": ^3.6.3
-    "@react-stately/utils": ^3.8.0
-    "@react-types/datepicker": ^3.6.1
-    "@react-types/shared": ^3.21.0
-    "@swc/helpers": ^0.5.0
-  peerDependencies:
-    react: ^16.8.0 || ^17.0.0-rc.1 || ^18.0.0
-  checksum: a460260bb606a9da663b519a0921c3a9339502bf72d6bb8bbba0a4bdd406fa9416801a8adfc36a91163645219d0d4edb0d39b024735931b081128e646c07aa46
-  languageName: node
-  linkType: hard
-
-"@react-stately/dnd@npm:^3.2.5":
-  version: 3.2.5
-  resolution: "@react-stately/dnd@npm:3.2.5"
-  dependencies:
-    "@react-stately/selection": ^3.14.0
-    "@react-types/shared": ^3.21.0
-    "@swc/helpers": ^0.5.0
-  peerDependencies:
-    react: ^16.8.0 || ^17.0.0-rc.1 || ^18.0.0
-  checksum: 9966b3ec1bc3b41d52f78003209dbb5b47a30bd8c63e0765739ac3ec8cab89f7d5318b4c85dd96d308464b98ee7d739abdbc92d67c4fb198920f86855dfd65f9
-  languageName: node
-  linkType: hard
-
-"@react-stately/flags@npm:^3.0.0":
-  version: 3.0.0
-  resolution: "@react-stately/flags@npm:3.0.0"
-  dependencies:
-    "@swc/helpers": ^0.4.14
-  checksum: 7bf5c08707d939a62d5739d2933e4057bc3f3587709521584000248dbdfb268423927eec4ee84a005197f6c8da54d8036d4eda094e50b930166f1dc5ac4be2ce
-  languageName: node
-  linkType: hard
-
-"@react-stately/grid@npm:^3.8.2":
-  version: 3.8.2
-  resolution: "@react-stately/grid@npm:3.8.2"
-  dependencies:
-    "@react-stately/collections": ^3.10.2
-    "@react-stately/selection": ^3.14.0
-    "@react-types/grid": ^3.2.2
-    "@react-types/shared": ^3.21.0
-    "@swc/helpers": ^0.5.0
-  peerDependencies:
-    react: ^16.8.0 || ^17.0.0-rc.1 || ^18.0.0
-  checksum: a43553985db22d8f16c29da751f232218dac45565eacb4cee59b266cad5b31a902aa9f20e835e07503f0706575c833871d78304a89e092e98f6d171f6ad969db
-  languageName: node
-  linkType: hard
-
-"@react-stately/layout@npm:^3.13.3":
-  version: 3.13.3
-  resolution: "@react-stately/layout@npm:3.13.3"
-  dependencies:
-    "@react-stately/collections": ^3.10.2
-    "@react-stately/table": ^3.11.2
-    "@react-stately/virtualizer": ^3.6.4
-    "@react-types/grid": ^3.2.2
-    "@react-types/shared": ^3.21.0
-    "@react-types/table": ^3.9.0
-    "@swc/helpers": ^0.5.0
-  peerDependencies:
-    react: ^16.8.0 || ^17.0.0-rc.1 || ^18.0.0
-  checksum: 31f7e79f90c40a5a0cce417ee02eb7cc1125111d018c0139b9a6403f4d1a1084a5f30c217089a8931a4c70f563d123c3f66d28a6ea3c24bcf2abe8f5b45b5222
-  languageName: node
-  linkType: hard
-
-"@react-stately/list@npm:^3.10.0, @react-stately/list@npm:^3.5.3":
-  version: 3.10.0
-  resolution: "@react-stately/list@npm:3.10.0"
-  dependencies:
-    "@react-stately/collections": ^3.10.2
-    "@react-stately/selection": ^3.14.0
-    "@react-stately/utils": ^3.8.0
-    "@react-types/shared": ^3.21.0
-    "@swc/helpers": ^0.5.0
-  peerDependencies:
-    react: ^16.8.0 || ^17.0.0-rc.1 || ^18.0.0
-  checksum: 49f96b06408fdc50cacd1cd0c704a161aefe6b6ae8b4e882a39a9907fdc22c2b7ed3c69db7aa6581b72a73ec29fbd118146e1380abcf128d35cfb6d9047b8a52
-  languageName: node
-  linkType: hard
-
-"@react-stately/menu@npm:^3.4.1, @react-stately/menu@npm:^3.5.6":
-  version: 3.5.6
-  resolution: "@react-stately/menu@npm:3.5.6"
-  dependencies:
-    "@react-stately/overlays": ^3.6.3
-    "@react-stately/utils": ^3.8.0
-    "@react-types/menu": ^3.9.5
-    "@react-types/shared": ^3.21.0
-    "@swc/helpers": ^0.5.0
-  peerDependencies:
-    react: ^16.8.0 || ^17.0.0-rc.1 || ^18.0.0
-  checksum: 471a4273abd55b19edb9d045618d225986ceab3dd46f2d6606a70628c38f0ce3597b2fd390638c067dc7be51621953b1d7176e3a38117df524d268552e3ec38f
-  languageName: node
-  linkType: hard
-
-"@react-stately/numberfield@npm:^3.2.1, @react-stately/numberfield@npm:^3.6.2":
-  version: 3.6.2
-  resolution: "@react-stately/numberfield@npm:3.6.2"
-  dependencies:
-    "@internationalized/number": ^3.3.0
-    "@react-stately/utils": ^3.8.0
-    "@react-types/numberfield": ^3.6.1
-    "@react-types/shared": ^3.21.0
-    "@swc/helpers": ^0.5.0
-  peerDependencies:
-    react: ^16.8.0 || ^17.0.0-rc.1 || ^18.0.0
-  checksum: 01be2853cfdc6811dc59c353f46dad676a040efcc7513794dfec156b8d0925e5b60d608bb02f42240618195394ad3bd9cd342ddacdf6084bcc925b4eff76728d
-  languageName: node
-  linkType: hard
-
-"@react-stately/overlays@npm:^3.4.1, @react-stately/overlays@npm:^3.6.3":
-  version: 3.6.3
-  resolution: "@react-stately/overlays@npm:3.6.3"
-  dependencies:
-    "@react-stately/utils": ^3.8.0
-    "@react-types/overlays": ^3.8.3
-    "@swc/helpers": ^0.5.0
-  peerDependencies:
-    react: ^16.8.0 || ^17.0.0-rc.1 || ^18.0.0
-  checksum: dca8e2dc2ab7150d365349a71b3851a81a33664de0b4048d96c20690ddb0cbfe83e454d8fde85a45d077aca9f993183088664f7aa079dc49641dacc38ec075a6
-  languageName: node
-  linkType: hard
-
-"@react-stately/radio@npm:^3.5.1, @react-stately/radio@npm:^3.9.1":
-  version: 3.9.1
-  resolution: "@react-stately/radio@npm:3.9.1"
-  dependencies:
-    "@react-stately/utils": ^3.8.0
-    "@react-types/radio": ^3.5.2
-    "@react-types/shared": ^3.21.0
-    "@swc/helpers": ^0.5.0
-  peerDependencies:
-    react: ^16.8.0 || ^17.0.0-rc.1 || ^18.0.0
-  checksum: b886820f8025289f92624bedc05688ed14e3c15609a95a666dc7cf062afb4bac3513419755fd171c1dbed7d321fc86c7c5d831d255ac5a7d0cff7c137025b06a
-  languageName: node
-  linkType: hard
-
-"@react-stately/searchfield@npm:^3.3.1, @react-stately/searchfield@npm:^3.4.6":
-  version: 3.4.6
-  resolution: "@react-stately/searchfield@npm:3.4.6"
-  dependencies:
-    "@react-stately/utils": ^3.8.0
-    "@react-types/searchfield": ^3.5.1
-    "@react-types/shared": ^3.21.0
-    "@swc/helpers": ^0.5.0
-  peerDependencies:
-    react: ^16.8.0 || ^17.0.0-rc.1 || ^18.0.0
-  checksum: d158889fd6844fd8a0a84592ab195d8cbb13e80a5afccf29804e07b297a9e5a7d10be12885f03779ccf30ed41ff339511efdcbec278708d25447fecf5c28ffc7
-  languageName: node
-  linkType: hard
-
-"@react-stately/select@npm:^3.3.1, @react-stately/select@npm:^3.5.5":
-  version: 3.5.5
-  resolution: "@react-stately/select@npm:3.5.5"
-  dependencies:
-    "@react-stately/collections": ^3.10.2
-    "@react-stately/list": ^3.10.0
-    "@react-stately/menu": ^3.5.6
-    "@react-stately/selection": ^3.14.0
-    "@react-stately/utils": ^3.8.0
-    "@react-types/select": ^3.8.4
-    "@react-types/shared": ^3.21.0
-    "@swc/helpers": ^0.5.0
-  peerDependencies:
-    react: ^16.8.0 || ^17.0.0-rc.1 || ^18.0.0
-  checksum: 013e6a0296afd01b6de7356955b86d7d4fc0158ca1fde5cbf40d8951195b6a87bebc53955d834db8edb3d355c9ecdd052085acc54f16983f628647bedc8d6e0c
-  languageName: node
-  linkType: hard
-
-"@react-stately/selection@npm:^3.10.3, @react-stately/selection@npm:^3.14.0":
-  version: 3.14.0
-  resolution: "@react-stately/selection@npm:3.14.0"
-  dependencies:
-    "@react-stately/collections": ^3.10.2
-    "@react-stately/utils": ^3.8.0
-    "@react-types/shared": ^3.21.0
-    "@swc/helpers": ^0.5.0
-  peerDependencies:
-    react: ^16.8.0 || ^17.0.0-rc.1 || ^18.0.0
-  checksum: ac0d91c9f53c359bf0088fc0a8e0ffc2c4e4650d24946d4879ad0945c51e4ce30b7ddcf698f62896d4bbd777dc64d9681897cd1faf4d8862eb17b077bbce0e68
-  languageName: node
-  linkType: hard
-
-"@react-stately/slider@npm:^3.2.1, @react-stately/slider@npm:^3.4.4":
-  version: 3.4.4
-  resolution: "@react-stately/slider@npm:3.4.4"
-  dependencies:
-    "@react-aria/i18n": ^3.8.4
-    "@react-aria/utils": ^3.21.1
-    "@react-stately/utils": ^3.8.0
-    "@react-types/shared": ^3.21.0
-    "@react-types/slider": ^3.6.2
-    "@swc/helpers": ^0.5.0
-  peerDependencies:
-    react: ^16.8.0 || ^17.0.0-rc.1 || ^18.0.0
-  checksum: f93b3e8fc57e035c306368254376ab547fba2ed9b545be439ab8187c62fcada86b8c2bc0d6b8efaf762c103ef25a055eace4db071330908c022ad54c2082f904
-  languageName: node
-  linkType: hard
-
-"@react-stately/table@npm:^3.11.2, @react-stately/table@npm:^3.4.0":
-  version: 3.11.2
-  resolution: "@react-stately/table@npm:3.11.2"
-  dependencies:
-    "@react-stately/collections": ^3.10.2
-    "@react-stately/flags": ^3.0.0
-    "@react-stately/grid": ^3.8.2
-    "@react-stately/selection": ^3.14.0
-    "@react-stately/utils": ^3.8.0
-    "@react-types/grid": ^3.2.2
-    "@react-types/shared": ^3.21.0
-    "@react-types/table": ^3.9.0
-    "@swc/helpers": ^0.5.0
-  peerDependencies:
-    react: ^16.8.0 || ^17.0.0-rc.1 || ^18.0.0
-  checksum: b174e794c1cacf705f4b60d4e111db662feaee4b5417046b8580ddcb0ed0ccfcd6138a41df4b316cc6604aa67151534b7fcec9a5ac0ff3ed0f799372b3237196
-  languageName: node
-  linkType: hard
-
-"@react-stately/tabs@npm:^3.2.1, @react-stately/tabs@npm:^3.6.1":
-  version: 3.6.1
-  resolution: "@react-stately/tabs@npm:3.6.1"
-  dependencies:
-    "@react-stately/list": ^3.10.0
-    "@react-stately/utils": ^3.8.0
-    "@react-types/shared": ^3.21.0
-    "@react-types/tabs": ^3.3.3
-    "@swc/helpers": ^0.5.0
-  peerDependencies:
-    react: ^16.8.0 || ^17.0.0-rc.1 || ^18.0.0
-  checksum: dc9f38fa8347b194a050aa0b9a78b398414d11b16ab07993d5280fc3410e5b0e8675b1bd584de0a59951cb59ec00044530d69914b35e182293e9e68a5b988448
-  languageName: node
-  linkType: hard
-
-"@react-stately/toggle@npm:^3.4.1, @react-stately/toggle@npm:^3.6.3":
-  version: 3.6.3
-  resolution: "@react-stately/toggle@npm:3.6.3"
-  dependencies:
-    "@react-stately/utils": ^3.8.0
-    "@react-types/checkbox": ^3.5.2
-    "@react-types/shared": ^3.21.0
-    "@swc/helpers": ^0.5.0
-  peerDependencies:
-    react: ^16.8.0 || ^17.0.0-rc.1 || ^18.0.0
-  checksum: 5c726c37876629ad958252a3a9bb319837676c288730192fa44bc705815eebc6ebcdc89351ff2b4be5f2148b51e7443156096eee25310a7fed69634ba821f84c
-  languageName: node
-  linkType: hard
-
-"@react-stately/tooltip@npm:^3.2.1, @react-stately/tooltip@npm:^3.4.5":
-  version: 3.4.5
-  resolution: "@react-stately/tooltip@npm:3.4.5"
-  dependencies:
-    "@react-stately/overlays": ^3.6.3
-    "@react-stately/utils": ^3.8.0
-    "@react-types/tooltip": ^3.4.5
-    "@swc/helpers": ^0.5.0
-  peerDependencies:
-    react: ^16.8.0 || ^17.0.0-rc.1 || ^18.0.0
-  checksum: 1ccda286e9e0db9139eced6993c9e913048b8dd0a2c0e434c14044e01d930e86d66f6523eca3839dc15edc7f54c02d9e4210448f8d9cad45a700d4784de347a3
-  languageName: node
-  linkType: hard
-
-"@react-stately/tree@npm:^3.3.3, @react-stately/tree@npm:^3.7.3":
-  version: 3.7.3
-  resolution: "@react-stately/tree@npm:3.7.3"
-  dependencies:
-    "@react-stately/collections": ^3.10.2
-    "@react-stately/selection": ^3.14.0
-    "@react-stately/utils": ^3.8.0
-    "@react-types/shared": ^3.21.0
-    "@swc/helpers": ^0.5.0
-  peerDependencies:
-    react: ^16.8.0 || ^17.0.0-rc.1 || ^18.0.0
-  checksum: 28fe973979b48437dc7cc71356b0345b4f4fbd7a5d7c56aaf4c861938678f5af068a6090f64fac4d02808399ed0a1044dbce54e4cd5cf808f136e331c70d7a91
-  languageName: node
-  linkType: hard
-
-"@react-stately/utils@npm:^3.8.0":
-  version: 3.8.0
-  resolution: "@react-stately/utils@npm:3.8.0"
-  dependencies:
-    "@swc/helpers": ^0.5.0
-  peerDependencies:
-    react: ^16.8.0 || ^17.0.0-rc.1 || ^18.0.0
-  checksum: 908423686bbf9a6d5d364456f60314047466f338de93e3789db38c292c6b9e953b227b554d0d175b7a2a5da544bbd59cb39d2897e575fcb79c85274bab65d223
-  languageName: node
-  linkType: hard
-
-"@react-stately/virtualizer@npm:^3.6.4":
-  version: 3.6.4
-  resolution: "@react-stately/virtualizer@npm:3.6.4"
-  dependencies:
-    "@react-aria/utils": ^3.21.1
-    "@react-types/shared": ^3.21.0
-    "@swc/helpers": ^0.5.0
-  peerDependencies:
-    react: ^16.8.0 || ^17.0.0-rc.1 || ^18.0.0
-  checksum: 1e5dc24062bb826314db7813305d06fe9ea74071b74b3ce2d2f752cd8850bffebc0717b98f41b85fcbc83688877b679ef4ef2279686c51bd949f16a6b2d34f68
-  languageName: node
-  linkType: hard
-
-"@react-types/breadcrumbs@npm:^3.7.1":
-  version: 3.7.1
-  resolution: "@react-types/breadcrumbs@npm:3.7.1"
-  dependencies:
-    "@react-types/link": ^3.5.1
-    "@react-types/shared": ^3.21.0
-  peerDependencies:
-    react: ^16.8.0 || ^17.0.0-rc.1 || ^18.0.0
-  checksum: 00d1b467dd305feeb1bb7df4a7b7fd8b9ba16afb5250a6d81907ca0480169f2d283630573f7854bb9c854efd1250723873214801d63c96962c55c39d55a981d6
-  languageName: node
-  linkType: hard
-
-"@react-types/button@npm:^3.9.0":
-  version: 3.9.0
-  resolution: "@react-types/button@npm:3.9.0"
-  dependencies:
-    "@react-types/shared": ^3.21.0
-  peerDependencies:
-    react: ^16.8.0 || ^17.0.0-rc.1 || ^18.0.0
-  checksum: 93bd08f894c2a5e0b53b680759326b3151773bf3594f3169ecff012cbfc376e6a0472506f8b2bbf43aa41e37e410d8054dfaee728da9db86287d06adb80c9809
-  languageName: node
-  linkType: hard
-
-"@react-types/calendar@npm:^3.4.1":
-  version: 3.4.1
-  resolution: "@react-types/calendar@npm:3.4.1"
-  dependencies:
-    "@internationalized/date": ^3.5.0
-    "@react-types/shared": ^3.21.0
-  peerDependencies:
-    react: ^16.8.0 || ^17.0.0-rc.1 || ^18.0.0
-  checksum: 314a4c52b0b3034ee38bb06c38887f1fba6d437e42fa34d7b622c7e4dcacf078d3ce12feb9afb1f853e5f9ab1240ee93f498ce87d25a4bdad67746c5aeeca536
-  languageName: node
-  linkType: hard
-
-"@react-types/checkbox@npm:^3.5.2":
-  version: 3.5.2
-  resolution: "@react-types/checkbox@npm:3.5.2"
-  dependencies:
-    "@react-types/shared": ^3.21.0
-  peerDependencies:
-    react: ^16.8.0 || ^17.0.0-rc.1 || ^18.0.0
-  checksum: 56e764547ab7943fc5522150769b5b670b804ac308224fc2a76bed339acf9472703efc320859ac36684d6cb4b00f9f6c25385737a42c54e4791095e96aacd57d
-  languageName: node
-  linkType: hard
-
-"@react-types/combobox@npm:^3.8.1":
-  version: 3.8.1
-  resolution: "@react-types/combobox@npm:3.8.1"
-  dependencies:
-    "@react-types/shared": ^3.21.0
-  peerDependencies:
-    react: ^16.8.0 || ^17.0.0-rc.1 || ^18.0.0
-  checksum: 8204380d553f85ffb7a3e22c5848d1f20fc28b2a4f88f668e136f3dfd838812e49d8a6b81c114d9e03997b75a48b1a34445a7c4a8b916d7345c81a17b05a72aa
-  languageName: node
-  linkType: hard
-
-"@react-types/datepicker@npm:^3.6.1":
-  version: 3.6.1
-  resolution: "@react-types/datepicker@npm:3.6.1"
-  dependencies:
-    "@internationalized/date": ^3.5.0
-    "@react-types/calendar": ^3.4.1
-    "@react-types/overlays": ^3.8.3
-    "@react-types/shared": ^3.21.0
-  peerDependencies:
-    react: ^16.8.0 || ^17.0.0-rc.1 || ^18.0.0
-  checksum: b9a39fbe0fe21d6395b5387d50ba3b382d72e55f30fecf82b654938d8602404caa70ad1230fc2143e5d01f96179848b9d8cad5affa4f0e49fef0a4620741a9c0
-  languageName: node
-  linkType: hard
-
-"@react-types/dialog@npm:^3.5.6":
-  version: 3.5.6
-  resolution: "@react-types/dialog@npm:3.5.6"
-  dependencies:
-    "@react-types/overlays": ^3.8.3
-    "@react-types/shared": ^3.21.0
-  peerDependencies:
-    react: ^16.8.0 || ^17.0.0-rc.1 || ^18.0.0
-  checksum: 4e6971bc93cce8fe9c0fb0995e6a924545701fb5a021b1eca904762247c8ab99fd8dc88eac05e6f6ae3b7b4864e9bd29891516fe2199d04e51152028973c5401
-  languageName: node
-  linkType: hard
-
-"@react-types/grid@npm:^3.2.2":
-  version: 3.2.2
-  resolution: "@react-types/grid@npm:3.2.2"
-  dependencies:
-    "@react-types/shared": ^3.21.0
-  peerDependencies:
-    react: ^16.8.0 || ^17.0.0-rc.1 || ^18.0.0
-  checksum: 4f1523ba6ffb8c896f8b2c26e750123be5754f3c20028557bd8b63c3a1b9164b55ef3c1bce4c649ab5aec8a3dd07ea590c0b537a961b8d8a2fcbac76d314a8e0
-  languageName: node
-  linkType: hard
-
-"@react-types/label@npm:^3.8.1":
-  version: 3.8.1
-  resolution: "@react-types/label@npm:3.8.1"
-  dependencies:
-    "@react-types/shared": ^3.21.0
-  peerDependencies:
-    react: ^16.8.0 || ^17.0.0-rc.1 || ^18.0.0
-  checksum: 92b16f25b588e909c54870666790099b83324ecb08da1860aff34a58a6cbbb018a1af6ebba40bba2e078bb3fc6f836ec345ffaf8380d7bcc766711d9aeb1344c
-  languageName: node
-  linkType: hard
-
-"@react-types/link@npm:^3.5.1":
-  version: 3.5.1
-  resolution: "@react-types/link@npm:3.5.1"
-  dependencies:
-    "@react-aria/interactions": ^3.19.1
-    "@react-types/shared": ^3.21.0
-  peerDependencies:
-    react: ^16.8.0 || ^17.0.0-rc.1 || ^18.0.0
-  checksum: e5c442353054761b9e0d5ece5393408c7f63dddd69eb9f3b7b66d06560eb0765783301883a4ae50dc744ce124ca9fa3beb0168fb44f3ee6714309647d38d7f1c
-  languageName: node
-  linkType: hard
-
-"@react-types/listbox@npm:^3.4.5":
-  version: 3.4.5
-  resolution: "@react-types/listbox@npm:3.4.5"
-  dependencies:
-    "@react-types/shared": ^3.21.0
-  peerDependencies:
-    react: ^16.8.0 || ^17.0.0-rc.1 || ^18.0.0
-  checksum: edcab86d4c13a4ff37524b72d7573933958eb71a733cfe83546ee1eb1a92314bfe177b6224d1ae40b5fab1b9a1d71334995903e9e47cabe1f1a548b6bdfc9e99
-  languageName: node
-  linkType: hard
-
-"@react-types/menu@npm:^3.9.5":
-  version: 3.9.5
-  resolution: "@react-types/menu@npm:3.9.5"
-  dependencies:
-    "@react-types/overlays": ^3.8.3
-    "@react-types/shared": ^3.21.0
-  peerDependencies:
-    react: ^16.8.0 || ^17.0.0-rc.1 || ^18.0.0
-  checksum: 505d762846d0ee221a39743fb357a5cc2146b4cdd1205356f3ba1fa2e1364c6a862fb3fafe7218173d1745a78b136e9826962f01ecd0fc11e2a6e5864fbd62fe
-  languageName: node
-  linkType: hard
-
-"@react-types/meter@npm:^3.3.5":
-  version: 3.3.5
-  resolution: "@react-types/meter@npm:3.3.5"
-  dependencies:
-    "@react-types/progress": ^3.5.0
-    "@react-types/shared": ^3.21.0
-  peerDependencies:
-    react: ^16.8.0 || ^17.0.0-rc.1 || ^18.0.0
-  checksum: 1740db44e4cb3e33daedbbd0be379c4d2f475f63d1dee2bf756498647f98f08a591d5d57128a86e1fbf00e7c0af6a1c6a5fa1ede5ee22be4d04dc7d426e9cb88
-  languageName: node
-  linkType: hard
-
-"@react-types/numberfield@npm:^3.6.1":
-  version: 3.6.1
-  resolution: "@react-types/numberfield@npm:3.6.1"
-  dependencies:
-    "@react-types/shared": ^3.21.0
-  peerDependencies:
-    react: ^16.8.0 || ^17.0.0-rc.1 || ^18.0.0
-  checksum: 41aa37282c819a0dc7f55368b0a743b2418b701222f7387415f383e8a6ba7bee60dee40f154589560441db319ba7d5ab0a4c05a9f8315814edba8f8ddf0357f7
-  languageName: node
-  linkType: hard
-
-"@react-types/overlays@npm:^3.8.3":
-  version: 3.8.3
-  resolution: "@react-types/overlays@npm:3.8.3"
-  dependencies:
-    "@react-types/shared": ^3.21.0
-  peerDependencies:
-    react: ^16.8.0 || ^17.0.0-rc.1 || ^18.0.0
-  checksum: e2b0a8170b2f0f6b53da91e3e55748b90951d7c0a03ff7150479e17dce4d32fbe58158786ce4037ac3fce733675e4f42049d5a2baad7e3d72601acd31c1fed46
-  languageName: node
-  linkType: hard
-
-"@react-types/progress@npm:^3.5.0":
-  version: 3.5.0
-  resolution: "@react-types/progress@npm:3.5.0"
-  dependencies:
-    "@react-types/shared": ^3.21.0
-  peerDependencies:
-    react: ^16.8.0 || ^17.0.0-rc.1 || ^18.0.0
-  checksum: a9649e8d22e2738bdc09c85bde5035bcea39e684fa0aa270951ad33e40f6400983943267d676aac503a15bbdda5c4a5e3f155965a425f617c841540bbbca4f52
-  languageName: node
-  linkType: hard
-
-"@react-types/radio@npm:^3.5.2":
-  version: 3.5.2
-  resolution: "@react-types/radio@npm:3.5.2"
-  dependencies:
-    "@react-types/shared": ^3.21.0
-  peerDependencies:
-    react: ^16.8.0 || ^17.0.0-rc.1 || ^18.0.0
-  checksum: 59ab99b35e370ace485e25b300264a2d611d15a6c7d647e85218c8317838430814ecc816a631ec2243274c2ea86a40bf05aacb6e1b43a9c5a6cc992cc9666f5f
-  languageName: node
-  linkType: hard
-
-"@react-types/searchfield@npm:^3.5.1":
-  version: 3.5.1
-  resolution: "@react-types/searchfield@npm:3.5.1"
-  dependencies:
-    "@react-types/shared": ^3.21.0
-    "@react-types/textfield": ^3.8.1
-  peerDependencies:
-    react: ^16.8.0 || ^17.0.0-rc.1 || ^18.0.0
-  checksum: 18b8041751c1dccd2c38c560972b9ded87d363ced197e675759eecb7c1bf3491e9ab04789bd6e61ab1cababb84f768bb29e4a317b169e0a9838f9f675390f6d1
-  languageName: node
-  linkType: hard
-
-"@react-types/select@npm:^3.8.4":
-  version: 3.8.4
-  resolution: "@react-types/select@npm:3.8.4"
-  dependencies:
-    "@react-types/shared": ^3.21.0
-  peerDependencies:
-    react: ^16.8.0 || ^17.0.0-rc.1 || ^18.0.0
-  checksum: 3d4c01fdd360a5162701e2dd8002c397f1598b6c1f4dc3773a9b9a59a4eeda6a345f6b998090a35888b4f8a62d151114065d0d257007b40b7b4065c2de486610
-  languageName: node
-  linkType: hard
-
-"@react-types/shared@npm:^3.14.1, @react-types/shared@npm:^3.21.0":
-  version: 3.21.0
-  resolution: "@react-types/shared@npm:3.21.0"
-  peerDependencies:
-    react: ^16.8.0 || ^17.0.0-rc.1 || ^18.0.0
-  checksum: 1decbd6765c345104225e9245eb865e154fa6b869f6f9ee298f4e0a988333b9d819fb05217eb6ce38c7f3d3f1b81e6aabf14c1ee378acbc2c21a162d1181ac12
-  languageName: node
-  linkType: hard
-
-"@react-types/slider@npm:^3.6.2":
-  version: 3.6.2
-  resolution: "@react-types/slider@npm:3.6.2"
-  dependencies:
-    "@react-types/shared": ^3.21.0
-  peerDependencies:
-    react: ^16.8.0 || ^17.0.0-rc.1 || ^18.0.0
-  checksum: 7230d315ba74ae1eb3a6bf7088d6c12c80cee3f6b4dfd29a66157bc72f38ff29a5920bd62ee48a7a9b2691e97120b67dc4dd9db798d763119f3914705d636eb7
-  languageName: node
-  linkType: hard
-
-"@react-types/switch@npm:^3.4.2":
-  version: 3.4.2
-  resolution: "@react-types/switch@npm:3.4.2"
-  dependencies:
-    "@react-types/checkbox": ^3.5.2
-    "@react-types/shared": ^3.21.0
-  peerDependencies:
-    react: ^16.8.0 || ^17.0.0-rc.1 || ^18.0.0
-  checksum: 319562f7188812be2882acc5a70ecea458a91e7e98a14ac70e6b7a29988171052957ff71caa3a2b8ee679875612a8587580ffd4043e6ed9be4aa0dad13009200
-  languageName: node
-  linkType: hard
-
-"@react-types/table@npm:^3.9.0":
-  version: 3.9.0
-  resolution: "@react-types/table@npm:3.9.0"
-  dependencies:
-    "@react-types/grid": ^3.2.2
-    "@react-types/shared": ^3.21.0
-  peerDependencies:
-    react: ^16.8.0 || ^17.0.0-rc.1 || ^18.0.0
-  checksum: 81babdd772bb81a70987957b71e4eefb6dbbcacdbfb8c72a4b7ac6dfcb362843e6e7e9b5e25b890c0c21fc640ef81a709d110fea6b83eebe5363b580d4dc3cf1
-  languageName: node
-  linkType: hard
-
-"@react-types/tabs@npm:^3.3.3":
-  version: 3.3.3
-  resolution: "@react-types/tabs@npm:3.3.3"
-  dependencies:
-    "@react-types/shared": ^3.21.0
-  peerDependencies:
-    react: ^16.8.0 || ^17.0.0-rc.1 || ^18.0.0
-  checksum: 567cf49a11ce9e49255e24b8da923f1cf0d2631ef2ce943ad892e5ccea28d57922937d7a92f5b664f49c83fe03efc9cb7f3ac26e442dcdf2fd8fd28f6ced9313
-  languageName: node
-  linkType: hard
-
-"@react-types/textfield@npm:^3.8.1":
-  version: 3.8.1
-  resolution: "@react-types/textfield@npm:3.8.1"
-  dependencies:
-    "@react-types/shared": ^3.21.0
-  peerDependencies:
-    react: ^16.8.0 || ^17.0.0-rc.1 || ^18.0.0
-  checksum: 0e0c76f5cbddf59b91e70db8c8d1328ea261ec31a65cfe5806906394f04b0f8a6c17b7ac17e94238f29413304bd5614d26b7eae24e7a48d3f3fe1e86d4e7df38
-  languageName: node
-  linkType: hard
-
-"@react-types/tooltip@npm:^3.4.5":
-  version: 3.4.5
-  resolution: "@react-types/tooltip@npm:3.4.5"
-  dependencies:
-    "@react-types/overlays": ^3.8.3
-    "@react-types/shared": ^3.21.0
-  peerDependencies:
-    react: ^16.8.0 || ^17.0.0-rc.1 || ^18.0.0
-  checksum: b5f5d431665558f29f39154c06799e0eaa99be141bc4d09c8762ebaa5c92543d57eac0d504ed306b8d604364ea431933c8015b99dbc493cd52e6e7fe07cbb852
-  languageName: node
-  linkType: hard
-
-"@rocket.chat/css-in-js@npm:^0.31.25":
-  version: 0.31.25
-  resolution: "@rocket.chat/css-in-js@npm:0.31.25"
-  dependencies:
-    "@emotion/hash": ^0.9.0
-    "@rocket.chat/css-supports": ^0.31.25
-    "@rocket.chat/memo": ^0.31.25
-    "@rocket.chat/stylis-logical-props-middleware": ^0.31.25
-    stylis: ~4.1.3
-  checksum: c9c60816a2517ed8fff7289587301421f0f36c064b7d8b99698470c8676b17f339be799a5703e9575437ccf1e4dafe2c12ca96264ef711d96388e196b8a38123
-  languageName: node
-  linkType: hard
-
-"@rocket.chat/css-supports@npm:^0.31.25":
-  version: 0.31.25
-  resolution: "@rocket.chat/css-supports@npm:0.31.25"
-  dependencies:
-    "@rocket.chat/memo": ^0.31.25
-  checksum: fb7fde175475af41a77c105bacbc10b56d883b75046eb1c15c65d977a2388166d927afa4953296a133037a78eae41c628c376ca4a155a0254930b64a9b3bc12b
-  languageName: node
-  linkType: hard
-
 "@rocket.chat/fuselage-hooks@npm:^0.31.23":
   version: 0.31.25
   resolution: "@rocket.chat/fuselage-hooks@npm:0.31.25"
@@ -7709,76 +6902,10 @@ __metadata:
   languageName: node
   linkType: hard
 
-"@rocket.chat/fuselage-polyfills@npm:^0.31.23":
-  version: 0.31.25
-  resolution: "@rocket.chat/fuselage-polyfills@npm:0.31.25"
-  dependencies:
-    "@juggle/resize-observer": ^3.4.0
-    clipboard-polyfill: ^3.0.3
-    element-closest-polyfill: ^1.0.6
-    focus-visible: ^5.2.0
-    focus-within-polyfill: ^5.2.1
-    new-event-polyfill: ^1.0.1
-  checksum: 191731a2b8bc963287e7072fa8eb7a7b3cc255b6bd8ecabb3c0303e8f3f046213a6a1bcc1d6c2812ce664657fb92c46bf370c6d3ff9981ba58140819189f2b62
-  languageName: node
-  linkType: hard
-
-"@rocket.chat/fuselage-toastbar@npm:^0.31.23":
-  version: 0.31.25
-  resolution: "@rocket.chat/fuselage-toastbar@npm:0.31.25"
-  peerDependencies:
-    "@rocket.chat/fuselage": "*"
-    "@rocket.chat/fuselage-hooks": "*"
-    "@rocket.chat/fuselage-polyfills": "*"
-    "@rocket.chat/styled": "*"
-    react: ^17.0.2
-    react-dom: ^17.0.2
-  checksum: 0dcc6e38c45594efefefe5763ef5bf98296cdf2f9b189f2f0c062d1d9bedf460b10508ccaaa689e2a656876f224eb9c9ac74e48fcd6acacb794c6fab3e8d4c33
-  languageName: node
-  linkType: hard
-
-"@rocket.chat/fuselage-tokens@npm:^0.31.25":
-  version: 0.31.25
-  resolution: "@rocket.chat/fuselage-tokens@npm:0.31.25"
-  checksum: d05460f2f7b7f01b1498aab6fb7d932b7d752d55ce5a6bad6e7a42f2c1f056164ff8caa7dd8ec11bc0f4441a83d8aad0b8aab5e02c03f3452c4583d159b1a2f7
-  languageName: node
-  linkType: hard
-
-"@rocket.chat/fuselage@npm:^0.31.23":
-  version: 0.31.25
-  resolution: "@rocket.chat/fuselage@npm:0.31.25"
-  dependencies:
-    "@rocket.chat/css-in-js": ^0.31.25
-    "@rocket.chat/css-supports": ^0.31.25
-    "@rocket.chat/fuselage-tokens": ^0.31.25
-    "@rocket.chat/memo": ^0.31.25
-    "@rocket.chat/styled": ^0.31.25
-    invariant: ^2.2.4
-    react-aria: ~3.23.1
-    react-keyed-flatten-children: ^1.3.0
-    react-stately: ~3.17.0
-  peerDependencies:
-    "@rocket.chat/fuselage-hooks": "*"
-    "@rocket.chat/fuselage-polyfills": "*"
-    "@rocket.chat/icons": "*"
-    react: ^17.0.2
-    react-dom: ^17.0.2
-    react-virtuoso: 1.2.4
-  checksum: a7b5bceeaaf8696b87d2eb0ce1370e41bfeb843ec2a7c5339299e3f03e7c80f61c1221df9043ab868d295ce7941243b2f25a92add289dc155c5024f502b8a0db
-  languageName: node
-  linkType: hard
-
 "@rocket.chat/icons@npm:^0.31.23":
   version: 0.31.25
   resolution: "@rocket.chat/icons@npm:0.31.25"
   checksum: b341dc808d5faa19d442cf19c749504a889c9721837d9a9765501ce291839505c92f09d0d741aa8b3b738766fbbcc200ebd88faaeb6f0387e5fbed82b01c75fe
-  languageName: node
-  linkType: hard
-
-"@rocket.chat/memo@npm:^0.31.25":
-  version: 0.31.25
-  resolution: "@rocket.chat/memo@npm:0.31.25"
-  checksum: 92d595c68d76a5258fb37ed4639e2709ba290c5d240df1272d81a2ab6b4be28ee2dd5b721dad940fe2638a89e8d14e684a970c59890003a06ce6088c655b7c0e
   languageName: node
   linkType: hard
 
@@ -7801,26 +6928,6 @@ __metadata:
     tiny-events: ^1.0.1
     universal-websocket-client: ^1.0.2
   checksum: e54e0a6c7049c3fb14b9d3a7f32a082d6b282d1b77543fc09c22b252daf1c7663da348532de90c96013c8a571471012fea8193e063faf2dc0148c175bd15b3f8
-  languageName: node
-  linkType: hard
-
-"@rocket.chat/styled@npm:^0.31.25":
-  version: 0.31.25
-  resolution: "@rocket.chat/styled@npm:0.31.25"
-  dependencies:
-    "@rocket.chat/css-in-js": ^0.31.25
-  checksum: 8b0a2b3d6248ab8256736da058061e5f1a2f6a4455a20d0e0b6b75887ac82a0bbfbfe91bd60e278f3462e849ef744f38093a9acc7c3ba5db46f00fd640d7a52e
-  languageName: node
-  linkType: hard
-
-"@rocket.chat/stylis-logical-props-middleware@npm:^0.31.25":
-  version: 0.31.25
-  resolution: "@rocket.chat/stylis-logical-props-middleware@npm:0.31.25"
-  dependencies:
-    "@rocket.chat/css-supports": ^0.31.25
-  peerDependencies:
-    stylis: 4.0.10
-  checksum: b0bc2afa2f020d65dc4af3f0180c6b7538471b2deeef026421a57d89a6279596fe6be14ab96d1634229b27308a0867c11db2684f9a51e5bc07683b6d0dc96c91
   languageName: node
   linkType: hard
 
@@ -10032,16 +9139,6 @@ __metadata:
   version: 0.1.2
   resolution: "@swc/counter@npm:0.1.2"
   checksum: 8427c594f1f0cf44b83885e9c8fe1e370c9db44ae96e07a37c117a6260ee97797d0709483efbcc244e77bac578690215f45b23254c4cd8a70fb25ddbb50bf33e
-  languageName: node
-  linkType: hard
-
-"@swc/helpers@npm:^0.4.14":
-  version: 0.4.36
-  resolution: "@swc/helpers@npm:0.4.36"
-  dependencies:
-    legacy-swc-helpers: "npm:@swc/helpers@=0.4.14"
-    tslib: ^2.4.0
-  checksum: 20b9f021a9711633d709ef1c231423eb079cb7ed14ad191dc9583b0b46684a95d0e87c3efd7472e7673ddbd30eb200c21490ab43ad251df8f845cd09df3d236f
   languageName: node
   linkType: hard
 
@@ -13914,13 +13011,6 @@ __metadata:
   languageName: node
   linkType: hard
 
-"clipboard-polyfill@npm:^3.0.3":
-  version: 3.0.3
-  resolution: "clipboard-polyfill@npm:3.0.3"
-  checksum: 735a1006eac8c7bbde64a23f47eb8ce15e8558591dd1a7bffe11f3f17c68fb6aa1d7c459f51e22348c65539d60e3746b15692fbc9b7930b8e14a22c7ce33948d
-  languageName: node
-  linkType: hard
-
 "cliui@npm:^6.0.0":
   version: 6.0.0
   resolution: "cliui@npm:6.0.0"
@@ -13979,7 +13069,7 @@ __metadata:
   languageName: node
   linkType: hard
 
-"clsx@npm:^1.1.1, clsx@npm:^1.2.1":
+"clsx@npm:^1.2.1":
   version: 1.2.1
   resolution: "clsx@npm:1.2.1"
   checksum: 30befca8019b2eb7dbad38cff6266cf543091dae2825c856a62a8ccf2c3ab9c2907c4d12b288b73101196767f66812365400a227581484a05f968b0307cfaf12
@@ -15789,13 +14879,6 @@ __metadata:
   languageName: node
   linkType: hard
 
-"dompurify@npm:^3.0.3":
-  version: 3.0.6
-  resolution: "dompurify@npm:3.0.6"
-  checksum: e5c6cdc5fe972a9d0859d939f1d86320de275be00bbef7bd5591c80b1e538935f6ce236624459a1b0c84ecd7c6a1e248684aa4637512659fccc0ce7c353828a6
-  languageName: node
-  linkType: hard
-
 "domutils@npm:^1.7.0":
   version: 1.7.0
   resolution: "domutils@npm:1.7.0"
@@ -15942,13 +15025,6 @@ __metadata:
   version: 1.4.559
   resolution: "electron-to-chromium@npm:1.4.559"
   checksum: 020388642361ee08744256d3e56842d28611b0ba5967897cba574e08abb6ad851c03626393f326cbb85e65318ee85afd240a5dbf1e72f3fb04f3050243146228
-  languageName: node
-  linkType: hard
-
-"element-closest-polyfill@npm:^1.0.6":
-  version: 1.0.6
-  resolution: "element-closest-polyfill@npm:1.0.6"
-  checksum: f47d6fec1a2962e35b4dd63fa6cc7d3bad7abb270305345ff98ffa0a997f844589ee9e57c268a3277295dce74dcd70775e059dc1475323b4655b7e3d2f9534c3
   languageName: node
   linkType: hard
 
@@ -17978,20 +17054,6 @@ __metadata:
   languageName: node
   linkType: hard
 
-"focus-visible@npm:^5.2.0":
-  version: 5.2.0
-  resolution: "focus-visible@npm:5.2.0"
-  checksum: 876f646ef453680d3d34e9f9b23961527ffd5ccaed8690f423d4fbfa37ff023d98a490972bc1387850e37ec2e44958c81f6096ef95b67462e5c4b5404cf1dbb9
-  languageName: node
-  linkType: hard
-
-"focus-within-polyfill@npm:^5.2.1":
-  version: 5.2.1
-  resolution: "focus-within-polyfill@npm:5.2.1"
-  checksum: 195057e26de9417ed739ed1a03ce97f906ec9bfe17bc57977c3b85c8e2df74d8c988f2ff031d8e98dc445a59af464b97b7c243eb10308037a7c767923081fbba
-  languageName: node
-  linkType: hard
-
 "follow-redirects@npm:^1.0.0, follow-redirects@npm:^1.15.0":
   version: 1.15.3
   resolution: "follow-redirects@npm:1.15.3"
@@ -19888,18 +18950,6 @@ __metadata:
   version: 0.12.2
   resolution: "intersection-observer@npm:0.12.2"
   checksum: d1fa9ebbb1e0baafe88ad95545bbb93f92bdcb8789912a2bd11b2463ab177ef185052c9c79c26187833d633f404acb077d4b1249353c5f6e2ca5cd64f50e216b
-  languageName: node
-  linkType: hard
-
-"intl-messageformat@npm:^10.1.0":
-  version: 10.5.4
-  resolution: "intl-messageformat@npm:10.5.4"
-  dependencies:
-    "@formatjs/ecma402-abstract": 1.17.2
-    "@formatjs/fast-memoize": 2.2.0
-    "@formatjs/icu-messageformat-parser": 2.7.0
-    tslib: ^2.4.0
-  checksum: 1ac36b37134c435956762b5e9078314bb1d999992253c7ec884d135bf94eea160a3feede9d3c61c3b8a3016ca1553ba3fa3132bf95be4400c59ea95cb85a5ad6
   languageName: node
   linkType: hard
 
@@ -22016,15 +21066,6 @@ __metadata:
   languageName: node
   linkType: hard
 
-"legacy-swc-helpers@npm:@swc/helpers@=0.4.14":
-  version: 0.4.14
-  resolution: "@swc/helpers@npm:0.4.14"
-  dependencies:
-    tslib: ^2.4.0
-  checksum: 273fd3f3fc461a92f3790cc551ea054745c6d6959afbe1232e6d7aa1c722bbc114d308aab96bef5c78fc0303c85c7b472ef00e2253251cc89737f3b1af56e5a5
-  languageName: node
-  linkType: hard
-
 "lerna@npm:^6.6.2":
   version: 6.6.2
   resolution: "lerna@npm:6.6.2"
@@ -22876,15 +21917,6 @@ __metadata:
   peerDependencies:
     react: ">= 0.14.0"
   checksum: 8885c6343b71570b0a7ec16cd85a49b853a830234790ee7430e2517ea5d8d361ff138bd52147f650790f3e7b3a28a15c755fc16f8856dd01ddf09a6161782e06
-  languageName: node
-  linkType: hard
-
-"marked@npm:^4.0.17":
-  version: 4.3.0
-  resolution: "marked@npm:4.3.0"
-  bin:
-    marked: bin/marked.js
-  checksum: 0db6817893952c3ec710eb9ceafb8468bf5ae38cb0f92b7b083baa13d70b19774674be04db5b817681fa7c5c6a088f61300815e4dd75a59696f4716ad69f6260
   languageName: node
   linkType: hard
 
@@ -24074,7 +23106,7 @@ __metadata:
   languageName: node
   linkType: hard
 
-"msgpackr@npm:^1.5.4, msgpackr@npm:^1.9.5":
+"msgpackr@npm:^1.5.4, msgpackr@npm:^1.9.5, msgpackr@npm:^1.9.9":
   version: 1.9.9
   resolution: "msgpackr@npm:1.9.9"
   dependencies:
@@ -24225,13 +23257,6 @@ __metadata:
   version: 2.0.1
   resolution: "nested-error-stacks@npm:2.0.1"
   checksum: 8430d7d80ad69b1add2992ee2992a363db6c1a26a54740963bc99a004c5acb1d2a67049397062eab2caa3a312b4da89a0b85de3bdf82d7d472a6baa166311fe6
-  languageName: node
-  linkType: hard
-
-"new-event-polyfill@npm:^1.0.1":
-  version: 1.0.1
-  resolution: "new-event-polyfill@npm:1.0.1"
-  checksum: 4c58d2b0505132b2b75d47d82e6ce4f11839f9fa13f89c22bc9cbfe6a60e18df6046b86da5bc8699dae3077beb3a9e503e76bc56a797b76379db07b44bb6952c
   languageName: node
   linkType: hard
 
@@ -25616,6 +24641,30 @@ __metadata:
     dot-case: ^3.0.4
     tslib: ^2.0.3
   checksum: b34227fd0f794e078776eb3aa6247442056cb47761e9cd2c4c881c86d84c64205f6a56ef0d70b41ee7d77da02c3f4ed2f88e3896a8fefe08bdfb4deca037c687
+  languageName: node
+  linkType: hard
+
+"parcel@npm:^2.10.3":
+  version: 2.10.3
+  resolution: "parcel@npm:2.10.3"
+  dependencies:
+    "@parcel/config-default": 2.10.3
+    "@parcel/core": 2.10.3
+    "@parcel/diagnostic": 2.10.3
+    "@parcel/events": 2.10.3
+    "@parcel/fs": 2.10.3
+    "@parcel/logger": 2.10.3
+    "@parcel/package-manager": 2.10.3
+    "@parcel/reporter-cli": 2.10.3
+    "@parcel/reporter-dev-server": 2.10.3
+    "@parcel/reporter-tracer": 2.10.3
+    "@parcel/utils": 2.10.3
+    chalk: ^4.1.0
+    commander: ^7.0.0
+    get-port: ^4.2.0
+  bin:
+    parcel: lib/bin.js
+  checksum: 3a277e8e85064227b2d3335520b272023b887df6ef4a8b56a145e00bec7c1fab581081bb0d9bdad026dc4fee64e622ae6386da2d34cc716e7a83ad97ac970100
   languageName: node
   linkType: hard
 
@@ -27605,51 +26654,6 @@ __metadata:
   languageName: node
   linkType: hard
 
-"react-aria@npm:~3.23.1":
-  version: 3.23.1
-  resolution: "react-aria@npm:3.23.1"
-  dependencies:
-    "@react-aria/breadcrumbs": ^3.5.0
-    "@react-aria/button": ^3.7.0
-    "@react-aria/calendar": ^3.1.0
-    "@react-aria/checkbox": ^3.8.0
-    "@react-aria/combobox": ^3.5.1
-    "@react-aria/datepicker": ^3.3.0
-    "@react-aria/dialog": ^3.5.0
-    "@react-aria/dnd": ^3.1.0
-    "@react-aria/focus": ^3.11.0
-    "@react-aria/gridlist": ^3.2.1
-    "@react-aria/i18n": ^3.7.0
-    "@react-aria/interactions": ^3.14.0
-    "@react-aria/label": ^3.5.0
-    "@react-aria/link": ^3.4.0
-    "@react-aria/listbox": ^3.8.1
-    "@react-aria/menu": ^3.8.1
-    "@react-aria/meter": ^3.4.0
-    "@react-aria/numberfield": ^3.4.0
-    "@react-aria/overlays": ^3.13.0
-    "@react-aria/progress": ^3.4.0
-    "@react-aria/radio": ^3.5.0
-    "@react-aria/searchfield": ^3.5.0
-    "@react-aria/select": ^3.9.1
-    "@react-aria/selection": ^3.13.1
-    "@react-aria/separator": ^3.3.0
-    "@react-aria/slider": ^3.3.0
-    "@react-aria/ssr": ^3.5.0
-    "@react-aria/switch": ^3.4.0
-    "@react-aria/table": ^3.8.1
-    "@react-aria/tabs": ^3.4.1
-    "@react-aria/textfield": ^3.9.0
-    "@react-aria/tooltip": ^3.4.0
-    "@react-aria/utils": ^3.15.0
-    "@react-aria/visually-hidden": ^3.7.0
-  peerDependencies:
-    react: ^16.8.0 || ^17.0.0-rc.1 || ^18.0.0
-    react-dom: ^16.8.0 || ^17.0.0-rc.1 || ^18.0.0
-  checksum: e91ee511f8cf5e521404194c30a17ec198a7c78d98d490522a646cedf89fdb6428f73993677096faee9ad08f78ef2abd370ca2bdb250108f04bd4cbf93f0e8cf
-  languageName: node
-  linkType: hard
-
 "react-colorful@npm:^5.1.2":
   version: 5.6.1
   resolution: "react-colorful@npm:5.6.1"
@@ -27807,7 +26811,7 @@ __metadata:
   languageName: node
   linkType: hard
 
-"react-is@npm:^16.13.1, react-is@npm:^16.7.0, react-is@npm:^16.8.6":
+"react-is@npm:^16.13.1, react-is@npm:^16.7.0":
   version: 16.13.1
   resolution: "react-is@npm:16.13.1"
   checksum: f7a19ac3496de32ca9ae12aa030f00f14a3d45374f1ceca0af707c831b2a6098ef0d6bdae51bd437b0a306d7f01d4677fcc8de7c0d331eb47ad0f46130e53c5f
@@ -27818,17 +26822,6 @@ __metadata:
   version: 17.0.2
   resolution: "react-is@npm:17.0.2"
   checksum: 9d6d111d8990dc98bc5402c1266a808b0459b5d54830bbea24c12d908b536df7883f268a7868cfaedde3dd9d4e0d574db456f84d2e6df9c4526f99bb4b5344d8
-  languageName: node
-  linkType: hard
-
-"react-keyed-flatten-children@npm:^1.3.0":
-  version: 1.3.0
-  resolution: "react-keyed-flatten-children@npm:1.3.0"
-  dependencies:
-    react-is: ^16.8.6
-  peerDependencies:
-    react: ">=15.0.0"
-  checksum: 3bb042bb7cd48909491a5f92b8e7b2fb0417d69ad24bf04dbe1ed7a308cc7dfe6e3c9b5550e7b9016ee6bef61829b92e7f3a355ed1b867affd251bd518bcdd90
   languageName: node
   linkType: hard
 
@@ -28151,37 +27144,6 @@ __metadata:
   peerDependencies:
     react: ^16.0.0 || ^17.0.0 || ^18.0.0
   checksum: 6052c7e3e9627485120ebd8257f128aad8f56386fe8d42374b7743eac1be457c33506d153c7886b4e32923c0c352d402ab805ef9ca02dbcd8393b2bdeb6e5af8
-  languageName: node
-  linkType: hard
-
-"react-stately@npm:~3.17.0":
-  version: 3.17.0
-  resolution: "react-stately@npm:3.17.0"
-  dependencies:
-    "@react-stately/calendar": ^3.0.2
-    "@react-stately/checkbox": ^3.2.1
-    "@react-stately/collections": ^3.4.3
-    "@react-stately/combobox": ^3.2.1
-    "@react-stately/data": ^3.6.1
-    "@react-stately/datepicker": ^3.0.2
-    "@react-stately/list": ^3.5.3
-    "@react-stately/menu": ^3.4.1
-    "@react-stately/numberfield": ^3.2.1
-    "@react-stately/overlays": ^3.4.1
-    "@react-stately/radio": ^3.5.1
-    "@react-stately/searchfield": ^3.3.1
-    "@react-stately/select": ^3.3.1
-    "@react-stately/selection": ^3.10.3
-    "@react-stately/slider": ^3.2.1
-    "@react-stately/table": ^3.4.0
-    "@react-stately/tabs": ^3.2.1
-    "@react-stately/toggle": ^3.4.1
-    "@react-stately/tooltip": ^3.2.1
-    "@react-stately/tree": ^3.3.3
-    "@react-types/shared": ^3.14.1
-  peerDependencies:
-    react: ^16.8.0 || ^17.0.0-rc.1 || ^18.0.0
-  checksum: da233f06f0c4a2b821755cde7b484b8cc07743b075224225a7213be1b62cf1db0966216528775d755fe83cb2a5eeda43c59684bbba47fcf2652f465557f8f4d2
   languageName: node
   linkType: hard
 
@@ -30690,20 +29652,6 @@ __metadata:
   version: 4.2.0
   resolution: "stylis@npm:4.2.0"
   checksum: 0eb6cc1b866dc17a6037d0a82ac7fa877eba6a757443e79e7c4f35bacedbf6421fadcab4363b39667b43355cbaaa570a3cde850f776498e5450f32ed2f9b7584
-  languageName: node
-  linkType: hard
-
-"stylis@npm:^4.2.0":
-  version: 4.3.0
-  resolution: "stylis@npm:4.3.0"
-  checksum: 6120de3f03eacf3b5adc8e7919c4cca991089156a6badc5248752a3088106afaaf74996211a6817a7760ebeadca09004048eea31875bd8d4df51386365c50025
-  languageName: node
-  linkType: hard
-
-"stylis@npm:~4.1.3":
-  version: 4.1.4
-  resolution: "stylis@npm:4.1.4"
-  checksum: cd929bd89709def13b47e6c16b11317bf996a09b4e987fc45a235549c3adf49d41531e017d7df511daa095bc9468c923ae9094a934fe9c62440b7351874dafb7
   languageName: node
   linkType: hard
 


### PR DESCRIPTION
This PR removes unused project dependencies 
It also removes the fuselage completely. There are still a few components that need to be built and tested carefully:
1. OverflowElement
2. MultiStaticSelectElement
3. PreviewBlock
4. StaticSelectElement

The bundle size is now reduced to half of the earlier size.
