### PR TITLE
Handle 'Message Too Long"

### DIFF
--- a/packages/react/src/components/ChatInput/ChatInput.js
+++ b/packages/react/src/components/ChatInput/ChatInput.js
@@ -256,7 +256,7 @@ const ChatInput = ({ scrollToBottom }) => {
   useEffect(() => {
     if (isAttachmentMode) sendMessage();
   }, [isAttachmentMode, sendMessage]);
-  
+
   const sendAttachment = (event) => {
     const fileObj = event.target.files && event.target.files[0];
     if (!fileObj) {

--- a/packages/react/src/components/ChatInput/ChatInput.js
+++ b/packages/react/src/components/ChatInput/ChatInput.js
@@ -137,10 +137,6 @@ const ChatInput = ({ scrollToBottom }) => {
     setErrorModal(false);
   };
 
-  useEffect(() => {
-    if (isAttachmentMode) sendMessage();
-  }, [isAttachmentMode]);
-
   const handleConvertToAttachment = () => {
     setIsAttachmentMode(true);
     closeErrorModal();
@@ -257,6 +253,10 @@ const ChatInput = ({ scrollToBottom }) => {
     scrollToBottom();
   };
 
+  useEffect(() => {
+    if (isAttachmentMode) sendMessage();
+  }, [isAttachmentMode, sendMessage]);
+  
   const sendAttachment = (event) => {
     const fileObj = event.target.files && event.target.files[0];
     if (!fileObj) {


### PR DESCRIPTION
# Add Alert for Long Message and Convert it into a file

## Acceptance Criteria fulfillment

- [x] Add Error Modal instead of logging out the user
- [x] Add the option to ask the user whether to send it as a file instead
- [x] Add the logic to covert and send long text messages as a file attachment

Fixes #384 

## Video/Screenshots

https://github.com/RocketChat/EmbeddedChat/assets/93793691/2f83b544-e5b7-465e-9163-729f49d3e3c8



