### PR TITLE
feat: added feature to show error message and log user out when channel doesn't exist

### DIFF
--- a/packages/react/src/components/ChatHeader/ChatHeader.js
+++ b/packages/react/src/components/ChatHeader/ChatHeader.js
@@ -9,6 +9,7 @@ import {
   useMemberStore,
   useSearchMessageStore,
   useChannelStore,
+  useToastStore
 } from '../../store';
 import { ThreadHeader } from '../ThreadHeader';
 import { Tooltip } from '../Tooltip';
@@ -18,6 +19,7 @@ import { Icon } from '../Icon';
 import { ActionButton } from '../ActionButton';
 import { Menu } from '../Menu';
 import useThreadsMessageStore from '../../store/threadsMessageStore';
+import { useToastBarDispatch } from '../../hooks/useToastBarDispatch';
 
 const ChatHeader = ({
   isClosable,
@@ -45,6 +47,8 @@ const ChatHeader = ({
     (state) => state.setIsUserAuthenticated
   );
 
+  const dispatchToastMessage = useToastBarDispatch();
+
   const avatarUrl = useUserStore((state) => state.avatarUrl);
   const setMessages = useMessageStore((state) => state.setMessages);
   const setFilter = useMessageStore((state) => state.setFilter);
@@ -56,6 +60,7 @@ const ChatHeader = ({
   const showMembers = useMemberStore((state) => state.showMembers);
   const setShowSearch = useSearchMessageStore((state) => state.setShowSearch);
   const setShowAllThreads = useThreadsMessageStore((state => state.setShowAllThreads));
+  const toastPosition = useToastStore((state) => state.position);
 
   const handleLogout = useCallback(async () => {
     try {
@@ -107,7 +112,17 @@ const ChatHeader = ({
       const res = await RCInstance.channelInfo();
       if (res.success) {
         setChannelInfo(res.channel);
+      } else {
+        if ('errorType' in res && res.errorType === 'error-room-not-found') {
+          dispatchToastMessage({
+            type: 'error',
+            message: "Channel doesn't exist. Logging out.",
+            position: toastPosition,
+          });
+          await RCInstance.logout();
+        }
       }
+
     };
     if (isUserAuthenticated) {
       getChannelInfo();


### PR DESCRIPTION
# Brief Title
Added a feature to show an error message and log the user out when the channel doesn't exist. The same has been added whenever the `channelInfo` function is called when any one of these dependencies changes: `[isUserAuthenticated, RCInstance, setChannelInfo]`

## Acceptance Criteria Fulfillment

- [x] Added a toast bar message to show that the channel doesn't exist, and the user is being logged out.
- [x] Calling `RCInstance.logout()` in this case to log out the user.

Fixes #418 

## Video/Screenshots


https://github.com/RocketChat/EmbeddedChat/assets/78961432/914a6740-535d-497d-9039-883b14f5babd

