### PR TITLE
[Feat] Display 'No Threads Found' Message in Thread Sidebar When No Threads Exist

### DIFF
--- a/packages/react/src/components/AllThreads/AllThreads.js
+++ b/packages/react/src/components/AllThreads/AllThreads.js
@@ -84,7 +84,7 @@ const AllThreads = () => {
     [messages, text]
   );
 
-  const containsThreads = messages.some(message => message.tcount > 0);
+  const containsThreads = messages.some((message) => message.tcount > 0);
 
   return (
     <Sidebar
@@ -112,11 +112,17 @@ const AllThreads = () => {
           overflow: 'auto',
           display: 'flex',
           flexDirection: 'column',
-          justifyContent: (!containsThreads || filteredThreads.length === 0) ? 'center' : 'initial',
-          alignItems: (!containsThreads || filteredThreads.length === 0) ? 'center' : 'initial',
+          justifyContent:
+            !containsThreads || filteredThreads.length === 0
+              ? 'center'
+              : 'initial',
+          alignItems:
+            !containsThreads || filteredThreads.length === 0
+              ? 'center'
+              : 'initial',
         }}
       >
-        {(!containsThreads || filteredThreads.length === 0) ? (
+        {!containsThreads || filteredThreads.length === 0 ? (
           <Box
             style={{
               display: 'flex',

--- a/packages/react/src/components/AllThreads/AllThreads.js
+++ b/packages/react/src/components/AllThreads/AllThreads.js
@@ -84,8 +84,7 @@ const AllThreads = () => {
     [messages, text]
   );
 
- // Check if there are any threads in the messages array
-  const hasThreads = messages.some(message => message.tcount > 0);
+  const containsThreads = messages.some(message => message.tcount > 0);
 
   return (
     <Sidebar
@@ -113,11 +112,11 @@ const AllThreads = () => {
           overflow: 'auto',
           display: 'flex',
           flexDirection: 'column',
-          justifyContent: (!hasThreads || filteredThreads.length === 0) ? 'center' : 'initial',
-          alignItems: (!hasThreads || filteredThreads.length === 0) ? 'center' : 'initial',
+          justifyContent: (!containsThreads || filteredThreads.length === 0) ? 'center' : 'initial',
+          alignItems: (!containsThreads || filteredThreads.length === 0) ? 'center' : 'initial',
         }}
       >
-        {(!hasThreads || filteredThreads.length === 0) ? (
+        {(!containsThreads || filteredThreads.length === 0) ? (
           <Box
             style={{
               display: 'flex',

--- a/packages/react/src/components/AllThreads/AllThreads.js
+++ b/packages/react/src/components/AllThreads/AllThreads.js
@@ -84,6 +84,9 @@ const AllThreads = () => {
     [messages, text]
   );
 
+ // Check if there are any threads in the messages array
+  const hasThreads = messages.some(message => message.tcount > 0);
+
   return (
     <Sidebar
       title="Threads"
@@ -110,11 +113,11 @@ const AllThreads = () => {
           overflow: 'auto',
           display: 'flex',
           flexDirection: 'column',
-          justifyContent: filteredThreads.length === 0 ? 'center' : 'initial',
-          alignItems: filteredThreads.length === 0 ? 'center' : 'initial',
+          justifyContent: (!hasThreads || filteredThreads.length === 0) ? 'center' : 'initial',
+          alignItems: (!hasThreads || filteredThreads.length === 0) ? 'center' : 'initial',
         }}
       >
-        {filteredThreads.length === 0 ? (
+        {(!hasThreads || filteredThreads.length === 0) ? (
           <Box
             style={{
               display: 'flex',


### PR DESCRIPTION
# Description
This PR addresses the issue where the `No Threads Found` message is not displayed in the thread sidebar when there are no threads in the chat. The solution ensures that the message, along with an icon, is shown to indicate the absence of threads, improving the user experience by providing clear feedback.

# Before fix
![beforefix](https://github.com/RocketChat/EmbeddedChat/assets/123318221/b10ecd33-7b78-4470-9fc8-f1581e7fa210)

# After fix 

https://github.com/RocketChat/EmbeddedChat/assets/123318221/ffe2a14b-fb1d-4ac2-a725-e2c40fd07068


- [X] The "No Threads Found" message with an icon is displayed in the thread sidebar when there are no threads.
- [X] The solution does not break any existing functionality.


Fixes : #529


