### PR TITLE
Fixed/authenticated user id read

### DIFF
--- a/.changeset/dull-ligers-deliver.md
+++ b/.changeset/dull-ligers-deliver.md
@@ -1,6 +1,0 @@
----
-"@embeddedchat/htmlembed": patch
-"@embeddedchat/react": patch
----
-
-Fixed: invalid storing of authenticatedUserId

--- a/.changeset/dull-ligers-deliver.md
+++ b/.changeset/dull-ligers-deliver.md
@@ -1,0 +1,6 @@
+---
+"@embeddedchat/htmlembed": patch
+"@embeddedchat/react": patch
+---
+
+Fixed: invalid storing of authenticatedUserId

--- a/packages/htmlembed/CHANGELOG.md
+++ b/packages/htmlembed/CHANGELOG.md
@@ -1,5 +1,13 @@
 # @embeddedchat/htmlembed
 
+## 0.0.5
+
+### Patch Changes
+
+- 14117c0: Fixed: invalid storing of authenticatedUserId
+- Updated dependencies [14117c0]
+  - @embeddedchat/react@0.1.12
+
 ## 0.0.4
 
 ### Patch Changes

--- a/packages/htmlembed/package.json
+++ b/packages/htmlembed/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@embeddedchat/htmlembed",
   "description": "A lightweight and easy-to-use package that allows seamless integration of Embedded Chat into web applications using a simple HTML snippet. Ideal for quickly embedding chat functionalities without complex setup",
-  "version": "0.0.4",
+  "version": "0.0.5",
   "main": "index.js",
   "license": "MIT",
   "type": "module",
@@ -11,7 +11,7 @@
     "preview": "npm run build && vite preview --port=4001"
   },
   "dependencies": {
-    "@embeddedchat/react": "0.1.11",
+    "@embeddedchat/react": "0.1.12",
     "react": "^18.2.0",
     "react-dom": "^18.2.0"
   },

--- a/packages/react/CHANGELOG.md
+++ b/packages/react/CHANGELOG.md
@@ -1,5 +1,11 @@
 # @embeddedchat/react
 
+## 0.1.12
+
+### Patch Changes
+
+- 14117c0: Fixed: invalid storing of authenticatedUserId
+
 ## 0.1.11
 
 ### Patch Changes

--- a/packages/react/package.json
+++ b/packages/react/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@embeddedchat/react",
-  "version": "0.1.11",
+  "version": "0.1.12",
   "description": "React component library for embedding Rocket.Chat in React applications, providing customizable and feature-rich chat interfaces with easy React integration.",
   "main": "dist/cjs/index.js",
   "module": "dist/esm/index.js",

--- a/packages/react/src/components/Message/Message.js
+++ b/packages/react/src/components/Message/Message.js
@@ -1,6 +1,5 @@
 import React, { memo, useContext, useMemo } from 'react';
 import PropTypes from 'prop-types';
-import Cookies from 'js-cookie';
 import { format } from 'date-fns';
 import { css } from '@emotion/react';
 import { Attachments } from '../Attachments';
@@ -9,7 +8,6 @@ import MessageHeader from './MessageHeader';
 import classes from './Message.module.css';
 import { useMessageStore, useUserStore } from '../../store';
 import RCContext from '../../context/RCInstance';
-import { RC_USER_ID_COOKIE } from '../../lib/constant';
 import { Box } from '../Box';
 import { UiKitComponent, kitContext, UiKitMessage } from '../uiKit';
 import useComponentOverrides from '../../theme/useComponentOverrides';
@@ -62,7 +60,7 @@ const Message = ({
     style
   );
   const { RCInstance } = useContext(RCContext);
-  const authenticatedUserId = Cookies.get(RC_USER_ID_COOKIE);
+  const authenticatedUserId = useUserStore((state) => state.userId);
   const authenticatedUserUsername = useUserStore((state) => state.username);
   const [setMessageToReport, toggletoggleShowReportMessage] = useMessageStore(
     (state) => [state.setMessageToReport, state.toggleShowReportMessage]


### PR DESCRIPTION
This pr removes storing authenticatedUserId from js-cookie. We no longer user js-cookie. Hence undefined was getting assigned to authenticatedUserId.
The value from the store is now used to assign authenticatedUserId.
