### PR TITLE
fix: centered throbber, added fallback, set default closable false

### DIFF
--- a/packages/react/src/components/Attachments/ImageGallery.js
+++ b/packages/react/src/components/Attachments/ImageGallery.js
@@ -6,23 +6,30 @@ import classes from './ImageGallery.module.css';
 import { Throbber } from '../Throbber';
 import { ActionButton } from '../ActionButton';
 import { Icon } from '../Icon';
+import { Button } from '../Button';
 
 const ImageGallery = ({ currentFileId, setShowGallery }) => {
   const { RCInstance } = useRCContext();
   const [files, setFiles] = useState([]);
   const [currentFileIndex, setCurrentFileIndex] = useState(-1);
   const [loading, setLoading] = useState(true);
+  const [imgFetchErr, setImgFetchErr] = useState(false);
 
   useEffect(() => {
     const fetchAllImages = async () => {
       const res = await RCInstance.getAllImages();
-      if (res?.files) {
-        setFiles(res.files);
-        const fileIndex = res.files.findIndex(
-          (file) => file._id === currentFileId
-        );
-        setCurrentFileIndex(fileIndex);
+      if (res) {
+        if (res?.files) {
+          setFiles(res.files);
+          const fileIndex = res.files.findIndex(
+            (file) => file._id === currentFileId
+          );
+          setCurrentFileIndex(fileIndex);
+          setLoading(false);
+        }
+      } else {
         setLoading(false);
+        setImgFetchErr(true);
       }
     };
     fetchAllImages();
@@ -38,9 +45,41 @@ const ImageGallery = ({ currentFileId, setShowGallery }) => {
       >
         <Icon name="cross" />
       </ActionButton>
-      {loading ? (
+      {loading && (
         <Box className={classes.throbberWrapper}>
           <Throbber />
+        </Box>
+      )}
+
+      {imgFetchErr ? (
+        <Box
+          className={classes.fetchErrorWrapper}
+          style={{
+            display: 'flex',
+            flexDirection: 'column',
+            alignItems: 'center',
+          }}
+        >
+          <Icon
+            name="magnifier"
+            size="3rem"
+            style={{ padding: '0.5rem', color: '#FF99A2' }}
+          />
+          <span
+            style={{ fontSize: '1.2rem', fontWeight: 'bold', color: '#fff' }}
+          >
+            Something went wrong
+          </span>
+          <Button
+            color="primary"
+            onClick={() => setShowGallery(false)}
+            style={{
+              alignSelf: 'auto',
+              margin: '10px',
+            }}
+          >
+            Close
+          </Button>
         </Box>
       ) : (
         <Swiper

--- a/packages/react/src/components/Attachments/ImageGallery.js
+++ b/packages/react/src/components/Attachments/ImageGallery.js
@@ -34,12 +34,14 @@ const ImageGallery = ({ currentFileId, setShowGallery }) => {
         ghost
         className={classes.exit}
         onClick={() => setShowGallery(false)}
-        size="large"
+        size="medium"
       >
         <Icon name="cross" />
       </ActionButton>
       {loading ? (
-        <Throbber />
+        <Box className={classes.throbberWrapper}>
+          <Throbber />
+        </Box>
       ) : (
         <Swiper
           navigation

--- a/packages/react/src/components/Attachments/ImageGallery.module.css
+++ b/packages/react/src/components/Attachments/ImageGallery.module.css
@@ -33,3 +33,10 @@
   max-height: 100%;
   object-fit: contain;
 }
+
+.throbberWrapper {
+  height: 100%;
+  display: flex;
+  justify-content: center;
+  align-items: center;
+}

--- a/packages/react/src/components/Attachments/ImageGallery.module.css
+++ b/packages/react/src/components/Attachments/ImageGallery.module.css
@@ -40,3 +40,11 @@
   justify-content: center;
   align-items: center;
 }
+
+.fetchErrorWrapper {
+  height: 100%;
+  display: flex;
+  flex-direction: column;
+  justify-content: center;
+  align-items: center;
+}

--- a/packages/react/src/components/EmbeddedChat.js
+++ b/packages/react/src/components/EmbeddedChat.js
@@ -23,7 +23,7 @@ import { styles } from './EmbeddedChat.styles';
 
 const EmbeddedChat = ({
   isClosable = false,
-  setClosableState,
+  setClosableState = () => {},
   moreOpts = false,
   width = '100%',
   height = '50vh',

--- a/packages/react/src/stories/EmbeddedChat.stories.js
+++ b/packages/react/src/stories/EmbeddedChat.stories.js
@@ -11,8 +11,6 @@ export const Simple = {
   args: {
     host: process.env.STORYBOOK_RC_HOST || 'http://localhost:3000',
     roomId: 'GENERAL',
-    isClosable: true,
-    setClosableState: true,
     moreOpts: true,
     channelName: 'general',
     anonymousMode: true,

--- a/packages/react/src/stories/EmbeddedChatAuthToken.stories.js
+++ b/packages/react/src/stories/EmbeddedChatAuthToken.stories.js
@@ -11,8 +11,6 @@ export const Simple = {
   args: {
     host: process.env.STORYBOOK_RC_HOST || 'http://localhost:3000',
     roomId: 'GENERAL',
-    isClosable: true,
-    setClosableState: true,
     moreOpts: true,
     channelName: 'general',
     anonymousMode: true,

--- a/packages/react/src/stories/EmbeddedChatTheme.stories.js
+++ b/packages/react/src/stories/EmbeddedChatTheme.stories.js
@@ -12,8 +12,6 @@ export const WithTheme = {
     host: process.env.STORYBOOK_RC_HOST || 'http://localhost:3000',
     roomId: 'GENERAL',
     GOOGLE_CLIENT_ID: '',
-    isClosable: true,
-    setClosableState: true,
     moreOpts: true,
     channelName: 'general',
     anonymousMode: true,

--- a/packages/react/src/stories/EmbeddedChatWithOAuth.stories.js
+++ b/packages/react/src/stories/EmbeddedChatWithOAuth.stories.js
@@ -11,8 +11,6 @@ export const WithOAuth = {
   args: {
     host: process.env.STORYBOOK_RC_HOST || 'http://localhost:3000',
     roomId: 'GENERAL',
-    isClosable: true,
-    setClosableState: true,
     moreOpts: true,
     channelName: 'general',
     anonymousMode: true,

--- a/packages/react/src/stories/EmbeddedChatWithoutHeader.stories.js
+++ b/packages/react/src/stories/EmbeddedChatWithoutHeader.stories.js
@@ -11,8 +11,6 @@ export const Simple = {
   args: {
     host: process.env.STORYBOOK_RC_HOST || 'http://localhost:3000',
     roomId: 'GENERAL',
-    isClosable: true,
-    setClosableState: true,
     moreOpts: true,
     channelName: 'general',
     anonymousMode: true,


### PR DESCRIPTION
# Brief Title
Aligned the throbber in the image gallery and fixed infinite loading even when image fetching fails in the newly added image gallery (The same is implemented in RC as well)

Separately, in relation to another issue: `isClosable` is set to true in story examples, causing confusion. It should only be enabled when the true prop is explicitly passed along with a proper `setClosable` function, rather than just a boolean value (which was causing errors in the console). To avoid confusion, I have set `setClosable` as false by default and am passing an empty function.

## Acceptance Criteria Fulfillment

- [x] Throbber centered in Image Gallery
- [x] Fallback text displayed when image fetch fails, preventing infinite loading
- [x] `isClosable` set to false by default in all stories
- [x] Default to an empty function for `setClosable` 

Fixes N.A

## Video/Screenshots

### Before:

![image](https://github.com/RocketChat/EmbeddedChat/assets/78961432/c1133707-a3bb-4013-b13d-a04d36c8443d)

![image](https://github.com/RocketChat/EmbeddedChat/assets/78961432/febb3f1d-d77b-47e4-a805-ddf8624f7589)


https://github.com/RocketChat/EmbeddedChat/assets/78961432/1e11cd83-5b6b-4a6a-baff-115f725b8e93




### After:

![image](https://github.com/RocketChat/EmbeddedChat/assets/78961432/7577f1a9-38b0-4a9c-94ad-af6b48703304)

![image](https://github.com/RocketChat/EmbeddedChat/assets/78961432/7aa21bea-0951-4e20-b59e-fdf1460082ba)


https://github.com/RocketChat/EmbeddedChat/assets/78961432/54e605e7-3395-4c42-9878-467b2b8b75fa

