### PR TITLE
Fix/#358 drag drop upload error handling

### DIFF
--- a/packages/react/src/components/Attachments/AttachmentWindow.js
+++ b/packages/react/src/components/Attachments/AttachmentWindow.js
@@ -12,7 +12,6 @@ function AttachmentWindow() {
   const toggle = useAttachmentWindowStore((state) => state.toggle);
   const data = useAttachmentWindowStore((state) => state.data);
   const setData = useAttachmentWindowStore((state) => state.setData);
-  console.log(data);
 
   const [fileName, setFileName] = useState(data?.name);
   const [fileDescription, setFileDescription] = useState('');

--- a/packages/react/src/components/Attachments/AttachmentWindow.js
+++ b/packages/react/src/components/Attachments/AttachmentWindow.js
@@ -12,8 +12,9 @@ function AttachmentWindow() {
   const toggle = useAttachmentWindowStore((state) => state.toggle);
   const data = useAttachmentWindowStore((state) => state.data);
   const setData = useAttachmentWindowStore((state) => state.setData);
+  console.log(data);
 
-  const [fileName, setFileName] = useState(data.name);
+  const [fileName, setFileName] = useState(data?.name);
   const [fileDescription, setFileDescription] = useState('');
 
   const threadId = useMessageStore((state) => state.threadMainMessage?._id);

--- a/packages/react/src/components/Attachments/AttachmentWindow/validateComponent.js
+++ b/packages/react/src/components/Attachments/AttachmentWindow/validateComponent.js
@@ -1,13 +1,29 @@
-import React, { useState } from 'react';
+import React, { useEffect, useState } from 'react';
 import PropTypes from 'prop-types';
 import PreviewImage from './preview/image';
 import PreviewAudio from './preview/audio';
 import PreviewDefault from './preview/default';
+import { useToastBarDispatch } from '../../../hooks/useToastBarDispatch';
 
 const ValidateComponent = ({ data }) => {
-  const type = data.type.split('/')[0];
+  const type = data ? data.type.split('/')[0] : '';
 
   const [previewURL, setPreviewURL] = useState('');
+  const dispatchToastMessage = useToastBarDispatch();
+
+
+  useEffect(() => {
+    if (!data) {
+      dispatchToastMessage({
+        type: 'error',
+        message: 'Media Type Not Accepted'
+      });
+    }
+  }, [data, dispatchToastMessage]);
+
+  if (!data) {
+    return null;
+  }
 
   const reader = new FileReader();
   reader.onload = (e) => {

--- a/packages/react/src/components/EmbeddedChat.js
+++ b/packages/react/src/components/EmbeddedChat.js
@@ -10,6 +10,7 @@ import { Home } from './Home';
 import { RCInstanceProvider } from '../context/RCInstance';
 import { useToastStore, useUserStore } from '../store';
 import AttachmentWindow from './Attachments/AttachmentWindow';
+import ValidateComponent from './Attachments/AttachmentWindow/validateComponent';
 import useAttachmentWindowStore from '../store/attachmentwindow';
 import DefaultTheme from '../theme/DefaultTheme';
 import { deleteToken, getToken, saveToken } from '../lib/auth';
@@ -17,7 +18,6 @@ import { Box } from './Box';
 import useComponentOverrides from '../theme/useComponentOverrides';
 import { ToastBarProvider } from './ToastBar';
 import { styles } from './EmbeddedChat.styles';
-import ValidateComponent from './Attachments/AttachmentWindow/validateComponent';
 
 const EmbeddedChat = ({
   isClosable = false,

--- a/packages/react/src/components/EmbeddedChat.js
+++ b/packages/react/src/components/EmbeddedChat.js
@@ -17,6 +17,7 @@ import { Box } from './Box';
 import useComponentOverrides from '../theme/useComponentOverrides';
 import { ToastBarProvider } from './ToastBar';
 import { styles } from './EmbeddedChat.styles';
+import ValidateComponent from './Attachments/AttachmentWindow/validateComponent';
 
 const EmbeddedChat = ({
   isClosable = false,
@@ -44,10 +45,11 @@ const EmbeddedChat = ({
   const [fullScreen, setFullScreen] = useState(false);
   const setToastbarPosition = useToastStore((state) => state.setPosition);
   const setShowAvatar = useUserStore((state) => state.setShowAvatar);
+
   useEffect(() => {
     setToastbarPosition(toastBarPosition);
     setShowAvatar(showAvatar);
-  }, []);
+  }, [toastBarPosition, showAvatar]);
 
   if (isClosable && !setClosableState) {
     throw Error(
@@ -135,6 +137,7 @@ const EmbeddedChat = ({
   ]);
 
   const attachmentWindowOpen = useAttachmentWindowStore((state) => state.open);
+  const data = useAttachmentWindowStore((state) => state.data);
 
   const ECOptions = useMemo(
     () => ({
@@ -174,7 +177,13 @@ const EmbeddedChat = ({
     <ThemeProvider theme={theme || DefaultTheme}>
       <ToastBarProvider position={toastBarPosition}>
         <RCInstanceProvider value={RCContextValue}>
-          {attachmentWindowOpen ? <AttachmentWindow /> : null}
+          {attachmentWindowOpen ? (!!data ?
+            <>
+              <AttachmentWindow />
+            </>
+            :
+            <ValidateComponent data={data} />
+          ) : null}
           <Box
             css={[
               styles.embeddedchat,


### PR DESCRIPTION
# Brief Title 
Error handling of corner-case when uploading file through `drag-and-drop` feature is done and the error-toastbar is rendered in case of invalid-file-type.

## Acceptance Criteria fulfillment

- [X] Error handling of edge-case in drag-drop upload feature.
- [X] Error Toast-bar is rendered in case of invalid file type.

Fixes #358 

## Video/Screenshots
[dragdrop.webm](https://github.com/RocketChat/EmbeddedChat/assets/95426993/212fae81-e659-4417-b67a-0c63297a4147)
