### PR TITLE
[FIX] Starred & Pinned messages sidebars fetch APIs infinitely

### DIFF
--- a/packages/react/src/components/PinnedMessages/PinnedMessages.js
+++ b/packages/react/src/components/PinnedMessages/PinnedMessages.js
@@ -23,7 +23,7 @@ const PinnedMessages = () => {
       setLoading(false);
     };
     getPinnedMessages();
-  });
+  }, [RCInstance, setMessageList, setLoading]);
 
   const isMessageNewDay = (current, previous) =>
     !previous || !isSameDay(new Date(current.ts), new Date(previous.ts));

--- a/packages/react/src/components/StarredMessages/StarredMessages.js
+++ b/packages/react/src/components/StarredMessages/StarredMessages.js
@@ -15,17 +15,17 @@ const StarredMessages = () => {
     (state) => state.setShowStarred
   );
 
-  const [messageList, setmessageList] = useState([]);
+  const [messageList, setMessageList] = useState([]);
   const [loading, setLoading] = useState(true);
 
   useEffect(() => {
     const getStarredMessages = async () => {
       const { messages } = await RCInstance.getStarredMessages();
-      setmessageList(messages);
+      setMessageList(messages);
       setLoading(false);
     };
     getStarredMessages();
-  });
+  }, [RCInstance, setMessageList, setLoading]);
 
   const isMessageNewDay = (current, previous) =>
     !previous || !isSameDay(new Date(current.ts), new Date(previous.ts));


### PR DESCRIPTION
## Acceptance Criteria fulfillment

- [x] Only fetch API once when the sidebar is opened

Fixes #531 

## Video/Screenshots
![sidebar-rerender-fixed](https://github.com/RocketChat/EmbeddedChat/assets/35394596/df1d40d5-ecef-4818-9943-3b69dbd2afa5)