### PR TITLE
Fix/error propagation totp issue display toast

### DIFF
--- a/packages/api/src/EmbeddedChatApi.ts
+++ b/packages/api/src/EmbeddedChatApi.ts
@@ -1,6 +1,6 @@
 import { Rocketchat } from '@rocket.chat/sdk';
 import cloneArray from './cloneArray';
-import { IRocketChatAuthOptions, RocketChatAuth } from '@embeddedchat/auth';
+import { IRocketChatAuthOptions, RocketChatAuth, ApiError } from '@embeddedchat/auth';
 
 // mutliple typing status can come at the same time they should be processed in order.
 let typingHandlerLock = 0;
@@ -133,6 +133,10 @@ export default class EmbeddedChatApi {
       }
       return { status: 'success', me: data.me };
     } catch (error) {
+      if (error instanceof ApiError && error.response?.status === 401) {
+        const authErrorRes = await error.response.json();
+        return { error: authErrorRes?.error };
+      }
       console.error(error);
     }
   }

--- a/packages/auth/src/index.ts
+++ b/packages/auth/src/index.ts
@@ -1,3 +1,4 @@
 export * from './auth';
 export { default as RocketChatAuth } from './RocketChatAuth';
 export * from './IRocketChatAuthOptions';
+export {ApiError} from './Api';

--- a/packages/react/src/components/ToastBar/ToastContainer.js
+++ b/packages/react/src/components/ToastBar/ToastContainer.js
@@ -1,14 +1,32 @@
 import React, { useContext, useMemo, useCallback } from 'react';
-import { css, useTheme } from '@emotion/react';
+import { css, useTheme, keyframes} from '@emotion/react';
 import ToastContext from '../../context/ToastContext';
 import { Box } from '../Box';
 import ToastBar from './ToastBar';
 
 const ToastContainer = () => {
   const theme = useTheme();
+
+  const animation = keyframes`
+    0% {
+      opacity: 0;
+    }
+    20% {
+      opacity: 1;
+    }
+    80% {
+      opacity: 1;
+    }
+    100% {
+      opacity: 0;
+    }
+  `;
   const ToastContainerCss = css`
     position: fixed;
     z-index: ${theme.zIndex.toastbar};
+    border-radius: 0.25em;
+    background-color:white;
+    animation: ${animation} ${2000}ms ease-in-out forwards;
   `;
 
   const { position, toasts, setToasts } = useContext(ToastContext);

--- a/packages/react/src/hooks/useRCAuth.js
+++ b/packages/react/src/hooks/useRCAuth.js
@@ -29,7 +29,7 @@ export const useRCAuth = () => {
   const handleLogin = async (userOrEmail, password, code) => {
     try {
       const res = await RCInstance.login(userOrEmail, password, code);
-      if (res.error === 'Unauthorized') {
+      if (res.error === 'Unauthorized' || res.error === 403) {
         dispatchToastMessage({
           type: 'error',
           message:

--- a/packages/react/src/theme/DefaultTheme.js
+++ b/packages/react/src/theme/DefaultTheme.js
@@ -138,8 +138,8 @@ const DefaultTheme = {
     header: 1100,
     popup: 1200,
     modal: 1300,
-    toastbar: 1400,
     tooltip: 1500,
+    toastbar: 10001,
   },
 };
 


### PR DESCRIPTION
Fixed the authentication flow for situations where 2FA is enabled, addressed the propagation of error messages so that error message will be displayed when password is incorrect, and also resolved the z-index issue related to the displayed error message.

## Acceptance Criteria fulfillment

[x] Resolved the issue with the opening of the TOTP modal when 2FA is enabled, prompting users to enter OTP for authentication.

[x] Addressed the proper propagation of required errors from auth to the API and frontend to ensure successful implementation and incorrect credentials error will be displayed.

[x] Additonally, fixed the z-index problem with the toast message, ensuring it now appears above the overlay (Modal Backdrop) instead of below it.

Fixes #400

## Video/Screenshots

https://github.com/RocketChat/EmbeddedChat/assets/78961432/9816b8f0-f5b4-474c-a8c4-4a2d0171ef79

