### PR TITLE
added login with rocketchat oauth

### DIFF
--- a/packages/api/src/EmbeddedChatApi.ts
+++ b/packages/api/src/EmbeddedChatApi.ts
@@ -798,6 +798,7 @@ export default class EmbeddedChatApi {
 
   async getChannelMembers() {
     try {
+      console.log('getCurrentUser', await this.auth.getCurrentUser());
       const { userId, authToken } = await this.auth.getCurrentUser() || {};
       const response = await fetch(
         `${this.host}/api/v1/channels.members?roomId=${this.rid}`,

--- a/packages/auth/src/RocketChatAuth.ts
+++ b/packages/auth/src/RocketChatAuth.ts
@@ -101,14 +101,9 @@ class RocketChatAuth {
 
   /**
    * Login with RocketChat OAuth. The EmbeddedChatApp must be installed and configured in RocketChat.
-   * @param credentials
    * @returns
    */
-  async loginWithRocketChatOAuth(credentials: {
-    [key: string]: string;
-    service: string;
-    access_token: string;
-  }) {
+  async loginWithRocketChatOAuth() {
     if (typeof window === "undefined") {
       throw new Error("loginWithRocketChatOAuth can only be called in browser");
     }

--- a/packages/react/src/components/ChatHeader/ChatHeader.js
+++ b/packages/react/src/components/ChatHeader/ChatHeader.js
@@ -2,7 +2,7 @@ import React, { useCallback, useContext, useEffect, useMemo } from 'react';
 import PropTypes from 'prop-types';
 import { css } from '@emotion/react';
 import stylesSheet from './ChatHeader.module.css';
-import RCContext from '../../context/RCInstance';
+import RCContext, { useRCContext } from '../../context/RCInstance';
 import {
   useUserStore,
   useMessageStore,
@@ -34,7 +34,7 @@ const ChatHeader = ({
     (state) => state.setShowChannelinfo
   );
 
-  const { RCInstance } = useContext(RCContext);
+  const { RCInstance } = useRCContext();
 
   const isUserAuthenticated = useUserStore(
     (state) => state.isUserAuthenticated

--- a/packages/react/src/components/ChatInput/ChatInput.js
+++ b/packages/react/src/components/ChatInput/ChatInput.js
@@ -1,13 +1,7 @@
-import React, {
-  useState,
-  useContext,
-  useRef,
-  useEffect,
-  useCallback,
-} from 'react';
+import React, { useState, useRef, useEffect, useCallback } from 'react';
 import { css } from '@emotion/react';
 import styles from './ChatInput.module.css';
-import RCContext from '../../context/RCInstance';
+import { useRCContext } from '../../context/RCInstance';
 import {
   useToastStore,
   useUserStore,
@@ -32,7 +26,7 @@ import { useToastBarDispatch } from '../../hooks/useToastBarDispatch';
 
 const ChatInput = () => {
   const { styleOverrides, classNames } = useComponentOverrides('ChatInput');
-  const { RCInstance, ECOptions } = useContext(RCContext);
+  const { RCInstance, ECOptions } = useRCContext();
   const [commands, setCommands] = useState([]);
   const isUserAuthenticated = useUserStore(
     (state) => state.isUserAuthenticated
@@ -116,9 +110,21 @@ const ChatInput = () => {
     setIsLoginModalOpen(true);
   };
 
-  const onJoin = () => {
+  const onJoin = async () => {
     if (!isUserAuthenticated) {
-      openLoginModal();
+      if (ECOptions.authFlow === 'OAUTH') {
+        try {
+          await RCInstance.auth.loginWithRocketChatOAuth();
+        } catch (e) {
+          console.error(e);
+          dispatchToastMessage({
+            type: 'error',
+            message: e.message,
+          });
+        }
+      } else {
+        openLoginModal();
+      }
     }
   };
 

--- a/packages/react/src/components/Message/Message.js
+++ b/packages/react/src/components/Message/Message.js
@@ -1,4 +1,4 @@
-import React, { useContext, useMemo } from 'react';
+import React, { memo, useContext, useMemo } from 'react';
 import PropTypes from 'prop-types';
 import Cookies from 'js-cookie';
 import { format } from 'date-fns';
@@ -255,4 +255,4 @@ Message.propTypes = {
   showAvatar: PropTypes.bool,
 };
 
-export default Message;
+export default memo(Message);

--- a/packages/react/src/index.js
+++ b/packages/react/src/index.js
@@ -33,7 +33,7 @@ export const EmbeddedChat = ({
   style = {},
   hideHeader = false,
   auth = {
-    flow: 'MANAGED',
+    flow: 'PASSWORD',
   },
 }) => {
   const { classNames, styleOverrides } = useComponentOverrides('EmbeddedChat');
@@ -56,7 +56,7 @@ export const EmbeddedChat = ({
       getToken,
       deleteToken,
       saveToken,
-      autoLogin: auth.flow === 'MANAGED',
+      autoLogin: ['PASSWORD', 'OAUTH'].includes(auth.flow),
     });
     if (auth.flow === 'TOKEN') {
       newRCInstance.auth.loginWithOAuthServiceToken(auth.credentials);
@@ -70,7 +70,7 @@ export const EmbeddedChat = ({
         getToken,
         deleteToken,
         saveToken,
-        autoLogin: auth.flow === 'MANAGED',
+        autoLogin: ['PASSWORD', 'OAUTH'].includes(auth.flow),
       });
       if (auth.flow === 'TOKEN') {
         newRCInstance.auth.loginWithOAuthServiceToken(auth.credentials);
@@ -226,7 +226,8 @@ EmbeddedChat.propTypes = {
   enableThreads: PropTypes.bool,
   theme: PropTypes.object,
   auth: PropTypes.oneOfType([
-    PropTypes.shape({ flow: PropTypes.oneOf(['MANAGED']) }),
+    PropTypes.shape({ flow: PropTypes.oneOf(['PASSWORD']) }),
+    PropTypes.shape({ flow: PropTypes.oneOf(['OAUTH']) }),
     PropTypes.shape({
       flow: PropTypes.oneOf(['TOKEN']),
       credentials: PropTypes.object,

--- a/packages/react/src/stories/EmbeddedChatAuthToken.stories.js
+++ b/packages/react/src/stories/EmbeddedChatAuthToken.stories.js
@@ -11,7 +11,6 @@ export const Simple = {
   args: {
     host: process.env.STORYBOOK_RC_HOST || 'http://localhost:3000',
     roomId: 'GENERAL',
-    GOOGLE_CLIENT_ID: '',
     isClosable: true,
     setClosableState: true,
     moreOpts: true,

--- a/packages/react/src/stories/EmbeddedChatWithOAuth.stories.js
+++ b/packages/react/src/stories/EmbeddedChatWithOAuth.stories.js
@@ -2,12 +2,12 @@ import { EmbeddedChat } from '..';
 
 // More on how to set up stories at: https://storybook.js.org/docs/react/writing-stories/introduction
 export default {
-  title: 'EmbeddedChat/Managed',
+  title: 'EmbeddedChat/WithOAuth',
   component: EmbeddedChat,
 };
 
 // More on writing stories with args: https://storybook.js.org/docs/react/writing-stories/args
-export const Simple = {
+export const WithOAuth = {
   args: {
     host: process.env.STORYBOOK_RC_HOST || 'http://localhost:3000',
     roomId: 'GENERAL',
@@ -19,10 +19,10 @@ export const Simple = {
     headerColor: 'white',
     toastBarPosition: 'bottom right',
     showRoles: true,
-    showAvatar: true,
+    showAvatar: false,
     enableThreads: true,
     auth: {
-      flow: 'PASSWORD',
+      flow: 'OAUTH',
     },
   },
 };

--- a/packages/react/src/stories/EmbeddedChatWithoutHeader.stories.js
+++ b/packages/react/src/stories/EmbeddedChatWithoutHeader.stories.js
@@ -11,7 +11,6 @@ export const Simple = {
   args: {
     host: process.env.STORYBOOK_RC_HOST || 'http://localhost:3000',
     roomId: 'GENERAL',
-    GOOGLE_CLIENT_ID: '',
     isClosable: true,
     setClosableState: true,
     moreOpts: true,
@@ -23,7 +22,7 @@ export const Simple = {
     showAvatar: false,
     enableThreads: true,
     auth: {
-      flow: 'MANAGED',
+      flow: 'PASSWORD',
     },
     hideHeader: true,
   },


### PR DESCRIPTION
# RocketChat OAuth Login Integration

## Overview
This PR introduces the integration of RocketChat OAuth for user authentication, leveraging the third-party login feature. It provides a streamlined OAuth login flow, enhancing the user authentication process.

## Implementation Steps
To enable RocketChat OAuth login, the following steps are necessary:
1. **Create a Third-Party Login (OAuth App)**: Set up an OAuth application to initiate the authentication process.
2. **Set Up Custom OAuth**: Configure custom OAuth in RocketChat to facilitate login using the created OAuth app.
3. **Install and Configure EmbeddedChatApp**: The EmbeddedChatApp must be installed and properly configured on the RocketChat server.
4. **Pass Authentication Props**: To activate this login method, pass the `auth={flow: 'OAUTH'}` props within the application.

## Testing and Validation
- Manual testing was performed to validate the integration with various OAuth providers.

## Notes
- Ensure that the RocketChat server is configured correctly to support OAuth.

Fixes #103 #211 

## Video/Screenshots

https://github.com/RocketChat/EmbeddedChat/assets/15830206/353c4e91-4d8e-460e-ab63-9efd2d76a3cf

