### PR TITLE
Fixed the unexpected appearance of the new messages notification on pinning and starring messages

### DIFF
--- a/packages/react/src/components/ChatBody/ChatBody.js
+++ b/packages/react/src/components/ChatBody/ChatBody.js
@@ -112,7 +112,7 @@ const ChatBody = ({
     (message) => {
       if (message.u.username !== username) {
         const isScrolledUp = messageListRef?.current?.scrollTop !== 0;
-        if (isScrolledUp) {
+        if (isScrolledUp && !('pinned' in message) && !('starred' in message)) {
           setOtherUserMessage(true);
         }
       }


### PR DESCRIPTION
Just added a simple fix which checks the message object and only triggers the popup if a new message is received from any other user.



https://github.com/RocketChat/EmbeddedChat/assets/98230836/16d5999e-3f16-4a28-b110-cd57039aef66

Fixes #544 
 