### PR TITLE
fix: fixed the app's behavior in read-only channels.

### DIFF
--- a/packages/api/src/EmbeddedChatApi.ts
+++ b/packages/api/src/EmbeddedChatApi.ts
@@ -445,18 +445,15 @@ export default class EmbeddedChatApi {
 
   async permissionInfo() {
     try {
-      const { userId, authToken } = await this.auth.getCurrentUser() || {};
-      const response = await fetch(
-        `${this.host}/api/v1/permissions.listAll`,
-        {
-          headers: {
-            'Content-Type': 'application/json',
-            'X-Auth-Token': authToken,
-            'X-User-Id': userId,
-          },
-          method: 'GET',
-        }
-      );
+      const { userId, authToken } = (await this.auth.getCurrentUser()) || {};
+      const response = await fetch(`${this.host}/api/v1/permissions.listAll`, {
+        headers: {
+          "Content-Type": "application/json",
+          "X-Auth-Token": authToken,
+          "X-User-Id": userId,
+        },
+        method: "GET",
+      });
       return await response.json();
     } catch (err) {
       console.error(err);

--- a/packages/api/src/EmbeddedChatApi.ts
+++ b/packages/api/src/EmbeddedChatApi.ts
@@ -443,6 +443,26 @@ export default class EmbeddedChatApi {
     }
   }
 
+  async permissionInfo() {
+    try {
+      const { userId, authToken } = await this.auth.getCurrentUser() || {};
+      const response = await fetch(
+        `${this.host}/api/v1/permissions.listAll`,
+        {
+          headers: {
+            'Content-Type': 'application/json',
+            'X-Auth-Token': authToken,
+            'X-User-Id': userId,
+          },
+          method: 'GET',
+        }
+      );
+      return await response.json();
+    } catch (err) {
+      console.error(err);
+    }
+  }
+
   async close() {
     await this.rcClient.unsubscribeAll();
     await this.rcClient.disconnect();

--- a/packages/react/src/components/ChatInput/ChatInput.js
+++ b/packages/react/src/components/ChatInput/ChatInput.js
@@ -39,6 +39,7 @@ const ChatInput = ({ scrollToBottom }) => {
   const isUserAuthenticated = useUserStore(
     (state) => state.isUserAuthenticated
   );
+  const canSendMsg = useUserStore((state)=>state.canSendMsg);
 
   const setIsUserAuthenticated = useUserStore(
     (state) => state.setIsUserAuthenticated
@@ -459,8 +460,8 @@ const ChatInput = ({ scrollToBottom }) => {
         >
           <textarea
             rows={1}
-            disabled={!isUserAuthenticated || isRecordingMessage}
-            placeholder={isUserAuthenticated ? 'Message' : 'Sign in to chat'}
+            disabled={!isUserAuthenticated || !canSendMsg || isRecordingMessage}
+            placeholder={isUserAuthenticated && canSendMsg? 'Message' : isUserAuthenticated ? 'This room is read only' : 'Sign in to chat'}
             className={styles.textInput}
             onChange={onTextChange}
             onKeyUp={showCommands}

--- a/packages/react/src/components/ChatInput/ChatInput.js
+++ b/packages/react/src/components/ChatInput/ChatInput.js
@@ -39,7 +39,7 @@ const ChatInput = ({ scrollToBottom }) => {
   const isUserAuthenticated = useUserStore(
     (state) => state.isUserAuthenticated
   );
-  const canSendMsg = useUserStore((state)=>state.canSendMsg);
+  const canSendMsg = useUserStore((state) => state.canSendMsg);
 
   const setIsUserAuthenticated = useUserStore(
     (state) => state.setIsUserAuthenticated
@@ -461,7 +461,13 @@ const ChatInput = ({ scrollToBottom }) => {
           <textarea
             rows={1}
             disabled={!isUserAuthenticated || !canSendMsg || isRecordingMessage}
-            placeholder={isUserAuthenticated && canSendMsg? 'Message' : isUserAuthenticated ? 'This room is read only' : 'Sign in to chat'}
+            placeholder={
+              isUserAuthenticated && canSendMsg
+                ? 'Message'
+                : isUserAuthenticated
+                ? 'This room is read only'
+                : 'Sign in to chat'
+            }
             className={styles.textInput}
             onChange={onTextChange}
             onKeyUp={showCommands}

--- a/packages/react/src/store/userStore.js
+++ b/packages/react/src/store/userStore.js
@@ -22,8 +22,7 @@ const useUserStore = create((set) => ({
   canSendMsg: true,
   setIsUserAuthenticated: (isUserAuthenticated) =>
     set(() => ({ isUserAuthenticated })),
-  setCanSendMsg: (canSendMsg) =>
-    set(() => ({ canSendMsg })),
+  setCanSendMsg: (canSendMsg) => set(() => ({ canSendMsg })),
   password: null,
   setPassword: (password) => set(() => ({ password })),
   emailoruser: null,

--- a/packages/react/src/store/userStore.js
+++ b/packages/react/src/store/userStore.js
@@ -19,8 +19,11 @@ const useUserStore = create((set) => ({
       avatarUrl,
     })),
   isUserAuthenticated: false,
+  canSendMsg: true,
   setIsUserAuthenticated: (isUserAuthenticated) =>
     set(() => ({ isUserAuthenticated })),
+  setCanSendMsg: (canSendMsg) =>
+    set(() => ({ canSendMsg })),
   password: null,
   setPassword: (password) => set(() => ({ password })),
   emailoruser: null,


### PR DESCRIPTION
# Brief Title

Fixed the issue where, in read-only channels, users with posting permissions can now send messages as usual. However, those users without permission to post can still read messages but are restricted from sending messages to the group. They will be notified that the group is read-only, ensuring appropriate behavior.

## Acceptance Criteria fulfillment

- [x] Fetched the permissions for posting in read-only from the permission API, as mentioned in the Rocket Chat REST API [docs](https://developer.rocket.chat/reference/api/rest-api/endpoints/user-management/permissions-endpoints/list-permissions), using the endpoint: `/api/v1/permissions.listAll.`
- [x] Retrieved the user's permissions using already defined function `getChannelRoles()` for the channel and determined the permissions of the logged-in user.
- [x] Compared the user's role with those who are permitted for posting in read-only.
- [x] Once verified, set a state in the userStore indicating whether the user is allowed to send messages in a read-only group.
- [x] Utilized that state to render whether the room is read-only and disabled the message box accordingly.
- [x] Logout the user with appropriate message when channel is private and user is not permitted.  

Fixes #420 

## Video/Screenshots

https://github.com/RocketChat/EmbeddedChat/assets/78961432/7582dc84-f976-4442-aad3-c9937945a72c


Note: This PR changes the backend code and requires a rebuild. 
