### PR TITLE
fix: Channel info fetch issue on refresh

### DIFF
--- a/packages/react/src/components/EmbeddedChat.js
+++ b/packages/react/src/components/EmbeddedChat.js
@@ -114,15 +114,16 @@ const EmbeddedChat = ({
         RCInstance.connect()
           .then(() => {
             console.log(`Connected to RocketChat ${RCInstance.host}`);
+            console.log('reinstantiated');
+            const { me } = user;
+            setAuthenticatedUserAvatarUrl(me.avatarUrl);
+            setAuthenticatedUserUsername(me.username);
+            setAuthenticatedUserId(me._id);
+            setAuthenticatedName(me.name);
+            setIsUserAuthenticated(true);
           })
           .catch(console.error);
-        console.log('reinstantiated');
-        const { me } = user;
-        setAuthenticatedUserAvatarUrl(me.avatarUrl);
-        setAuthenticatedUserUsername(me.username);
-        setAuthenticatedUserId(me._id);
-        setAuthenticatedName(me.name);
-        setIsUserAuthenticated(true);
+
       } else {
         setIsUserAuthenticated(false);
       }


### PR DESCRIPTION
# Brief Title
Resolved Channel Information Fetch Issue on Refresh

## Acceptance Criteria Fulfillment

- [x] Debugged the issue and identified that it is related to order of execution and state changes.
- [x] Adjusted the location of state changes and placed them inside the .then(), ensuring that the states are set only once the connection with RCInstance is established and promise is successfully returned.
- [x] With this modification, the execution of getChannelInfo() is will run only upon the successful establishment of the connection, hence addressing the issue.

Fixes #424 
Fixes #340 
## Video/Screenshots


https://github.com/RocketChat/EmbeddedChat/assets/78961432/a57e544e-a00d-441b-9f5b-89a2c95920d9

