### PR TITLE
fix: attachment direct download and video type support

### DIFF
--- a/packages/react/src/components/Attachments/AttachmentMetadata.js
+++ b/packages/react/src/components/Attachments/AttachmentMetadata.js
@@ -3,14 +3,23 @@ import { ActionButton } from '../ActionButton';
 import { Box } from '../Box';
 
 const AttachmentMetadata = ({ attachment, url }) => {
-  const handleDownload = () => {
-    const anchor = document.createElement('a');
-    anchor.href = url;
-    anchor.download = attachment.title;
+  const handleDownload = async () => {
+    try {
+      const response = await fetch(url);
+      const data = await response.blob();
+      const downloadUrl = URL.createObjectURL(data);
 
-    document.body.appendChild(anchor);
-    anchor.click();
-    document.body.removeChild(anchor);
+      const anchor = document.createElement('a');
+      anchor.href = downloadUrl;
+      anchor.download = attachment.title || 'download';
+
+      document.body.appendChild(anchor);
+      anchor.click();
+      document.body.removeChild(anchor);
+      URL.revokeObjectURL(downloadUrl);
+    } catch (error) {
+      console.error('Error downloading the file:', error);
+    }
   };
 
   return (

--- a/packages/react/src/components/Attachments/AudioAttachment.js
+++ b/packages/react/src/components/Attachments/AudioAttachment.js
@@ -7,7 +7,7 @@ const AudioAttachment = ({ attachment, host }) => (
   <Box>
     <AttachmentMetadata
       attachment={attachment}
-      url={host + attachment.audio_url}
+      url={host + (attachment.title_url || attachment.audio_url)}
     />
     <audio src={host + attachment.audio_url} width="100%" controls />
   </Box>

--- a/packages/react/src/components/Attachments/ImageAttachment.js
+++ b/packages/react/src/components/Attachments/ImageAttachment.js
@@ -17,7 +17,7 @@ const ImageAttachment = ({ attachment, host }) => {
     <Box>
       <AttachmentMetadata
         attachment={attachment}
-        url={host + attachment.title_link}
+        url={host + (attachment.title_link || attachment.image_url)}
       />
       <Button ghost onClick={() => setShowGallery(true)}>
         <img

--- a/packages/react/src/components/Attachments/VideoAttachment.js
+++ b/packages/react/src/components/Attachments/VideoAttachment.js
@@ -3,14 +3,27 @@ import PropTypes from 'prop-types';
 import { Box } from '../Box';
 import AttachmentMetadata from './AttachmentMetadata';
 
+const userAgentMIMETypeFallback = (type) => {
+  const userAgent = navigator.userAgent.toLocaleLowerCase();
+
+  if (type === 'video/quicktime' && userAgent.indexOf('safari') !== -1) {
+    return 'video/mp4';
+  }
+
+  return type;
+};
+
 const VideoAttachment = ({ attachment, host }) => (
   <Box>
     <AttachmentMetadata
       attachment={attachment}
-      url={host + attachment.video_url}
+      url={host + (attachment.title_url || attachment.video_url)}
     />
     <video width={300} controls>
-      <source src={host + attachment.video_url} type={attachment.video_type} />
+      <source
+        src={host + attachment.video_url}
+        type={userAgentMIMETypeFallback(attachment.video_type)}
+      />
     </video>
   </Box>
 );


### PR DESCRIPTION
## Fixes

- Download button directly downloads the file
- Support QuickTime video types in safari (common, e.g. storybook)
- Download original file (if available) and default to preview file

Closes #547 

## Video/Screenshots
![attachment-fix](https://github.com/RocketChat/EmbeddedChat/assets/35394596/7e0e9f6b-aa95-41a2-b732-581b455bc9fc)