### PR TITLE
fix: fixed static message limit to adapt to workspace setting

### DIFF
--- a/packages/api/src/EmbeddedChatApi.ts
+++ b/packages/api/src/EmbeddedChatApi.ts
@@ -924,6 +924,27 @@ export default class EmbeddedChatApi {
       console.error(err);
     }
   }
+
+  async getMessageLimit() {
+    try {
+      const { userId, authToken } = (await this.auth.getCurrentUser()) || {};
+      const response = await fetch(
+        `${this.host}/api/v1/settings/Message_MaxAllowedSize`,
+        {
+          headers: {
+            "Content-Type": "application/json",
+            "X-Auth-Token": authToken,
+            "X-User-Id": userId,
+          },
+          method: "GET",
+        }
+      );
+      return await response.json();
+    } catch (err) {
+      console.error(err);
+    }
+  }
+
   async triggerBlockAction({
     type,
     actionId,

--- a/packages/react/src/components/ChatHeader/ChatHeader.js
+++ b/packages/react/src/components/ChatHeader/ChatHeader.js
@@ -25,6 +25,7 @@ import { ActionButton } from '../ActionButton';
 import { Menu } from '../Menu';
 import { useToastBarDispatch } from '../../hooks/useToastBarDispatch';
 import useFetchChatData from '../../hooks/useFetchChatData';
+import useSettingsStore from '../../store/settingsStore';
 
 const ChatHeader = ({
   isClosable,
@@ -64,12 +65,10 @@ const ChatHeader = ({
   const avatarUrl = useUserStore((state) => state.avatarUrl);
   const headerTitle = useMessageStore((state) => state.headerTitle);
   const filtered = useMessageStore((state) => state.filtered);
-  const setMessages = useMessageStore((state) => state.setMessages);
   const setFilter = useMessageStore((state) => state.setFilter);
   const isThreadOpen = useMessageStore((state) => state.isThreadOpen);
   const closeThread = useMessageStore((state) => state.closeThread);
   const threadTitle = useMessageStore((state) => state.threadMainMessage?.msg);
-  const setHeaderTitle = useMessageStore((state) => state.setHeaderTitle);
   const setMembersHandler = useMemberStore((state) => state.setMembersHandler);
   const toggleShowMembers = useMemberStore((state) => state.toggleShowMembers);
   const showMembers = useMemberStore((state) => state.showMembers);
@@ -84,6 +83,7 @@ const ChatHeader = ({
   const setShowAllFiles = useFileStore((state) => state.setShowAllFiles);
   const setShowMentions = useMentionsStore((state) => state.setShowMentions);
   const toastPosition = useToastStore((state) => state.position);
+  const setMessageLimit = useSettingsStore((state) => state.setMessageLimit);
 
   const handleGoBack = async () => {
     if (isUserAuthenticated) {
@@ -156,6 +156,11 @@ const ChatHeader = ({
   }, [setShowMentions, setShowSearch]);
 
   useEffect(() => {
+    const getMessageLimit = async () => {
+      const messageLimitObj = await RCInstance.getMessageLimit();
+      setMessageLimit(messageLimitObj?.value);
+    };
+
     const setMessageAllowed = async () => {
       const permissionRes = await RCInstance.permissionInfo();
       const channelRolesRes = await RCInstance.getChannelRoles(
@@ -205,6 +210,7 @@ const ChatHeader = ({
 
     if (isUserAuthenticated) {
       getChannelInfo();
+      getMessageLimit();
     }
   }, [
     isUserAuthenticated,
@@ -216,6 +222,7 @@ const ChatHeader = ({
     isChannelPrivate,
     setCanSendMsg,
     authenticatedUserId,
+    setMessageLimit,
   ]);
 
   const menuOptions = useMemo(() => {

--- a/packages/react/src/components/ChatInput/ChatInput.js
+++ b/packages/react/src/components/ChatInput/ChatInput.js
@@ -26,6 +26,7 @@ import { Divider } from '../Divider';
 import useComponentOverrides from '../../theme/useComponentOverrides';
 import { useToastBarDispatch } from '../../hooks/useToastBarDispatch';
 import { Modal } from '../Modal';
+import useSettingsStore from '../../store/settingsStore';
 
 const editingMessageCss = css`
   background-color: #fff8e0;
@@ -51,6 +52,7 @@ const ChatInput = ({ scrollToBottom }) => {
 
   const members = useMemberStore((state) => state.members);
   const setMembersHandler = useMemberStore((state) => state.setMembersHandler);
+  const msgMaxLength = useSettingsStore((state) => state.messageLimit);
 
   useEffect(() => {
     RCInstance.auth.onAuthChange((user) => {
@@ -173,8 +175,6 @@ const ChatInput = ({ scrollToBottom }) => {
       setEditMessage({});
       return;
     }
-
-    const msgMaxLength = 500;
     if (message.length > msgMaxLength) {
       openMsgLongModal();
       return;

--- a/packages/react/src/store/settingsStore.js
+++ b/packages/react/src/store/settingsStore.js
@@ -1,0 +1,8 @@
+import { create } from 'zustand';
+
+const useSettingsStore = create((set) => ({
+  messageLimit: 5000,
+  setMessageLimit: (messageLimit) => set(() => ({ messageLimit })),
+}));
+
+export default useSettingsStore;


### PR DESCRIPTION
# Brief Title
This pull request is intended to fix the static message limit set in the code.

## Acceptance Criteria Fulfillment

- [x] Added function to fetch the maxMessage limit setting.
- [x] Upon user login, fetch this setting and set it in the global state immediately.
- [x] Utilize that limit to determine whether to send as a message or attachments.

Fixes #527 

## Video/Screenshots


https://github.com/RocketChat/EmbeddedChat/assets/78961432/ca8898ee-1770-40ea-9827-9cbdd4854a1b

Note : This requires a rebuild of EC as there are some backend codes introduced.