### PR TITLE
fix: Back Button Inconsistency in Threads and Starred/Pinned Sections.

### DIFF
--- a/packages/react/src/components/AllThreads/AllThreads.js
+++ b/packages/react/src/components/AllThreads/AllThreads.js
@@ -4,13 +4,16 @@ import classes from './AllThreads.module.css';
 import { Icon } from '../Icon';
 import { Box } from '../Box';
 import { ActionButton } from '../ActionButton';
-import { useMessageStore, useUserStore, useThreadsMessageStore } from '../../store';
+import {
+  useMessageStore,
+  useUserStore,
+  useThreadsMessageStore,
+} from '../../store';
 import { MessageBody } from '../Message/MessageBody';
 import { MessageMetrics } from '../Message/MessageMetrics';
 import MessageAvatarContainer from '../Message/MessageAvatarContainer';
 import MessageBodyContainer from '../Message/MessageBodyContainer';
 import MessageHeader from '../Message/MessageHeader';
-
 
 const MessageCss = css`
   display: flex;
@@ -32,118 +35,146 @@ const MessageCss = css`
 `;
 
 const AllThreads = () => {
-    const showAvatar = useUserStore((state) => state.showAvatar);
-    const messages = useMessageStore((state) => state.messages);
-    const setShowAllThreads = useThreadsMessageStore((state) => state.setShowAllThreads);
-    const openThread = useMessageStore((state) => state.openThread);
-    const [text, setText] = useState('');
+  const showAvatar = useUserStore((state) => state.showAvatar);
+  const messages = useMessageStore((state) => state.messages);
+  const setShowAllThreads = useThreadsMessageStore(
+    (state) => state.setShowAllThreads
+  );
+  const openThread = useMessageStore((state) => state.openThread);
+  const [text, setText] = useState('');
 
-    const toggleShowAllThreads = () => {
-        setShowAllThreads(false);
-    };
+  const toggleShowAllThreads = () => {
+    setShowAllThreads(false);
+  };
 
-    const handleOpenThread = (msg) => () => {
-        openThread(msg);
-        toggleShowAllThreads(false);
-    };
+  const handleOpenThread = (msg) => () => {
+    openThread(msg);
+    toggleShowAllThreads(false);
+  };
 
-    const handleInputChange = (e) => {
-        setText(e.target.value);
-    };
+  const handleInputChange = (e) => {
+    setText(e.target.value);
+  };
 
-    const filteredThreads = useMemo(() => {
-        return messages.filter((message) =>
-            message.msg.toLowerCase().includes(text.toLowerCase())
-        );
-    }, [messages, text]);
+  const filteredThreads = useMemo(
+    () =>
+      messages.filter((message) =>
+        message.msg.toLowerCase().includes(text.toLowerCase())
+      ),
+    [messages, text]
+  );
 
-    return (
-        <Box className={classes.component}>
-            <Box className={classes.wrapContainer}>
+  return (
+    <Box className={classes.component}>
+      <Box className={classes.wrapContainer}>
+        <Box style={{ padding: '16px' }}>
+          <Box
+            css={css`
+              display: flex;
+            `}
+          >
+            <h3 style={{ display: 'contents' }}>
+              <Icon
+                name="thread"
+                size="1.25rem"
+                style={{ padding: '0px 20px 20px 0px' }}
+              />
+              <Box
+                css={css`
+                  width: 100%;
+                  color: #4a4a4a;
+                `}
+              >
+                Threads
+              </Box>
+              <ActionButton onClick={toggleShowAllThreads} ghost size="small">
+                <Icon name="cross" size="1.25rem" />
+              </ActionButton>
+            </h3>
+          </Box>
 
-                <Box style={{ padding: '16px' }}>
-                    <Box css={css`display: flex;`}>
-                        <h3 style={{ display: 'contents' }}>
-                            <Icon
-                                name="thread"
-                                size="1.25rem"
-                                style={{ padding: '0px 20px 20px 0px' }}
-                            />
-                            <Box css={css`
-                                width: 100%;
-                                color: #4a4a4a;
-                            `}
-                            >
-                                Threads
-                            </Box>
-                            <ActionButton onClick={toggleShowAllThreads} ghost size="small">
-                                <Icon name="cross" size="1.25rem" />
-                            </ActionButton>
-                        </h3>
-                    </Box>
+          <Box
+            className={classes.searchContainer}
+            style={{ border: '2px solid #ddd', position: 'relative' }}
+          >
+            <input
+              placeholder="Search Messages"
+              onChange={handleInputChange}
+              className={classes.textInput}
+            />
 
-                    <Box
-                        className={classes.searchContainer}
-                        style={{ border: '2px solid #ddd', position: 'relative' }}
-                    >
-                        <input
-                            placeholder="Search Messages"
-                            onChange={handleInputChange}
-                            className={classes.textInput}
-                        />
-
-                        <Icon name="magnifier" size="1.25rem" style={{ padding: '0.125em', cursor: 'pointer' }} />
-                    </Box>
-                </Box>
-
-                <Box
-                    style={{
-                        flex: '1',
-                        overflow: 'auto',
-                        display: 'flex',
-                        flexDirection: 'column',
-                        justifyContent: filteredThreads.length === 0 ? 'center' : 'initial',
-                        alignItems: filteredThreads.length === 0 ? 'center' : 'initial'
-                    }}
-                >
-                    {filteredThreads.length === 0 ? (
-                        <Box style={{ display: 'flex', flexDirection: 'column', alignItems: 'center', color: '#4a4a4a' }}>
-                            <Icon name="magnifier" size="3rem" style={{ padding: '0.5rem' }} />
-                            <span style={{ fontSize: '1.2rem', fontWeight: 'bold' }}>No threads found</span>
-                        </Box>
-                    ) : (filteredThreads
-                        .map((message) => (
-                            !message.t && message.tcount && (
-                                <Box key={message._id} css={MessageCss} onClick={handleOpenThread(message)}>
-                                    {showAvatar && (
-                                        <MessageAvatarContainer
-                                            message={message}
-                                            sequential={false}
-                                            isStarred={false}
-                                        />
-                                    )}
-                                    <MessageBodyContainer>
-                                        {<MessageHeader message={message} isTimeStamped={false} />}
-                                        <MessageBody>
-                                            {message.attachments && message.attachments.length > 0 ? (
-                                                message.file.name
-                                            ) : (
-                                                message.msg
-                                            )}
-                                        </MessageBody>
-
-                                        <MessageMetrics
-                                            message={message}
-                                            isReplyButton={false}
-                                        />
-                                    </MessageBodyContainer>
-                                </Box>
-                            )
-                        )))}
-                </Box>
-            </Box>
+            <Icon
+              name="magnifier"
+              size="1.25rem"
+              style={{ padding: '0.125em', cursor: 'pointer' }}
+            />
+          </Box>
         </Box>
-    );
+
+        <Box
+          style={{
+            flex: '1',
+            overflow: 'auto',
+            display: 'flex',
+            flexDirection: 'column',
+            justifyContent: filteredThreads.length === 0 ? 'center' : 'initial',
+            alignItems: filteredThreads.length === 0 ? 'center' : 'initial',
+          }}
+        >
+          {filteredThreads.length === 0 ? (
+            <Box
+              style={{
+                display: 'flex',
+                flexDirection: 'column',
+                alignItems: 'center',
+                color: '#4a4a4a',
+              }}
+            >
+              <Icon
+                name="magnifier"
+                size="3rem"
+                style={{ padding: '0.5rem' }}
+              />
+              <span style={{ fontSize: '1.2rem', fontWeight: 'bold' }}>
+                No threads found
+              </span>
+            </Box>
+          ) : (
+            filteredThreads.map(
+              (message) =>
+                !message.t &&
+                message.tcount && (
+                  <Box
+                    key={message._id}
+                    css={MessageCss}
+                    onClick={handleOpenThread(message)}
+                  >
+                    {showAvatar && (
+                      <MessageAvatarContainer
+                        message={message}
+                        sequential={false}
+                        isStarred={false}
+                      />
+                    )}
+                    <MessageBodyContainer>
+                      <MessageHeader message={message} isTimeStamped={false} />
+
+                      <MessageBody>
+                        {message.attachments && message.attachments.length > 0
+                          ? message.file.name
+                          : message.msg}
+                      </MessageBody>
+
+                      <MessageMetrics message={message} isReplyButton={false} />
+                    </MessageBodyContainer>
+                  </Box>
+                )
+            )
+          )}
+        </Box>
+      </Box>
+    </Box>
+  );
 };
 
 export default AllThreads;

--- a/packages/react/src/components/ChatBody/ChatBody.js
+++ b/packages/react/src/components/ChatBody/ChatBody.js
@@ -15,7 +15,13 @@ import useComponentOverrides from '../../theme/useComponentOverrides';
 import RecentMessageButton from './RecentMessageButton';
 import useFetchChatData from '../../hooks/useFetchChatData';
 
-const ChatBody = ({ height, anonymousMode, showRoles, scrollToBottom, messageListRef }) => {
+const ChatBody = ({
+  height,
+  anonymousMode,
+  showRoles,
+  scrollToBottom,
+  messageListRef,
+}) => {
   const { classNames, styleOverrides } = useComponentOverrides('ChatBody');
   const ChatBodyCss = css`
     word-break: break-all;
@@ -63,9 +69,7 @@ const ChatBody = ({ height, anonymousMode, showRoles, scrollToBottom, messageLis
     (state) => state.isUserAuthenticated
   );
 
-  const username = useUserStore(
-    (state) => state.username
-  );
+  const username = useUserStore((state) => state.username);
 
   const getMessagesAndRoles = useFetchChatData(showRoles);
 
@@ -90,7 +94,7 @@ const ChatBody = ({ height, anonymousMode, showRoles, scrollToBottom, messageLis
     RCInstance,
     threadMainMessage?._id,
     setThreadMessages,
-    isChannelPrivate
+    isChannelPrivate,
   ]);
 
   useEffect(() => {
@@ -169,7 +173,6 @@ const ChatBody = ({ height, anonymousMode, showRoles, scrollToBottom, messageLis
     anonymousMode,
   ]);
 
-
   const [scrollPosition, setScrollPosition] = useState(0);
   const [popupVisible, setPopupVisible] = useState(false);
   const [isUserScrolledUp, setIsUserScrolledUp] = useState(false);
@@ -182,13 +185,12 @@ const ChatBody = ({ height, anonymousMode, showRoles, scrollToBottom, messageLis
     setPopupVisible(false);
   };
 
-
   const handleScroll = () => {
     setScrollPosition(messageListRef.current.scrollTop);
 
     setIsUserScrolledUp(
       messageListRef.current.scrollTop + messageListRef.current.clientHeight <
-      messageListRef.current.scrollHeight
+        messageListRef.current.scrollHeight
     );
 
     const isAtBottom = messageListRef.current.scrollTop === 0;
@@ -203,7 +205,6 @@ const ChatBody = ({ height, anonymousMode, showRoles, scrollToBottom, messageLis
     setPopupVisible(true);
   };
 
-
   useEffect(() => {
     messageListRef.current.addEventListener('scroll', handleScroll);
 
@@ -211,7 +212,6 @@ const ChatBody = ({ height, anonymousMode, showRoles, scrollToBottom, messageLis
       messageListRef.current.removeEventListener('scroll', handleScroll);
     };
   }, [messageListRef]);
-
 
   useEffect(() => {
     const isScrolledUp =
@@ -257,9 +257,9 @@ const ChatBody = ({ height, anonymousMode, showRoles, scrollToBottom, messageLis
           />
         )}
       </Box>
-      {(popupVisible && otherUserMessage) && (
+      {popupVisible && otherUserMessage && (
         <RecentMessageButton
-          visible={true}
+          visible
           text="New messages"
           onClick={handlePopupClick}
         />

--- a/packages/react/src/components/ChatHeader/ChatHeader.js
+++ b/packages/react/src/components/ChatHeader/ChatHeader.js
@@ -20,6 +20,8 @@ import { ActionButton } from '../ActionButton';
 import { Menu } from '../Menu';
 import useThreadsMessageStore from '../../store/threadsMessageStore';
 import { useToastBarDispatch } from '../../hooks/useToastBarDispatch';
+import useFetchChatData from '../../hooks/useFetchChatData';
+
 
 const ChatHeader = ({
   isClosable,
@@ -30,6 +32,8 @@ const ChatHeader = ({
   channelName,
   className = '',
   styles = {},
+  anonymousMode,
+  showRoles
 }) => {
   const { classNames, styleOverrides } = useComponentOverrides('ChatHeader');
   const channelInfo = useChannelStore((state) => state.channelInfo);
@@ -50,6 +54,7 @@ const ChatHeader = ({
   );
 
   const dispatchToastMessage = useToastBarDispatch();
+  const getMessagesAndRoles = useFetchChatData(showRoles);
 
   const avatarUrl = useUserStore((state) => state.avatarUrl);
   const headerTitle = useMessageStore((state) => state.headerTitle);
@@ -66,6 +71,16 @@ const ChatHeader = ({
   const setShowSearch = useSearchMessageStore((state) => state.setShowSearch);
   const setShowAllThreads = useThreadsMessageStore((state => state.setShowAllThreads));
   const toastPosition = useToastStore((state) => state.position);
+
+
+  const handleGoBack = async () => {
+    if (isUserAuthenticated) {
+      getMessagesAndRoles();
+    } else {
+      getMessagesAndRoles(anonymousMode);
+    }
+    setFilter(false);
+  };
 
 
   const handleLogout = useCallback(async () => {
@@ -320,11 +335,11 @@ const ChatHeader = ({
         </Box>
       </Box>
       {isThreadOpen && (
-        <DynamicHeader title={threadTitle} isClosable={true} handleClose={closeThread} iconName='arrow-back' />
+        <DynamicHeader title={threadTitle} handleClose={closeThread} iconName='arrow-back' />
       )}
 
       {!isThreadOpen && filtered && (
-   <DynamicHeader title={headerTitle} iconName={headerTitle && headerTitle.includes('Pin') ? 'pin' : 'star'} />
+        <DynamicHeader title={headerTitle} handleClose={handleGoBack} iconName='arrow-back' isHeaderIcon headerIconName={headerTitle && headerTitle.includes('Pin') ? 'pin' : 'star'} />
       )}
     </Box>
   );

--- a/packages/react/src/components/ChatHeader/ChatHeader.js
+++ b/packages/react/src/components/ChatHeader/ChatHeader.js
@@ -9,7 +9,7 @@ import {
   useMemberStore,
   useSearchMessageStore,
   useChannelStore,
-  useToastStore
+  useToastStore,
 } from '../../store';
 import { DynamicHeader } from '../DynamicHeader';
 import { Tooltip } from '../Tooltip';
@@ -22,7 +22,6 @@ import useThreadsMessageStore from '../../store/threadsMessageStore';
 import { useToastBarDispatch } from '../../hooks/useToastBarDispatch';
 import useFetchChatData from '../../hooks/useFetchChatData';
 
-
 const ChatHeader = ({
   isClosable,
   setClosableState,
@@ -33,7 +32,7 @@ const ChatHeader = ({
   className = '',
   styles = {},
   anonymousMode,
-  showRoles
+  showRoles,
 }) => {
   const { classNames, styleOverrides } = useComponentOverrides('ChatHeader');
   const channelInfo = useChannelStore((state) => state.channelInfo);
@@ -42,7 +41,9 @@ const ChatHeader = ({
     (state) => state.setShowChannelinfo
   );
   const isChannelPrivate = useChannelStore((state) => state.isChannelPrivate);
-  const setIsChannelPrivate = useChannelStore((state) => state.setIsChannelPrivate);
+  const setIsChannelPrivate = useChannelStore(
+    (state) => state.setIsChannelPrivate
+  );
 
   const { RCInstance } = useRCContext();
 
@@ -69,9 +70,10 @@ const ChatHeader = ({
   const toggleShowMembers = useMemberStore((state) => state.toggleShowMembers);
   const showMembers = useMemberStore((state) => state.showMembers);
   const setShowSearch = useSearchMessageStore((state) => state.setShowSearch);
-  const setShowAllThreads = useThreadsMessageStore((state => state.setShowAllThreads));
+  const setShowAllThreads = useThreadsMessageStore(
+    (state) => state.setShowAllThreads
+  );
   const toastPosition = useToastStore((state) => state.position);
-
 
   const handleGoBack = async () => {
     if (isUserAuthenticated) {
@@ -81,7 +83,6 @@ const ChatHeader = ({
     }
     setFilter(false);
   };
-
 
   const handleLogout = useCallback(async () => {
     try {
@@ -96,23 +97,31 @@ const ChatHeader = ({
   const showStarredMessage = useCallback(async () => {
     const { messages } = await RCInstance.getStarredMessages();
     setMessages(messages);
-    setHeaderTitle("Starred Messages");
+    setHeaderTitle('Starred Messages');
     setFilter(true);
-  }, [RCInstance, setMessages, setFilter]);
+  }, [RCInstance, setMessages, setHeaderTitle, setFilter]);
 
   const showPinnedMessage = useCallback(async () => {
     const { messages } = await RCInstance.getPinnedMessages();
     setMessages(messages);
-    setHeaderTitle("Pinned Messages");
+    setHeaderTitle('Pinned Messages');
     setFilter(true);
-  }, [RCInstance, setMessages, setFilter]);
+  }, [RCInstance, setMessages, setHeaderTitle, setFilter]);
 
   const showChannelMembers = useCallback(async () => {
-    const { members = [] } = await RCInstance.getChannelMembers(isChannelPrivate);
+    const { members = [] } = await RCInstance.getChannelMembers(
+      isChannelPrivate
+    );
     setMembersHandler(members);
     toggleShowMembers();
     setShowSearch(false);
-  }, [RCInstance, setMembersHandler, toggleShowMembers, setShowSearch, isChannelPrivate]);
+  }, [
+    RCInstance,
+    setMembersHandler,
+    toggleShowMembers,
+    setShowSearch,
+    isChannelPrivate,
+  ]);
 
   const showSearchMessage = useCallback(() => {
     setShowSearch(true);
@@ -136,8 +145,8 @@ const ChatHeader = ({
       if (res.success) {
         setChannelInfo(res.room);
         if (res.room.t === 'p') setIsChannelPrivate(true);
-      } else {
-        if ('errorType' in res && res.errorType === 'error-room-not-found') {
+      } else if ('errorType' in res) {
+        if (res.errorType === 'error-room-not-found') {
           dispatchToastMessage({
             type: 'error',
             message: "Channel doesn't exist. Logging out.",
@@ -146,12 +155,18 @@ const ChatHeader = ({
           await RCInstance.logout();
         }
       }
-
     };
     if (isUserAuthenticated) {
       getChannelInfo();
     }
-  }, [isUserAuthenticated, RCInstance, setChannelInfo, setIsChannelPrivate]);
+  }, [
+    isUserAuthenticated,
+    RCInstance,
+    setChannelInfo,
+    setIsChannelPrivate,
+    dispatchToastMessage,
+    toastPosition,
+  ]);
 
   const menuOptions = useMemo(() => {
     const options = [];
@@ -221,6 +236,7 @@ const ChatHeader = ({
     isUserAuthenticated,
     moreOpts,
     setFullScreen,
+    showAllThreads,
     showChannelMembers,
     showChannelinformation,
     showPinnedMessage,
@@ -299,23 +315,22 @@ const ChatHeader = ({
             <img width="20px" height="20px" src={avatarUrl} alt="avatar" />
           )}
           {fullScreen ? (
-
             <Menu options={menuOptions} />
-
           ) : (
-            <><Tooltip text="Maximize" position="bottom">
-              <ActionButton
-                onClick={() => {
-                  setFullScreen((prev) => !prev);
-                }}
-                ghost
-                display="inline"
-                square
-                size='medium'
-              >
-                <Icon name="computer" size="1.25rem" />
-              </ActionButton>
-            </Tooltip>
+            <>
+              <Tooltip text="Maximize" position="bottom">
+                <ActionButton
+                  onClick={() => {
+                    setFullScreen((prev) => !prev);
+                  }}
+                  ghost
+                  display="inline"
+                  square
+                  size="medium"
+                >
+                  <Icon name="computer" size="1.25rem" />
+                </ActionButton>
+              </Tooltip>
               <Menu options={menuOptions} />
             </>
           )}
@@ -327,7 +342,7 @@ const ChatHeader = ({
               ghost
               display="inline"
               square
-              size='medium'
+              size="medium"
             >
               <Icon name="cross" size="1.25rem" />
             </ActionButton>
@@ -335,11 +350,23 @@ const ChatHeader = ({
         </Box>
       </Box>
       {isThreadOpen && (
-        <DynamicHeader title={threadTitle} handleClose={closeThread} iconName='arrow-back' />
+        <DynamicHeader
+          title={threadTitle}
+          handleClose={closeThread}
+          iconName="arrow-back"
+        />
       )}
 
       {!isThreadOpen && filtered && (
-        <DynamicHeader title={headerTitle} handleClose={handleGoBack} iconName='arrow-back' isHeaderIcon headerIconName={headerTitle && headerTitle.includes('Pin') ? 'pin' : 'star'} />
+        <DynamicHeader
+          title={headerTitle}
+          handleClose={handleGoBack}
+          iconName="arrow-back"
+          isHeaderIcon
+          headerIconName={
+            headerTitle && headerTitle.includes('Pin') ? 'pin' : 'star'
+          }
+        />
       )}
     </Box>
   );

--- a/packages/react/src/components/DynamicHeader/DynamicHeader.js
+++ b/packages/react/src/components/DynamicHeader/DynamicHeader.js
@@ -5,7 +5,7 @@ import { Icon } from '../Icon';
 import { Box } from '../Box';
 import { ActionButton } from '../ActionButton';
 
-const DynamicHeader = ({ title, isClosable = false, handleClose = () => { }, iconName }) => {
+const DynamicHeader = ({ title, isHeaderIcon = false, handleClose = () => { }, iconName, headerIconName }) => {
   return (
     <Box
       className={styles.container}
@@ -21,17 +21,14 @@ const DynamicHeader = ({ title, isClosable = false, handleClose = () => { }, ico
           gap: '0.5rem',
         }}
       >
-        {isClosable && (
           <ActionButton onClick={handleClose} ghost display="inline" square small>
             <Icon name={iconName} size="1.25rem" />
           </ActionButton>
-        )}
-        {!isClosable && (
-          <div>
-            <Icon name={iconName} size="1.25rem" />
-          </div>
-        )}
+
         <h4 className={styles.nospace}>{title}</h4>
+        {isHeaderIcon && (
+            <Icon name={headerIconName} size="1.25rem" />
+        )}
       </Box>
     </Box>
   );
@@ -42,6 +39,6 @@ export default DynamicHeader;
 DynamicHeader.propTypes = {
   handleClose: PropTypes.func,
   title: PropTypes.string,
-  isClosable: PropTypes.bool,
+  isHeaderIcon: PropTypes.bool,
   iconName: PropTypes.string,
 };

--- a/packages/react/src/components/DynamicHeader/DynamicHeader.js
+++ b/packages/react/src/components/DynamicHeader/DynamicHeader.js
@@ -5,34 +5,36 @@ import { Icon } from '../Icon';
 import { Box } from '../Box';
 import { ActionButton } from '../ActionButton';
 
-const DynamicHeader = ({ title, isHeaderIcon = false, handleClose = () => { }, iconName, headerIconName }) => {
-  return (
+const DynamicHeader = ({
+  title,
+  isHeaderIcon = false,
+  handleClose = () => {},
+  iconName,
+  headerIconName,
+}) => (
+  <Box
+    className={styles.container}
+    style={{
+      paddingBlockStart: '10px',
+    }}
+  >
     <Box
-      className={styles.container}
       style={{
-        paddingBlockStart: '10px',
+        display: 'flex',
+        alignItems: 'center',
+        flexDirection: 'row',
+        gap: '0.5rem',
       }}
     >
-      <Box
-        style={{
-          display: 'flex',
-          alignItems: 'center',
-          flexDirection: 'row',
-          gap: '0.5rem',
-        }}
-      >
-          <ActionButton onClick={handleClose} ghost display="inline" square small>
-            <Icon name={iconName} size="1.25rem" />
-          </ActionButton>
+      <ActionButton onClick={handleClose} ghost display="inline" square small>
+        <Icon name={iconName} size="1.25rem" />
+      </ActionButton>
 
-        <h4 className={styles.nospace}>{title}</h4>
-        {isHeaderIcon && (
-            <Icon name={headerIconName} size="1.25rem" />
-        )}
-      </Box>
+      <h4 className={styles.nospace}>{title}</h4>
+      {isHeaderIcon && <Icon name={headerIconName} size="1.25rem" />}
     </Box>
-  );
-};
+  </Box>
+);
 
 export default DynamicHeader;
 

--- a/packages/react/src/components/EmbeddedChat.js
+++ b/packages/react/src/components/EmbeddedChat.js
@@ -225,6 +225,8 @@ const EmbeddedChat = ({
                 moreOpts={moreOpts}
                 fullScreen={fullScreen}
                 setFullScreen={setFullScreen}
+                anonymousMode={anonymousMode}
+                showRoles={showRoles}
               />
             )}
 

--- a/packages/react/src/components/EmbeddedChat.js
+++ b/packages/react/src/components/EmbeddedChat.js
@@ -21,7 +21,6 @@ import { ToastBarProvider } from './ToastBar';
 import { DropBoxOverlay, dropBoxStyles } from './DropBox';
 import { styles } from './EmbeddedChat.styles';
 
-
 const EmbeddedChat = ({
   isClosable = false,
   setClosableState,
@@ -53,7 +52,14 @@ const EmbeddedChat = ({
     setShowAvatar(showAvatar);
   }, [toastBarPosition, showAvatar]);
 
-  const { onDrag, data, handleDrag, handleDragEnter, handleDragLeave, handleDragDrop } = useDropBox();
+  const {
+    onDrag,
+    data,
+    handleDrag,
+    handleDragEnter,
+    handleDragLeave,
+    handleDragDrop,
+  } = useDropBox();
 
   if (isClosable && !setClosableState) {
     throw Error(
@@ -127,7 +133,6 @@ const EmbeddedChat = ({
             setIsUserAuthenticated(true);
           })
           .catch(console.error);
-
       } else {
         setIsUserAuthenticated(false);
       }
@@ -187,17 +192,18 @@ const EmbeddedChat = ({
     }
   };
 
-
   return (
     <ThemeProvider theme={theme || DefaultTheme}>
       <ToastBarProvider position={toastBarPosition}>
         <RCInstanceProvider value={RCContextValue}>
-          {attachmentWindowOpen ? (!!data ?
-            <>
-              <AttachmentWindow />
-            </>
-            :
-            <ValidateComponent data={data} />
+          {attachmentWindowOpen ? (
+            !!data ? (
+              <>
+                <AttachmentWindow />
+              </>
+            ) : (
+              <ValidateComponent data={data} />
+            )
           ) : null}
           <Box
             css={[
@@ -235,7 +241,7 @@ const EmbeddedChat = ({
                 <Box
                   css={[
                     onDrag && dropBoxStyles.dropBoxCss,
-                    onDrag && dropBoxStyles.borderCss
+                    onDrag && dropBoxStyles.borderCss,
                   ]}
                   style={{ height: !fullScreen ? height : '90vh' }}
                 >

--- a/packages/react/src/components/MessageList/MessageList.js
+++ b/packages/react/src/components/MessageList/MessageList.js
@@ -26,7 +26,9 @@ const MessageList = ({ messages }) => {
   const showReportMessage = useMessageStore((state) => state.showReportMessage);
   const messageToReport = useMessageStore((state) => state.messageToReport);
   const showAvatar = useUserStore((state) => state.showAvatar);
-  const showAllThreads = useThreadsMessageStore((state) => state.showAllThreads);
+  const showAllThreads = useThreadsMessageStore(
+    (state) => state.showAllThreads
+  );
 
   const isMessageNewDay = (current, previous) =>
     !previous || !isSameDay(new Date(current.ts), new Date(previous.ts));
@@ -65,5 +67,4 @@ export default MessageList;
 
 MessageList.propTypes = {
   messages: PropTypes.arrayOf(PropTypes.shape),
-
 };

--- a/packages/react/src/components/MessageList/MessageList.js
+++ b/packages/react/src/components/MessageList/MessageList.js
@@ -15,14 +15,12 @@ import SearchMessage from '../SearchMessage/SearchMessage';
 import Roominfo from '../RoomInformation/RoomInformation';
 import AllThreads from '../AllThreads/AllThreads';
 import { Message } from '../Message';
-import { ActionButton } from '../ActionButton';
-import { Icon } from '../Icon';
+
 import useThreadsMessageStore from '../../store/threadsMessageStore';
 
-const MessageList = ({ messages, handleGoBack }) => {
+const MessageList = ({ messages }) => {
   const showSearch = useSearchMessageStore((state) => state.showSearch);
   const showChannelinfo = useChannelStore((state) => state.showChannelinfo);
-  const filtered = useMessageStore((state) => state.filtered);
   const showMembers = useMemberStore((state) => state.showMembers);
   const members = useMemberStore((state) => state.members);
   const showReportMessage = useMessageStore((state) => state.showReportMessage);
@@ -53,11 +51,7 @@ const MessageList = ({ messages, handleGoBack }) => {
             )
           );
         })}
-      {filtered && (
-        <ActionButton onClick={handleGoBack} ghost display="inline" square small>
-          <Icon name="arrow-back" size="1.25rem" color="error" />
-        </ActionButton>
-      )}
+
       {showMembers && <RoomMembers members={members} />}
       {showReportMessage && <MessageReportWindow messageId={messageToReport} />}
       {showSearch && <SearchMessage />}
@@ -71,5 +65,5 @@ export default MessageList;
 
 MessageList.propTypes = {
   messages: PropTypes.arrayOf(PropTypes.shape),
-  handleGoBack: PropTypes.func,
+
 };

--- a/packages/react/src/hooks/useFetchChatData.js
+++ b/packages/react/src/hooks/useFetchChatData.js
@@ -1,62 +1,76 @@
 import { useCallback, useContext } from 'react';
 import RCContext from '../context/RCInstance';
 import { useUserStore, useChannelStore, useMessageStore } from '../store';
+
 const useFetchChatData = (showRoles) => {
-    const { RCInstance, ECOptions } = useContext(RCContext);
-    const setRoles = useUserStore((state) => state.setRoles);
-    const isChannelPrivate = useChannelStore((state) => state.isChannelPrivate);
-    const setMessages = useMessageStore((state) => state.setMessages);
-    const isUserAuthenticated = useUserStore(
-        (state) => state.isUserAuthenticated
-      );
-    
-    const getMessagesAndRoles = useCallback(async (anonymousMode) => {
-        try {
-            if (!isUserAuthenticated && !anonymousMode) {
-                return;
-            }
+  const { RCInstance, ECOptions } = useContext(RCContext);
+  const setRoles = useUserStore((state) => state.setRoles);
+  const isChannelPrivate = useChannelStore((state) => state.isChannelPrivate);
+  const setMessages = useMessageStore((state) => state.setMessages);
+  const isUserAuthenticated = useUserStore(
+    (state) => state.isUserAuthenticated
+  );
 
-            const { messages } = await RCInstance.getMessages(
-                anonymousMode,
-                ECOptions?.enableThreads
-                    ? {
-                        query: {
-                            tmid: {
-                                $exists: false,
-                            },
-                        },
-                    }
-                    : undefined,
-                anonymousMode ? false : isChannelPrivate
-            );
-
-            if (messages) {
-                setMessages(messages.filter((message) => message._hidden !== true));
-            }
-
-            if (!isUserAuthenticated) {
-                // fetch roles only when the user is authenticated
-                return;
-            }
-
-            if (showRoles) {
-                const { roles } = await RCInstance.getChannelRoles(isChannelPrivate);
-
-                // convert roles array from the API into an object for better search
-                const rolesObj =
-                    roles?.length > 0
-                        ? roles.reduce((obj, item) => ({ ...obj, [item.u.username]: item }), {})
-                        : {};
-
-                setRoles(rolesObj);
-            }
-        } catch (e) {
-            console.error(e);
+  const getMessagesAndRoles = useCallback(
+    async (anonymousMode) => {
+      try {
+        if (!isUserAuthenticated && !anonymousMode) {
+          return;
         }
-    }, [isUserAuthenticated, RCInstance, ECOptions?.enableThreads, showRoles, setMessages, setRoles, isChannelPrivate]);
 
+        const { messages } = await RCInstance.getMessages(
+          anonymousMode,
+          ECOptions?.enableThreads
+            ? {
+                query: {
+                  tmid: {
+                    $exists: false,
+                  },
+                },
+              }
+            : undefined,
+          anonymousMode ? false : isChannelPrivate
+        );
 
-    return getMessagesAndRoles;
+        if (messages) {
+          setMessages(messages.filter((message) => message._hidden !== true));
+        }
+
+        if (!isUserAuthenticated) {
+          // fetch roles only when the user is authenticated
+          return;
+        }
+
+        if (showRoles) {
+          const { roles } = await RCInstance.getChannelRoles(isChannelPrivate);
+
+          // convert roles array from the API into an object for better search
+          const rolesObj =
+            roles?.length > 0
+              ? roles.reduce(
+                  (obj, item) => ({ ...obj, [item.u.username]: item }),
+                  {}
+                )
+              : {};
+
+          setRoles(rolesObj);
+        }
+      } catch (e) {
+        console.error(e);
+      }
+    },
+    [
+      isUserAuthenticated,
+      RCInstance,
+      ECOptions?.enableThreads,
+      showRoles,
+      setMessages,
+      setRoles,
+      isChannelPrivate,
+    ]
+  );
+
+  return getMessagesAndRoles;
 };
 
 export default useFetchChatData;

--- a/packages/react/src/hooks/useFetchChatData.js
+++ b/packages/react/src/hooks/useFetchChatData.js
@@ -1,0 +1,62 @@
+import { useCallback, useContext } from 'react';
+import RCContext from '../context/RCInstance';
+import { useUserStore, useChannelStore, useMessageStore } from '../store';
+const useFetchChatData = (showRoles) => {
+    const { RCInstance, ECOptions } = useContext(RCContext);
+    const setRoles = useUserStore((state) => state.setRoles);
+    const isChannelPrivate = useChannelStore((state) => state.isChannelPrivate);
+    const setMessages = useMessageStore((state) => state.setMessages);
+    const isUserAuthenticated = useUserStore(
+        (state) => state.isUserAuthenticated
+      );
+    
+    const getMessagesAndRoles = useCallback(async (anonymousMode) => {
+        try {
+            if (!isUserAuthenticated && !anonymousMode) {
+                return;
+            }
+
+            const { messages } = await RCInstance.getMessages(
+                anonymousMode,
+                ECOptions?.enableThreads
+                    ? {
+                        query: {
+                            tmid: {
+                                $exists: false,
+                            },
+                        },
+                    }
+                    : undefined,
+                anonymousMode ? false : isChannelPrivate
+            );
+
+            if (messages) {
+                setMessages(messages.filter((message) => message._hidden !== true));
+            }
+
+            if (!isUserAuthenticated) {
+                // fetch roles only when the user is authenticated
+                return;
+            }
+
+            if (showRoles) {
+                const { roles } = await RCInstance.getChannelRoles(isChannelPrivate);
+
+                // convert roles array from the API into an object for better search
+                const rolesObj =
+                    roles?.length > 0
+                        ? roles.reduce((obj, item) => ({ ...obj, [item.u.username]: item }), {})
+                        : {};
+
+                setRoles(rolesObj);
+            }
+        } catch (e) {
+            console.error(e);
+        }
+    }, [isUserAuthenticated, RCInstance, ECOptions?.enableThreads, showRoles, setMessages, setRoles, isChannelPrivate]);
+
+
+    return getMessagesAndRoles;
+};
+
+export default useFetchChatData;


### PR DESCRIPTION
# Brief Title

## Acceptance Criteria Fulfillment

- [x] Changed the dynamic header to accept both the back button icon and a header icon.
- [x] Removed the back button and its functionality from `MessageList.js`.
- [x] Introduced a custom hook `useFetchChatData` to fetch messages and roles using `getMessagesAndRoles` function.
- [x] Formatted the code using Prettier to avoid linting issues.
- [x] Additionally, fixed the linting issues in the changed file, specifically the portions that I was able to understand and change before.

**Previously, when going back, the `handleGoBack` function, which calls `getMessagesAndRoles` to set all messages back in the state, could be directly passed as a prop from `ChatBody` to `MessageList` since it was the child component of it. However, now the `handleGoBack` function has to be implemented in `ChatHeader`, which is not a child of `ChatBody` and the `handleGoBack` button uses the function `getMessagesAndRoles`, which was defined inside `ChatBody`. So the same function has to be reused here as well. Hence, In order to avoid code duplication, a custom hook is introduced for reusability.**

Note: Since a new custom hook is introduced to avoid code duplication, please review the CustomHook section of the PR carefully to check for any potential state problems. I have tested it, and it is working fine as expected, but I would like to receive feedback from you to avoid any potential issues. The formatting part and the actual changed code part commit are separated for easy review.

Fixes #459 

## Video/Screenshots

https://github.com/RocketChat/EmbeddedChat/assets/78961432/aff15dad-ec26-4e08-8b45-f35b3f3e7565