### PR TITLE
feat: Added a Threads menu to easily access ongoing threads in a channel.

### DIFF
--- a/packages/react/src/components/AllThreads/AllThreads.js
+++ b/packages/react/src/components/AllThreads/AllThreads.js
@@ -1,0 +1,149 @@
+import React, { useState, useMemo } from 'react';
+import { css } from '@emotion/react';
+import classes from './AllThreads.module.css';
+import { Icon } from '../Icon';
+import { Box } from '../Box';
+import { ActionButton } from '../ActionButton';
+import { useMessageStore, useUserStore, useThreadsMessageStore } from '../../store';
+import { MessageBody } from '../Message/MessageBody';
+import { MessageMetrics } from '../Message/MessageMetrics';
+import MessageAvatarContainer from '../Message/MessageAvatarContainer';
+import MessageBodyContainer from '../Message/MessageBodyContainer';
+import MessageHeader from '../Message/MessageHeader';
+
+
+const MessageCss = css`
+  display: flex;
+  flex-direction: row;
+  align-items: flex-start;
+  padding-top: 0.5rem;
+  -webkit-padding-before: 0.5rem;
+  padding-block-start: 0.5rem;
+  padding-bottom: 0.25rem;
+  -webkit-padding-after: 0.25rem;
+  padding-block-end: 0.25rem;
+  padding-left: 1.25rem;
+  padding-right: 1.25rem;
+  padding-inline: 1.25rem;
+  cursor: pointer;
+  &:hover {
+    background: #f2f3f5;
+  }
+`;
+
+const AllThreads = () => {
+    const showAvatar = useUserStore((state) => state.showAvatar);
+    const messages = useMessageStore((state) => state.messages);
+    const setShowAllThreads = useThreadsMessageStore((state) => state.setShowAllThreads);
+    const openThread = useMessageStore((state) => state.openThread);
+    const [text, setText] = useState('');
+
+    const toggleShowAllThreads = () => {
+        setShowAllThreads(false);
+    };
+
+    const handleOpenThread = (msg) => () => {
+        openThread(msg);
+        toggleShowAllThreads(false);
+    };
+
+    const handleInputChange = (e) => {
+        setText(e.target.value);
+    };
+
+    const filteredThreads = useMemo(() => {
+        return messages.filter((message) =>
+            message.msg.toLowerCase().includes(text.toLowerCase())
+        );
+    }, [messages, text]);
+
+    return (
+        <Box className={classes.component}>
+            <Box className={classes.wrapContainer}>
+
+                <Box style={{ padding: '16px' }}>
+                    <Box css={css`display: flex;`}>
+                        <h3 style={{ display: 'contents' }}>
+                            <Icon
+                                name="thread"
+                                size="1.25rem"
+                                style={{ padding: '0px 20px 20px 0px' }}
+                            />
+                            <Box css={css`
+                                width: 100%;
+                                color: #4a4a4a;
+                            `}
+                            >
+                                Threads
+                            </Box>
+                            <ActionButton onClick={toggleShowAllThreads} ghost size="small">
+                                <Icon name="cross" size="1.25rem" />
+                            </ActionButton>
+                        </h3>
+                    </Box>
+
+                    <Box
+                        className={classes.searchContainer}
+                        style={{ border: '2px solid #ddd', position: 'relative' }}
+                    >
+                        <input
+                            placeholder="Search Messages"
+                            onChange={handleInputChange}
+                            className={classes.textInput}
+                        />
+
+                        <Icon name="magnifier" size="1.25rem" style={{ padding: '0.125em', cursor: 'pointer' }} />
+                    </Box>
+                </Box>
+
+                <Box
+                    style={{
+                        flex: '1',
+                        overflow: 'auto',
+                        display: 'flex',
+                        flexDirection: 'column',
+                        justifyContent: filteredThreads.length === 0 ? 'center' : 'initial',
+                        alignItems: filteredThreads.length === 0 ? 'center' : 'initial'
+                    }}
+                >
+                    {filteredThreads.length === 0 ? (
+                        <Box style={{ display: 'flex', flexDirection: 'column', alignItems: 'center', color: '#4a4a4a' }}>
+                            <Icon name="magnifier" size="3rem" style={{ padding: '0.5rem' }} />
+                            <span style={{ fontSize: '1.2rem', fontWeight: 'bold' }}>No threads found</span>
+                        </Box>
+                    ) : (filteredThreads
+                        .map((message) => (
+                            !message.t && message.tcount && (
+                                <Box key={message._id} css={MessageCss} onClick={handleOpenThread(message)}>
+                                    {showAvatar && (
+                                        <MessageAvatarContainer
+                                            message={message}
+                                            sequential={false}
+                                            isStarred={false}
+                                        />
+                                    )}
+                                    <MessageBodyContainer>
+                                        {<MessageHeader message={message} isTimeStamped={false} />}
+                                        <MessageBody>
+                                            {message.attachments && message.attachments.length > 0 ? (
+                                                message.file.name
+                                            ) : (
+                                                message.msg
+                                            )}
+                                        </MessageBody>
+
+                                        <MessageMetrics
+                                            message={message}
+                                            isReplyButton={false}
+                                        />
+                                    </MessageBodyContainer>
+                                </Box>
+                            )
+                        )))}
+                </Box>
+            </Box>
+        </Box>
+    );
+};
+
+export default AllThreads;

--- a/packages/react/src/components/AllThreads/AllThreads.module.css
+++ b/packages/react/src/components/AllThreads/AllThreads.module.css
@@ -1,0 +1,41 @@
+.component {
+  position: fixed;
+  right: 0;
+  top: 0;
+  width: 350px;
+  height: 100%;
+  overflow: hidden;
+  background-color: white;
+  box-shadow: -1px 0px 5px rgb(0 0 0 / 25%);
+  z-index: 100;
+}
+
+.wrapContainer {
+  height: 100%;
+  display: flex;
+  flex-direction: column;
+}
+
+.searchContainer {
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  background-color: #fff;
+}
+
+.textInput {
+  width: 75%;
+  height: 2.5rem;
+  border: none;
+  outline: none;
+}
+
+.textInput::placeholder {
+  padding-left: 5px;
+}
+
+@media (max-width: 550px) {
+  .component {
+    width: 100vw;
+  }
+}

--- a/packages/react/src/components/ChatHeader/ChatHeader.js
+++ b/packages/react/src/components/ChatHeader/ChatHeader.js
@@ -17,6 +17,7 @@ import useComponentOverrides from '../../theme/useComponentOverrides';
 import { Icon } from '../Icon';
 import { ActionButton } from '../ActionButton';
 import { Menu } from '../Menu';
+import useThreadsMessageStore from '../../store/threadsMessageStore';
 
 const ChatHeader = ({
   isClosable,
@@ -54,6 +55,7 @@ const ChatHeader = ({
   const toggleShowMembers = useMemberStore((state) => state.toggleShowMembers);
   const showMembers = useMemberStore((state) => state.showMembers);
   const setShowSearch = useSearchMessageStore((state) => state.setShowSearch);
+  const setShowAllThreads = useThreadsMessageStore((state => state.setShowAllThreads));
 
   const handleLogout = useCallback(async () => {
     try {
@@ -95,6 +97,11 @@ const ChatHeader = ({
     if (showMembers) toggleShowMembers();
   }, [setShowChannelinfo, setShowSearch, showMembers, toggleShowMembers]);
 
+  const showAllThreads = useCallback(async () => {
+    setShowAllThreads(true);
+    setShowSearch(false);
+  }, [setShowAllThreads, setShowSearch]);
+
   useEffect(() => {
     const getChannelInfo = async () => {
       const res = await RCInstance.channelInfo();
@@ -120,13 +127,12 @@ const ChatHeader = ({
     if (moreOpts) {
       options.push(
         ...[
-          // TODO
-          // {
-          //   id: 'thread',
-          //   action: function noRefCheck() {},
-          //   label: 'Threads',
-          //   icon: 'thread',
-          // },
+          {
+            id: 'thread',
+            action: showAllThreads,
+            label: 'Threads',
+            icon: 'thread',
+          },
           {
             id: 'members',
             action: showChannelMembers,

--- a/packages/react/src/components/Menu/Menu.stories.js
+++ b/packages/react/src/components/Menu/Menu.stories.js
@@ -17,7 +17,6 @@ export const Menu = {
         id: 'thread',
         label: 'Threads',
         icon: 'thread',
-        disabled: true,
       },
       {
         id: 'members',

--- a/packages/react/src/components/Message/MessageHeader.js
+++ b/packages/react/src/components/Message/MessageHeader.js
@@ -57,7 +57,7 @@ const MessageHeaderTimestapCss = css`
   color: #9ea2a8;
 `;
 
-const MessageHeader = ({ message }) => {
+const MessageHeader = ({ message, isTimeStamped = true }) => {
   const { styleOverrides, classNames } = useComponentOverrides('MessageHeader');
   const roles = useUserStore((state) => state.roles);
   const authenticatedUserId = useUserStore((state) => state.userId);
@@ -115,13 +115,14 @@ const MessageHeader = ({ message }) => {
               </Message.Role>
             ))
           : null} */}
-        <Box
+        {isTimeStamped && <Box
           is="span"
           css={MessageHeaderTimestapCss}
           className={appendClassNames('ec-message-header-timestamp')}
         >
           {format(new Date(message.ts), 'h:mm a')}
         </Box>
+        }
         {message.editedAt && (
           <Icon
             style={{ marginInlineEnd: '0.4rem', opacity: 0.5 }}

--- a/packages/react/src/components/Message/MessageMetrics.js
+++ b/packages/react/src/components/Message/MessageMetrics.js
@@ -40,6 +40,7 @@ export const MessageMetrics = ({
   message,
   style = {},
   handleOpenThread = () => { },
+  isReplyButton = true,
   ...props
 }) => {
   const { styleOverrides, classNames } = useComponentOverrides(
@@ -54,9 +55,9 @@ export const MessageMetrics = ({
       style={styleOverrides}
       {...props}
     >
-      <Button size="small" onClick={handleOpenThread(message)}>
+      {isReplyButton && <Button size="small" onClick={handleOpenThread(message)}>
         Reply
-      </Button>
+      </Button>}
       <div css={MessageMetricsItemCss} title="Replies">
         <Icon size="1.25rem" name="thread" />
         <div css={MessageMetricsItemLabelCss}>{message.tcount}</div>

--- a/packages/react/src/components/MessageList/MessageList.js
+++ b/packages/react/src/components/MessageList/MessageList.js
@@ -13,10 +13,12 @@ import MessageReportWindow from '../ReportMessage/MessageReportWindow';
 import isMessageSequential from '../../lib/isMessageSequential';
 import SearchMessage from '../SearchMessage/SearchMessage';
 import Roominfo from '../RoomInformation/RoomInformation';
+import AllThreads from '../AllThreads/AllThreads';
 import { Message } from '../Message';
 import { Button } from '../Button';
 import { Box } from '../Box';
 import { Icon } from '../Icon';
+import useThreadsMessageStore from '../../store/threadsMessageStore';
 
 const MessageList = ({ messages, handleGoBack }) => {
   const showSearch = useSearchMessageStore((state) => state.showSearch);
@@ -27,6 +29,7 @@ const MessageList = ({ messages, handleGoBack }) => {
   const showReportMessage = useMessageStore((state) => state.showReportMessage);
   const messageToReport = useMessageStore((state) => state.messageToReport);
   const showAvatar = useUserStore((state) => state.showAvatar);
+  const showAllThreads = useThreadsMessageStore((state) => state.showAllThreads);
 
   const isMessageNewDay = (current, previous) =>
     !previous || !isSameDay(new Date(current.ts), new Date(previous.ts));
@@ -68,6 +71,7 @@ const MessageList = ({ messages, handleGoBack }) => {
       {showReportMessage && <MessageReportWindow messageId={messageToReport} />}
       {showSearch && <SearchMessage />}
       {showChannelinfo && <Roominfo />}
+      {showAllThreads && <AllThreads />}
     </>
   );
 };

--- a/packages/react/src/store/index.js
+++ b/packages/react/src/store/index.js
@@ -6,3 +6,4 @@ export { default as totpModalStore } from './totpmodalStore';
 export { default as useSearchMessageStore } from './searchMessageStore';
 export { default as loginModalStore } from './loginmodalStore';
 export { default as useChannelStore } from './channelStore';
+export { default as useThreadsMessageStore } from './threadsMessageStore';

--- a/packages/react/src/store/threadsMessageStore.js
+++ b/packages/react/src/store/threadsMessageStore.js
@@ -1,0 +1,8 @@
+import { create } from 'zustand';
+
+const useThreadsMessageStore = create((set) => ({
+  showAllThreads: false,
+  setShowAllThreads: (showAllThreads) => set(() => ({ showAllThreads })),
+}));
+
+export default useThreadsMessageStore;


### PR DESCRIPTION
# Brief Title
Added a new section "Threads menu" where users can navigate through ongoing threads in the channel, search for different messages, and navigate directly to those threads.

## Acceptance Criteria Fulfillment

- [x] Identified the correct modal in which we can display ongoing threads.
- [x] Designed it consistently with the original Rocket.Chat design and reused existing components in the embedded chat.
- [x] Since the message was already retrieved, used the global message state and filtered through the messages that are threads and not just messages or other notifications.
- [x] Each thread in the menu is clickable, allowing users to navigate directly to that thread.
- [x] Threads are searchable, enabling users to easily search through thread messages.
- [x] Created a UI for "No Thread Messages" to inform users when there are no threads that match the search.
- [x] Also checked the `showAvatar` state that can be given as props and will be disabled when set to false.

Fixes #441 

## Video/Screenshots
The following video demonstrates how it works:

https://github.com/RocketChat/EmbeddedChat/assets/78961432/9ef0a24f-46e0-4089-9cb5-457e5ff89f05



The following screenshot shows that the avatar will be displayed only when enabled:
![Screenshot from 2024-02-01 15-42-19](https://github.com/RocketChat/EmbeddedChat/assets/78961432/0b53951d-05ee-4606-b5a3-550571616b42)