### PR TITLE
[fix] Re-rendering fixed while opening pinned and starred messages.

### DIFF
--- a/packages/react/src/hooks/useSetMessageList.js
+++ b/packages/react/src/hooks/useSetMessageList.js
@@ -1,16 +1,14 @@
-import { useState, useEffect } from 'react';
+import { useState, useEffect, useMemo } from 'react';
 
 export const useSetMessageList = (messages, shouldRender) => {
   const [loading, setLoading] = useState(true);
-  const [messageList, setMessageList] = useState([]);
+
+  const messageList = useMemo(
+    () => messages.filter(shouldRender),
+    [messages, shouldRender]
+  );
 
   useEffect(() => {
-    setLoading(true);
-    const filteredMessages = messages.filter((message) =>
-      shouldRender(message)
-    );
-
-    setMessageList(filteredMessages);
     setLoading(false);
   }, [messages, shouldRender]);
 

--- a/packages/react/src/views/MessageAggregators/StarredMessages.js
+++ b/packages/react/src/views/MessageAggregators/StarredMessages.js
@@ -1,4 +1,4 @@
-import React from 'react';
+import React, { useCallback } from 'react';
 import { useComponentOverrides } from '@embeddedchat/ui-elements';
 import { useUserStore } from '../../store';
 import { MessageAggregator } from './common/MessageAggregator';
@@ -8,12 +8,9 @@ const StarredMessages = () => {
   const { variantOverrides } = useComponentOverrides('StarredMessages');
   const viewType = variantOverrides.viewType || 'Sidebar';
   const shouldRender = useCallback(
-    (msg) => {
-      return (
-        msg.starred &&
-        msg.starred.some((star) => star._id === authenticatedUserId)
-      );
-    },
+    (msg) =>
+      msg.starred &&
+      msg.starred.some((star) => star._id === authenticatedUserId),
     [authenticatedUserId]
   );
   return (

--- a/packages/react/src/views/MessageAggregators/StarredMessages.js
+++ b/packages/react/src/views/MessageAggregators/StarredMessages.js
@@ -7,15 +7,21 @@ const StarredMessages = () => {
   const authenticatedUserId = useUserStore((state) => state.userId);
   const { variantOverrides } = useComponentOverrides('StarredMessages');
   const viewType = variantOverrides.viewType || 'Sidebar';
+  const shouldRender = useCallback(
+    (msg) => {
+      return (
+        msg.starred &&
+        msg.starred.some((star) => star._id === authenticatedUserId)
+      );
+    },
+    [authenticatedUserId]
+  );
   return (
     <MessageAggregator
       title="Starred Messages"
       iconName="star"
       noMessageInfo="No Starred Messages"
-      shouldRender={(msg) =>
-        msg.starred &&
-        msg.starred.some((star) => star._id === authenticatedUserId)
-      }
+      shouldRender={shouldRender}
       viewType={viewType}
     />
   );

--- a/packages/react/src/views/MessageAggregators/common/MessageAggregator.js
+++ b/packages/react/src/views/MessageAggregators/common/MessageAggregator.js
@@ -1,4 +1,4 @@
-import React, { useState } from 'react';
+import React, { useState, useMemo } from 'react';
 import { isSameDay, format } from 'date-fns';
 import { Box, Sidebar, Popup, useTheme } from '@embeddedchat/ui-elements';
 import { MessageDivider } from '../../Message/MessageDivider';
@@ -27,9 +27,10 @@ export const MessageAggregator = ({
   const setExclusiveState = useSetExclusiveState();
   const messages = useMessageStore((state) => state.messages);
   const threadMessages = useMessageStore((state) => state.threadMessages) || [];
-  const allMessages = useMemo(() => {
-    return [...messages, ...threadMessages];
-  }, [messages, threadMessages]);
+  const allMessages = useMemo(
+    () => [...messages, ...threadMessages],
+    [messages, threadMessages]
+  );
   const [messageRendered, setMessageRendered] = useState(false);
   const { loading, messageList } = useSetMessageList(
     searchFiltered || allMessages,

--- a/packages/react/src/views/MessageAggregators/common/MessageAggregator.js
+++ b/packages/react/src/views/MessageAggregators/common/MessageAggregator.js
@@ -27,7 +27,9 @@ export const MessageAggregator = ({
   const setExclusiveState = useSetExclusiveState();
   const messages = useMessageStore((state) => state.messages);
   const threadMessages = useMessageStore((state) => state.threadMessages) || [];
-  const allMessages = [...messages, ...threadMessages];
+  const allMessages = useMemo(() => {
+    return [...messages, ...threadMessages];
+  }, [messages, threadMessages]);
   const [messageRendered, setMessageRendered] = useState(false);
   const { loading, messageList } = useSetMessageList(
     searchFiltered || allMessages,


### PR DESCRIPTION
# Brief Title
While opening starred messages, useSetMessageList hook was getting re-rendered many infinitely.
## Acceptance Criteria fulfillment

- [ ] Stop the re-rendering while keeping the functionality same.

Fixes #642 

## Video/Screenshots
Previously:


https://github.com/user-attachments/assets/a7bdd883-4e8d-4688-a5ed-a2c0c1a7ff16

Now:


https://github.com/user-attachments/assets/d7f89547-772f-48a6-a303-86a49764c2e6


## PR Test Details
Added memoization to stop the infinite re-render cycle.

**Note**: The PR will be ready for live testing at https://rocketchat.github.io/EmbeddedChat/pulls/pr-<pr_number> after approval.


