### PR TITLE
[fix] Re-rendering fixed while opening pinned and starred messages.

### DIFF
--- a/packages/react/src/hooks/useSetMessageList.js
+++ b/packages/react/src/hooks/useSetMessageList.js
@@ -1,16 +1,14 @@
-import { useState, useEffect } from 'react';
+import { useState, useEffect, useMemo } from 'react';
 
 export const useSetMessageList = (messages, shouldRender) => {
   const [loading, setLoading] = useState(true);
-  const [messageList, setMessageList] = useState([]);
+
+  const messageList = useMemo(
+    () => messages.filter(shouldRender),
+    [messages, shouldRender]
+  );
 
   useEffect(() => {
-    setLoading(true);
-    const filteredMessages = messages.filter((message) =>
-      shouldRender(message)
-    );
-
-    setMessageList(filteredMessages);
     setLoading(false);
   }, [messages, shouldRender]);
 


### PR DESCRIPTION
# Brief Title
While opening starred messages, useSetMessageList hook was getting re-rendered many infinitely. 
## Acceptance Criteria fulfillment

- [ ] Stop the re-rendering while keeping the functionality same.

Fixes # (issue)
Added memoization to stop the infinite re-render cycle.

## Video/Screenshots
Previously:

https://github.com/user-attachments/assets/adf0110c-15c1-489d-b1ba-52ee30bde871

Now:

https://github.com/user-attachments/assets/00da0211-d63d-45d2-ba13-c5badee16379

**Note**: The PR will be ready for live testing at https://rocketchat.github.io/EmbeddedChat/pulls/pr-<pr_number> after approval.


