### PR TITLE
fix: display notification for role changed

### DIFF
--- a/packages/react/src/components/Message/MessageHeader.js
+++ b/packages/react/src/components/Message/MessageHeader.js
@@ -79,6 +79,10 @@ const MessageHeader = ({ message, isTimeStamped = true }) => {
         return 'Pinned a message:';
       case 'rm':
         return 'message removed';
+      case 'subscription-role-added':
+        return `set ${message?.msg} as ${message?.role}`;
+      case 'subscription-role-removed':
+        return `removed ${message?.msg} as ${message?.role}`;
       default:
         return '';
     }


### PR DESCRIPTION
# Brief Title
This PR fixes the issue where notifications are not displayed correctly when a user's role changes.

## Acceptance Criteria Fulfillment

- [x] Display appropriate notification when a user's role changes

Fixes N.A.

## Video/Screenshots
Before:

![image](https://github.com/RocketChat/EmbeddedChat/assets/78961432/91445d80-50a6-4603-bc0b-1a3874dd5955)

After:

![image](https://github.com/RocketChat/EmbeddedChat/assets/78961432/da604b4c-bfcc-4981-9da9-3831752455c3)
