### PR TITLE
Fix UI Not Updating Immediately After Pinning/Unpinning Messages

### DIFF
--- a/packages/react/src/views/Message/Message.js
+++ b/packages/react/src/views/Message/Message.js
@@ -91,10 +91,13 @@ const Message = ({
 
   const handlePinMessage = async (msg) => {
     const isPinned = msg.pinned;
+    // Optimistically update the UI
+    msg.pinned = !isPinned;
     const pinOrUnpin = isPinned
       ? await RCInstance.unpinMessage(msg._id)
       : await RCInstance.pinMessage(msg._id);
     if (pinOrUnpin.error) {
+      msg.pinned = isPinned;
       dispatchToastMessage({
         type: 'error',
         message: 'Error pinning message',


### PR DESCRIPTION
# Brief Title
This PR addresses the issue where the UI does not immediately reflect the change when pinning or unpinning a message. The pin icon remains unchanged until the page is refreshed, and the system allows pinning the same message multiple times without updating the UI to show the message is already pinned.

## Acceptance Criteria fulfillment

- Optimistically update the UI by changing the pinned status of the message immediately before making the asynchronous call to pin/unpin the message.
- Revert the change if the asynchronous call fails.


Fixes #653

## Video/Screenshots

https://github.com/user-attachments/assets/fc985902-c59a-4c12-8167-95d52b34f154


## PR Test Details

**Note**: The PR will be ready for live testing at https://rocketchat.github.io/EmbeddedChat/pulls/pr-<pr_number> after approval.


