### PR TITLE
fix: windows build issue, changed to platform independent external parameter in rollup config file

### DIFF
--- a/packages/api/rollup.config.js
+++ b/packages/api/rollup.config.js
@@ -1,13 +1,16 @@
 import dts from 'rollup-plugin-dts'
 import esbuild from 'rollup-plugin-esbuild'
 import packageJson from './package.json' assert { type: 'json' };
+import path from 'path';
 
 const name = packageJson.main.replace(/\.js$/, '');
 
 const bundle = config => ({
   ...config,
   input: 'src/index.ts',
-  external: id => !/^[./]/.test(id),
+  external: id => {
+    return id[0] !== '.' && !path.isAbsolute(id);
+  },
 })
 
 export default [

--- a/packages/auth/rollup.config.js
+++ b/packages/auth/rollup.config.js
@@ -1,6 +1,6 @@
 import dts from 'rollup-plugin-dts'
 import esbuild from 'rollup-plugin-esbuild'
-
+import path from 'path';
 import packageJson from './package.json' assert { type: 'json' };
 
 const name = packageJson.main.replace(/\.js$/, '');
@@ -8,7 +8,9 @@ const name = packageJson.main.replace(/\.js$/, '');
 const bundle = config => ({
   ...config,
   input: 'src/index.ts',
-  external: id => !/^[./]/.test(id),
+  external: id => {
+    return id[0] !== '.' && !path.isAbsolute(id);
+  },
 })
 
 export default [


### PR DESCRIPTION
Resolved build problem in windows environment by modifying the rollup configuration file to use a platform-independent external parameter.

## Acceptance Criteria fulfillment

- [✓] Identified the problem by debugging through the log file and confirmed it by replicating the issue in a dummy project with the same configuration.
- [✓] Updated the external parameter passed via the bundle function in the rollup configuration file, making it platform-independent. 
- [✓] Referred to the issue link for details for the fix: https://github.com/rollup/rollup/issues/3811
- [✓] Performed comprehensive testing on both Windows and Linux environments to ensure that it functions correctly.

Fixes #405 

## Video/Screenshots

Verification of the build process on Linux:
https://github.com/RocketChat/EmbeddedChat/assets/78961432/717b61d1-2f2b-43f9-91fb-b8faa275dbd8

Building process on Windows for verification:
https://github.com/RocketChat/EmbeddedChat/assets/78961432/1631d5b9-bd74-4022-be83-bd46340561ca


