### PR TITLE
Update rollup.config.js - Error handler for Rollup plugins

### DIFF
--- a/packages/api/rollup.config.js
+++ b/packages/api/rollup.config.js
@@ -1,5 +1,5 @@
-import dts from 'rollup-plugin-dts'
-import esbuild from 'rollup-plugin-esbuild'
+import dts from 'rollup-plugin-dts';
+import esbuild from 'rollup-plugin-esbuild';
 import packageJson from './package.json' assert { type: 'json' };
 import path from 'path';
 
@@ -8,14 +8,38 @@ const name = packageJson.main.replace(/\.js$/, '');
 const bundle = config => ({
   ...config,
   input: 'src/index.ts',
-  external: id => {
-    return id[0] !== '.' && !path.isAbsolute(id);
+  external: id => id[0] !== '.' && !path.isAbsolute(id),
+  onwarn: (warning, warn) => {
+    // Handling warnings here
+    console.warn(warning);
+    if (warning.code === 'PLUGIN_WARNING_CODE') {
+      throw new Error('Error during Rollup build: Plugin warning occurred.');
+    }
+    // Calling the default warning handler
+    warn(warning);
   },
-})
+});
 
 export default [
   bundle({
-    plugins: [esbuild()],
+    plugins: [
+      esbuild(),
+      {
+        name: 'custom-dts-plugin',
+        generateBundle() {
+          // Adding custom logic for the dts plugin
+        },
+        // Handling warnings for this specific plugin
+        handleWarn(warning) {
+          console.warn(`Custom DTS Plugin Warning: ${warning.message}`);
+        },
+        // Handling errors for this specific plugin
+        handleErr(error) {
+          console.error('Custom DTS Plugin Error:', error);
+          process.exit(1);
+        },
+      },
+    ],
     output: [
       {
         file: `${name}.js`,
@@ -30,10 +54,15 @@ export default [
     ],
   }),
   bundle({
-    plugins: [dts()],
+    plugins: [
+      dts(),
+      {
+        // We can add any other custom plugin options or handlers here
+      },
+    ],
     output: {
       file: `${name}.d.ts`,
       format: 'es',
     },
   }),
-]
+];


### PR DESCRIPTION
Error handler for Rollup plugins

In the empty plugins part I have added an error handler for Rollup plugins. If the build fails due to an error in the plugins, it's helpful to have clear error messages. I have attached error handlers to the Rollup plugin instances. I've added an `onwarn` handler to the main `bundle` function. This handler is triggered for warnings during the build process. Additionally, for the custom plugin (`custom-dts-plugin` ), I've added `handleWarn` and `handleErr` handlers to manage warnings and errors specifically for that plugin. 

