### PR TITLE
Fix: fix typo in README

### DIFF
--- a/README.md
+++ b/README.md
@@ -16,7 +16,7 @@ _EmbeddedChat is a full-stack React component node module of the RocketChat appl
 </div>
 
 ## Installation and Usage
-Installtion and usage documentation could be found here [EmbeddedChat installation and usage](packages/react/README.md)
+Installation and usage documentation could be found here [EmbeddedChat installation and usage](packages/react/README.md)
 
 ## Development
 


### PR DESCRIPTION
# Brief Title
Fixing small typo in README file

## Acceptance Criteria fulfillment
"Installtion" should be corrected to "Installation" in the "Installation and Usage" section.
