### PR TITLE
feat: Display error message for incorrect user credentials

### DIFF
--- a/packages/api/src/EmbeddedChatApi.ts
+++ b/packages/api/src/EmbeddedChatApi.ts
@@ -134,6 +134,7 @@ export default class EmbeddedChatApi {
       return { status: 'success', me: data.me };
     } catch (error) {
       console.error(error);
+      return {error:'Unauthorized'}
     }
   }
 

--- a/packages/react/src/components/auth/LoginForm.js
+++ b/packages/react/src/components/auth/LoginForm.js
@@ -2,12 +2,14 @@ import React, { useState } from 'react';
 import { css } from '@emotion/react';
 import { GenericModal } from '../GenericModal';
 import { loginModalStore } from '../../store';
+import { unAuthStore } from '../../store';
 import { useRCAuth } from '../../hooks/useRCAuth';
 import { Button } from '../Button';
 import { Box } from '../Box';
 import { Input } from '../Input';
 import EyeOpen from './icons/EyeOpen';
 import EyeClose from './icons/EyeClose';
+import UserNotFound from './icons/UserNotFound';
 
 export default function LoginForm() {
   const [userOrEmail, setuserOrEmail] = useState(null);
@@ -17,6 +19,8 @@ export default function LoginForm() {
   const setIsLoginModalOpen = loginModalStore(
     (state) => state.setIsLoginModalOpen
   );
+  const isUnauthorizedAttempt = unAuthStore((state)=>state.isUnauthorizedAttempt);
+  const setIsUnauthorizedAttempt = unAuthStore((state)=>state.setIsUnauthorizedAttempt);
   const { handleLogin } = useRCAuth();
 
   const handleSubmit = () => {
@@ -24,6 +28,7 @@ export default function LoginForm() {
   };
   const handleClose = () => {
     setIsLoginModalOpen(false);
+    setIsUnauthorizedAttempt(false);
   };
 
   const handleEdituserOrEmail = (e) => {
@@ -81,6 +86,17 @@ export default function LoginForm() {
     right: 1em;
   `;
 
+  const callOutRow = css`
+  display: flex;
+  align-self:flex-start;
+  padding:0.5rem;
+  margin-top: 1rem;
+  border: 1px solid #b02e2c;
+  border-radius:0.3rem;
+  width:100%;
+  `
+
+
   return isLoginModalOpen ? (
     <>
       <GenericModal
@@ -127,6 +143,13 @@ export default function LoginForm() {
               alignItems: 'center',
             }}
           >
+            {isUnauthorizedAttempt && (
+              <Box css={callOutRow}>
+                <UserNotFound />
+                <Box style={{ marginLeft: '0.5rem' }}>User not found or incorrect password</Box>
+              </Box>
+            )}
+
             <Button
               color="primary"
               onClick={handleSubmit}

--- a/packages/react/src/components/auth/icons/UserNotFound.js
+++ b/packages/react/src/components/auth/icons/UserNotFound.js
@@ -1,0 +1,14 @@
+const UserNotFound = (props) => (
+    <svg
+        xmlns="http://www.w3.org/2000/svg"
+        height="16"
+        width="16"
+        viewBox="0 0 512 512"
+        className="deny"
+        {...props}
+    >
+        <path fill="#b02e2c" d="M367.2 412.5L99.5 144.8C77.1 176.1 64 214.5 64 256c0 106 86 192 192 192c41.5 0 79.9-13.1 111.2-35.5zm45.3-45.3C434.9 335.9 448 297.5 448 256c0-106-86-192-192-192c-41.5 0-79.9 13.1-111.2 35.5L412.5 367.2zM0 256a256 256 0 1 1 512 0A256 256 0 1 1 0 256z" />
+    </svg>
+);
+
+export default UserNotFound;

--- a/packages/react/src/hooks/useRCAuth.js
+++ b/packages/react/src/hooks/useRCAuth.js
@@ -5,6 +5,7 @@ import {
   useUserStore,
   totpModalStore,
   loginModalStore,
+  unAuthStore
 } from '../store';
 import { useToastBarDispatch } from './useToastBarDispatch';
 
@@ -15,6 +16,7 @@ export const useRCAuth = () => {
   const setIsLoginModalOpen = loginModalStore(
     (state) => state.setIsLoginModalOpen
   );
+  const setIsUnauthorizedAttempt = unAuthStore((state)=>state.setIsUnauthorizedAttempt);
   const setAuthenticatedUserUsername = useUserStore(
     (state) => state.setUsername
   );
@@ -30,13 +32,15 @@ export const useRCAuth = () => {
     try {
       const res = await RCInstance.login(userOrEmail, password, code);
       if (res.error === 'Unauthorized') {
-        dispatchToastMessage({
-          type: 'error',
-          message:
-            'Invalid username or password. Please check your credentials and try again',
-          position: toastPosition,
-        });
+        setIsUnauthorizedAttempt(true);
+        // dispatchToastMessage({
+        //   type: 'error',
+        //   message:
+        //     'Invalid username or password. Please check your credentials and try again',
+        //   position: toastPosition,
+        // });
       } else {
+        setIsUnauthorizedAttempt(false);
         if (res.error === 'totp-required') {
           setPassword(password);
           setEmailorUser(userOrEmail);
@@ -57,6 +61,7 @@ export const useRCAuth = () => {
 
         if (res.status === 'success') {
           setIsLoginModalOpen(false);
+          setIsUnauthorizedAttempt(false);
           setUserAvatarUrl(res.me.avatarUrl);
           setAuthenticatedUserUsername(res.me.username);
           setIsUserAuthenticated(true);

--- a/packages/react/src/store/index.js
+++ b/packages/react/src/store/index.js
@@ -6,3 +6,4 @@ export { default as totpModalStore } from './totpmodalStore';
 export { default as useSearchMessageStore } from './searchMessageStore';
 export { default as loginModalStore } from './loginmodalStore';
 export { default as useChannelStore } from './channelStore';
+export {default as unAuthStore} from './unauthStore';

--- a/packages/react/src/store/unauthStore.js
+++ b/packages/react/src/store/unauthStore.js
@@ -1,0 +1,8 @@
+import { create } from 'zustand';
+
+const unAuthStore = create((set) => ({
+  isUnauthorizedAttempt: false,
+  setIsUnauthorizedAttempt: (isUnauthorizedAttempt) => set(() => ({ isUnauthorizedAttempt })),
+}));
+
+export default unAuthStore;


### PR DESCRIPTION
Feature to show error message when user credentials are incorrect promptly

## Acceptance Criteria fulfillment

- [&#10003;] Issues an 'Unauthorized' error tag when login fails due to incorrect credentials.
- [&#10003;] Removed the toastbar as it was behind the overlay and not user friendly.
- [&#10003;] Added a frontend callout message and icon, resembling the fuselage callout style.
- [&#10003;] Used Zustand for state management.
- [&#10003;] Organized the icon into a separate file.

Fixes #398 

## Video/Screenshots

https://github.com/RocketChat/EmbeddedChat/assets/78961432/bae3e066-3baf-4b7d-8e48-0cfdc17d63dc


