### PR TITLE
fix: Addressed issues related to fetching different informations in private channels.

### DIFF
--- a/packages/api/src/EmbeddedChatApi.ts
+++ b/packages/api/src/EmbeddedChatApi.ts
@@ -407,7 +407,7 @@ export default class EmbeddedChatApi {
     try {
       const { userId, authToken } = await this.auth.getCurrentUser() || {};
       const response = await fetch(
-        `${this.host}/api/v1/channels.info?roomId=${this.rid}`,
+        `${this.host}/api/v1/rooms.info?roomId=${this.rid}`,
         {
           headers: {
             'Content-Type': 'application/json',
@@ -435,13 +435,14 @@ export default class EmbeddedChatApi {
    * fields - json object with properties that have either 1 or 0 to include them or exclude them
    * @returns messages
    */
-  async getMessages(anonymousMode = false, options: {
+  async getMessages(anonymousMode = false, isChannelPrivate = false, options: {
     query?: object | undefined;
     field?: object | undefined;
     } = {
       query: undefined,
       field: undefined
     }) {
+    const roomType = isChannelPrivate ? 'groups' : 'channels' ;
     const endp = anonymousMode ? 'anonymousread' : 'messages';
     const query = options?.query
       ? `&query=${JSON.stringify(options.query)}`
@@ -452,7 +453,7 @@ export default class EmbeddedChatApi {
     try {
       const { userId, authToken } = await this.auth.getCurrentUser() || {};
       const messages = await fetch(
-        `${this.host}/api/v1/channels.${endp}?roomId=${this.rid}${query}${field}`,
+        `${this.host}/api/v1/${roomType}.${endp}?roomId=${this.rid}${query}${field}`,
         {
           headers: {
             'Content-Type': 'application/json',
@@ -468,19 +469,20 @@ export default class EmbeddedChatApi {
     }
   }
 
-  async getThreadMessages(tmid: string) {
-    return this.getMessages(false, {
+  async getThreadMessages(tmid: string, isChannelPrivate = false,) {
+    return this.getMessages(false, isChannelPrivate,{
       query: {
         tmid,
       },
     });
   }
 
-  async getChannelRoles() {
+  async getChannelRoles(isChannelPrivate = false) {
+    const roomType = isChannelPrivate ? 'groups' : 'channels';
     try {
       const { userId, authToken } = await this.auth.getCurrentUser() || {};
       const roles = await fetch(
-        `${this.host}/api/v1/channels.roles?roomId=${this.rid}`,
+        `${this.host}/api/v1/${roomType}.roles?roomId=${this.rid}`,
         {
           headers: {
             'Content-Type': 'application/json',
@@ -796,11 +798,12 @@ export default class EmbeddedChatApi {
     }
   }
 
-  async getChannelMembers() {
+  async getChannelMembers(isChannelPrivate = false) {
+    const roomType = isChannelPrivate ? 'groups' : 'channels';
     try {
       const { userId, authToken } = await this.auth.getCurrentUser() || {};
       const response = await fetch(
-        `${this.host}/api/v1/channels.members?roomId=${this.rid}`,
+        `${this.host}/api/v1/${roomType}.members?roomId=${this.rid}`,
         {
           headers: {
             'Content-Type': 'application/json',

--- a/packages/api/src/EmbeddedChatApi.ts
+++ b/packages/api/src/EmbeddedChatApi.ts
@@ -435,13 +435,13 @@ export default class EmbeddedChatApi {
    * fields - json object with properties that have either 1 or 0 to include them or exclude them
    * @returns messages
    */
-  async getMessages(anonymousMode = false, isChannelPrivate = false, options: {
+  async getMessages(anonymousMode = false, options: {
     query?: object | undefined;
     field?: object | undefined;
     } = {
       query: undefined,
       field: undefined
-    }) {
+    }, isChannelPrivate = false) {
     const roomType = isChannelPrivate ? 'groups' : 'channels' ;
     const endp = anonymousMode ? 'anonymousread' : 'messages';
     const query = options?.query
@@ -469,12 +469,12 @@ export default class EmbeddedChatApi {
     }
   }
 
-  async getThreadMessages(tmid: string, isChannelPrivate = false,) {
-    return this.getMessages(false, isChannelPrivate,{
+  async getThreadMessages(tmid: string, isChannelPrivate = false) {
+    return this.getMessages(false, {
       query: {
         tmid,
       },
-    });
+    }, isChannelPrivate);
   }
 
   async getChannelRoles(isChannelPrivate = false) {

--- a/packages/react/src/components/ChatBody/ChatBody.js
+++ b/packages/react/src/components/ChatBody/ChatBody.js
@@ -90,7 +90,6 @@ const ChatBody = ({ height, anonymousMode, showRoles, messageListRef }) => {
         }
         const { messages } = await RCInstance.getMessages(
           anonymousMode,
-          anonymousMode ? false : isChannelPrivate,
           ECOptions?.enableThreads
             ? {
               query: {
@@ -99,7 +98,7 @@ const ChatBody = ({ height, anonymousMode, showRoles, messageListRef }) => {
                 },
               },
             }
-            : undefined
+            : undefined, anonymousMode ? false : isChannelPrivate
         );
         if (messages) {
           setMessages(messages.filter((message) => message._hidden !== true));

--- a/packages/react/src/components/ChatHeader/ChatHeader.js
+++ b/packages/react/src/components/ChatHeader/ChatHeader.js
@@ -37,6 +37,8 @@ const ChatHeader = ({
   const setShowChannelinfo = useChannelStore(
     (state) => state.setShowChannelinfo
   );
+  const isChannelPrivate = useChannelStore((state)=>state.isChannelPrivate);
+  const setIsChannelPrivate = useChannelStore((state)=>state.setIsChannelPrivate);
 
   const { RCInstance } = useRCContext();
 
@@ -91,11 +93,11 @@ const ChatHeader = ({
   }, [RCInstance, setMessages, setFilter]);
 
   const showChannelMembers = useCallback(async () => {
-    const { members = [] } = await RCInstance.getChannelMembers();
+    const { members = [] } = await RCInstance.getChannelMembers(isChannelPrivate);
     setMembersHandler(members);
     toggleShowMembers();
     setShowSearch(false);
-  }, [RCInstance, setMembersHandler, toggleShowMembers, setShowSearch]);
+  }, [RCInstance, setMembersHandler, toggleShowMembers, setShowSearch, isChannelPrivate]);
 
   const showSearchMessage = useCallback(() => {
     setShowSearch(true);
@@ -117,7 +119,8 @@ const ChatHeader = ({
     const getChannelInfo = async () => {
       const res = await RCInstance.channelInfo();
       if (res.success) {
-        setChannelInfo(res.channel);
+        setChannelInfo(res.room);
+        if(res.room.t === 'p') setIsChannelPrivate(true);
       } else {
         if ('errorType' in res && res.errorType === 'error-room-not-found') {
           dispatchToastMessage({
@@ -133,7 +136,7 @@ const ChatHeader = ({
     if (isUserAuthenticated) {
       getChannelInfo();
     }
-  }, [isUserAuthenticated, RCInstance, setChannelInfo]);
+  }, [isUserAuthenticated, RCInstance, setChannelInfo, setIsChannelPrivate]);
 
   const menuOptions = useMemo(() => {
     const options = [];

--- a/packages/react/src/components/ChatHeader/ChatHeader.js
+++ b/packages/react/src/components/ChatHeader/ChatHeader.js
@@ -37,8 +37,8 @@ const ChatHeader = ({
   const setShowChannelinfo = useChannelStore(
     (state) => state.setShowChannelinfo
   );
-  const isChannelPrivate = useChannelStore((state)=>state.isChannelPrivate);
-  const setIsChannelPrivate = useChannelStore((state)=>state.setIsChannelPrivate);
+  const isChannelPrivate = useChannelStore((state) => state.isChannelPrivate);
+  const setIsChannelPrivate = useChannelStore((state) => state.setIsChannelPrivate);
 
   const { RCInstance } = useRCContext();
 
@@ -120,7 +120,7 @@ const ChatHeader = ({
       const res = await RCInstance.channelInfo();
       if (res.success) {
         setChannelInfo(res.room);
-        if(res.room.t === 'p') setIsChannelPrivate(true);
+        if (res.room.t === 'p') setIsChannelPrivate(true);
       } else {
         if ('errorType' in res && res.errorType === 'error-room-not-found') {
           dispatchToastMessage({

--- a/packages/react/src/components/ChatInput/ChatInput.js
+++ b/packages/react/src/components/ChatInput/ChatInput.js
@@ -7,6 +7,7 @@ import {
   useUserStore,
   useMessageStore,
   loginModalStore,
+  useChannelStore
 } from '../../store';
 import ChatInputFormattingToolbar from './ChatInputFormattingToolbar';
 import useAttachmentWindowStore from '../../store/attachmentwindow';
@@ -84,6 +85,8 @@ const ChatInput = ({ scrollToBottom }) => {
   const setIsLoginModalOpen = loginModalStore(
     (state) => state.setIsLoginModalOpen
   );
+  const isChannelPrivate = useChannelStore((state) => state.isChannelPrivate);
+  const setIsChannelPrivate = useChannelStore((state) => state.setIsChannelPrivate);
 
   const {
     editMessage,
@@ -213,12 +216,12 @@ const ChatInput = ({ scrollToBottom }) => {
   };
   const getAllChannelMembers = useCallback(async () => {
     try {
-      const channelMembers = await RCInstance.getChannelMembers();
+      const channelMembers = await RCInstance.getChannelMembers(isChannelPrivate);
       setRoomMembers(channelMembers.members);
     } catch (e) {
       console.error(e);
     }
-  }, [RCInstance, setRoomMembers]);
+  }, [RCInstance, setRoomMembers, isChannelPrivate]);
 
   useEffect(() => {
     if (editMessage.msg) {

--- a/packages/react/src/store/channelStore.js
+++ b/packages/react/src/store/channelStore.js
@@ -2,9 +2,11 @@ import { create } from 'zustand';
 
 const useChannelStore = create((set) => ({
   showChannelinfo: false,
+  isChannelPrivate: false,
   setShowChannelinfo: (showChannelinfo) => set(() => ({ showChannelinfo })),
   channelInfo: {},
   setChannelInfo: (channelInfo) => set(() => ({ channelInfo })),
+  setIsChannelPrivate: (isChannelPrivate) => set(() => ({ isChannelPrivate }))
 }));
 
 export default useChannelStore;


### PR DESCRIPTION
# Brief Title
Resolved issue with fetching messages, member, channel info and roles in private channels.

## Acceptance Criteria fulfillment

- [x] Identified the bug causing inability to fetch messages in private channels. Found that the API `channels.info` was unable to retrieve private channel information. Replaced it with `rooms.info` as per Rocket Chat REST API documentation. Introduced a state variable `isChannelPrivate` which will change based on `t` property of channel information to determine which API to use for fetching messages, members, and roles based on channel privacy.

- [x] Utilized `groups.*` API instead of `channel.*`  as per the documentation when fetching messages, members, and roles to address the limitations of the former in handling private channel information.

- [x] Adjusted frontend calls accordingly to accommodate the updated API. No breaking changes introduced, as `isChannelPrivate` defaults to false.

Fixes #423 

## Video/Screenshots


https://github.com/RocketChat/EmbeddedChat/assets/78961432/abf8409d-f228-4ad2-90c3-1250869dbd64

Note: In the video, zishan.barun@gmail.com is the authorized user and ahmadzishan7277@gmail.com is the unauthorized user. This is to demonstrate the functionality of the app.