### PR TITLE
Fix thread title for files and  messages in report modal

### DIFF
--- a/packages/react/src/views/ChatHeader/ChatHeader.js
+++ b/packages/react/src/views/ChatHeader/ChatHeader.js
@@ -93,8 +93,13 @@ const ChatHeader = ({
   const headerTitle = useMessageStore((state) => state.headerTitle);
   const filtered = useMessageStore((state) => state.filtered);
   const setFilter = useMessageStore((state) => state.setFilter);
-  const threadTitle = useMessageStore((state) => state.threadMainMessage?.msg);
+
   const isThreadOpen = useMessageStore((state) => state.isThreadOpen);
+  const threadMainMessage = useMessageStore((state) => state.threadMainMessage);
+  const threadTitle =
+    threadMainMessage?.msg ||
+    (threadMainMessage?.file ? threadMainMessage.file.name : '');
+
   const closeThread = useMessageStore((state) => state.closeThread);
 
   const setShowMembers = useMemberStore((state) => state.setShowMembers);

--- a/packages/react/src/views/ReportMessage/MessageReportWindow.js
+++ b/packages/react/src/views/ReportMessage/MessageReportWindow.js
@@ -13,7 +13,6 @@ const MessageReportWindow = ({ messageId }) => {
   const messageText = allMessages.filter(
     (message) => message._id === messageId
   )[0]?.msg;
-  console.log('messagetext', messageText);
   return (
     <ReportWindowButtons
       variant="danger"

--- a/packages/react/src/views/ReportMessage/MessageReportWindow.js
+++ b/packages/react/src/views/ReportMessage/MessageReportWindow.js
@@ -7,9 +7,13 @@ import styles from './ReportMessage.styles';
 
 const MessageReportWindow = ({ messageId }) => {
   const [reportDescription, setDescription] = useState('');
-  const messages = useMessageStore((state) => state.messages);
-  const messageText = messages.filter((message) => message._id === messageId)[0]
-    ?.msg;
+  const messages = useMessageStore((state) => state.messages) || [];
+  const threadMessages = useMessageStore((state) => state.threadMessages) || [];
+  const allMessages = [...messages, ...threadMessages];
+  const messageText = allMessages.filter(
+    (message) => message._id === messageId
+  )[0]?.msg;
+  console.log('messagetext', messageText);
   return (
     <ReportWindowButtons
       variant="danger"


### PR DESCRIPTION
# Brief Title

This pr demonstrates the visibility of thread title when initialsed by files and the message is visible in the report modal in thread

## Acceptance Criteria fulfillment

- [x] Fixed the thread title issue at the time of files
- [x] Report modal contains the message in the thread

Fixes #625

## Video/Screenshots


https://github.com/user-attachments/assets/4335cccc-8d52-43c5-803f-83c00bda03cb

