### PR TITLE
Fix: Prevent repeated API calls in searchMessages after typing stops

### DIFF
--- a/packages/react/src/views/MessageAggregators/SearchMessages.js
+++ b/packages/react/src/views/MessageAggregators/SearchMessages.js
@@ -1,4 +1,4 @@
-import React, { useState, useContext, useEffect } from 'react';
+import React, { useState, useContext, useEffect, useCallback } from 'react';
 import debounce from 'lodash/debounce';
 import { useComponentOverrides } from '@embeddedchat/ui-elements';
 import RCContext from '../../context/RCInstance';
@@ -15,14 +15,17 @@ const SearchMessages = () => {
     setText(e.target.value);
   };
 
-  const searchMessages = async () => {
+  const searchMessages = useCallback(async () => {
     const { messages } = await RCInstance.getSearchMessages(text);
     setMessageList(messages);
-  };
+  }, [text, RCInstance]);
 
-  const debouncedSearch = debounce(async () => {
-    await searchMessages();
-  }, 500);
+  const debouncedSearch = useCallback(
+    debounce(async () => {
+      await searchMessages();
+    }, 500),
+    [searchMessages]
+  );
 
   useEffect(() => {
     if (!text.trim()) {

--- a/packages/react/src/views/MessageAggregators/SearchMessages.js
+++ b/packages/react/src/views/MessageAggregators/SearchMessages.js
@@ -1,6 +1,13 @@
-import React, { useState, useContext, useEffect, useCallback } from 'react';
+import React, {
+  useState,
+  useContext,
+  useEffect,
+  useCallback,
+  useRef,
+} from 'react';
 import debounce from 'lodash/debounce';
-import { useComponentOverrides } from '@embeddedchat/ui-elements';
+import { useComponentOverrides, useTheme } from '@embeddedchat/ui-elements';
+import { css } from '@emotion/react';
 import RCContext from '../../context/RCInstance';
 import { MessageAggregator } from './common/MessageAggregator';
 
@@ -10,18 +17,52 @@ const SearchMessages = () => {
   const { RCInstance } = useContext(RCContext);
   const [text, setText] = useState('');
   const [messageList, setMessageList] = useState([]);
+  const [error, setError] = useState(null);
+
+  const { theme } = useTheme();
+
+  const requestCount = useRef(0);
+  const lastRequestTime = useRef(0);
+  const requestInterval = 1000;
 
   const handleInputChange = (e) => {
     setText(e.target.value);
+    setError(null);
   };
 
   const searchMessages = useCallback(async () => {
-    const { messages } = await RCInstance.getSearchMessages(text);
-    setMessageList(messages);
+    const presentTime = Date.now();
+    if (presentTime - lastRequestTime.current < requestInterval) {
+      return;
+    }
+
+    requestCount.current += 1;
+    lastRequestTime.current = presentTime;
+
+    try {
+      const { messages } = await RCInstance.getSearchMessages(text);
+      setMessageList(messages || []);
+      requestCount.current -= 1;
+    } catch (err) {
+      if (err?.status === 429) {
+        const retryAfter = parseInt(
+          err.headers?.get('Retry-After') || '30',
+          10
+        );
+        setError(`Please wait ${retryAfter} seconds`);
+        setMessageList([]);
+      } else {
+        setError('Failed to search messages');
+      }
+      requestCount.current -= 1;
+    }
   }, [text, RCInstance]);
 
   const debouncedSearch = useCallback(
     debounce(async () => {
+      if (requestCount.current > 0) {
+        return;
+      }
       await searchMessages();
     }, 500),
     [searchMessages]
@@ -32,28 +73,43 @@ const SearchMessages = () => {
       if (messageList.length > 0) {
         setMessageList([]);
       }
+      setError(null);
     } else {
       debouncedSearch();
     }
     return () => {
       debouncedSearch.cancel();
+      requestCount.current = 0;
+      lastRequestTime.current = 0;
     };
   }, [text, debouncedSearch, messageList.length]);
 
   return (
-    <MessageAggregator
-      title="Search Messages"
-      iconName="magnifier"
-      noMessageInfo="No results found"
-      searchProps={{
-        isSearch: true,
-        handleInputChange,
-        placeholder: 'Search Messages',
-      }}
-      searchFiltered={messageList}
-      shouldRender={(msg) => !!msg}
-      viewType={viewType}
-    />
+    <>
+      <MessageAggregator
+        title="Search Messages"
+        iconName="magnifier"
+        noMessageInfo="No results found"
+        searchProps={{
+          isSearch: true,
+          handleInputChange,
+          placeholder: 'Search Messages',
+        }}
+        searchFiltered={messageList}
+        shouldRender={(msg) => !!msg}
+        viewType={viewType}
+      />
+      {error && (
+        <div
+          css={css`
+            color: ${theme.colors.destructive};
+            font-size: 13px;
+          `}
+        >
+          {error}
+        </div>
+      )}
+    </>
   );
 };
 export default SearchMessages;

--- a/packages/react/src/views/MessageAggregators/SearchMessages.js
+++ b/packages/react/src/views/MessageAggregators/SearchMessages.js
@@ -1,13 +1,6 @@
-import React, {
-  useState,
-  useContext,
-  useEffect,
-  useCallback,
-  useRef,
-} from 'react';
+import React, { useState, useContext, useEffect, useCallback } from 'react';
 import debounce from 'lodash/debounce';
-import { useComponentOverrides, useTheme } from '@embeddedchat/ui-elements';
-import { css } from '@emotion/react';
+import { useComponentOverrides } from '@embeddedchat/ui-elements';
 import RCContext from '../../context/RCInstance';
 import { MessageAggregator } from './common/MessageAggregator';
 
@@ -17,52 +10,18 @@ const SearchMessages = () => {
   const { RCInstance } = useContext(RCContext);
   const [text, setText] = useState('');
   const [messageList, setMessageList] = useState([]);
-  const [error, setError] = useState(null);
-
-  const { theme } = useTheme();
-
-  const requestCount = useRef(0);
-  const lastRequestTime = useRef(0);
-  const requestInterval = 1000;
 
   const handleInputChange = (e) => {
     setText(e.target.value);
-    setError(null);
   };
 
   const searchMessages = useCallback(async () => {
-    const presentTime = Date.now();
-    if (presentTime - lastRequestTime.current < requestInterval) {
-      return;
-    }
-
-    requestCount.current += 1;
-    lastRequestTime.current = presentTime;
-
-    try {
-      const { messages } = await RCInstance.getSearchMessages(text);
-      setMessageList(messages || []);
-      requestCount.current -= 1;
-    } catch (err) {
-      if (err?.status === 429) {
-        const retryAfter = parseInt(
-          err.headers?.get('Retry-After') || '30',
-          10
-        );
-        setError(`Please wait ${retryAfter} seconds`);
-        setMessageList([]);
-      } else {
-        setError('Failed to search messages');
-      }
-      requestCount.current -= 1;
-    }
+    const { messages } = await RCInstance.getSearchMessages(text);
+    setMessageList(messages);
   }, [text, RCInstance]);
 
   const debouncedSearch = useCallback(
     debounce(async () => {
-      if (requestCount.current > 0) {
-        return;
-      }
       await searchMessages();
     }, 500),
     [searchMessages]
@@ -73,43 +32,28 @@ const SearchMessages = () => {
       if (messageList.length > 0) {
         setMessageList([]);
       }
-      setError(null);
     } else {
       debouncedSearch();
     }
     return () => {
       debouncedSearch.cancel();
-      requestCount.current = 0;
-      lastRequestTime.current = 0;
     };
   }, [text, debouncedSearch, messageList.length]);
 
   return (
-    <>
-      <MessageAggregator
-        title="Search Messages"
-        iconName="magnifier"
-        noMessageInfo="No results found"
-        searchProps={{
-          isSearch: true,
-          handleInputChange,
-          placeholder: 'Search Messages',
-        }}
-        searchFiltered={messageList}
-        shouldRender={(msg) => !!msg}
-        viewType={viewType}
-      />
-      {error && (
-        <div
-          css={css`
-            color: ${theme.colors.destructive};
-            font-size: 13px;
-          `}
-        >
-          {error}
-        </div>
-      )}
-    </>
+    <MessageAggregator
+      title="Search Messages"
+      iconName="magnifier"
+      noMessageInfo="No results found"
+      searchProps={{
+        isSearch: true,
+        handleInputChange,
+        placeholder: 'Search Messages',
+      }}
+      searchFiltered={messageList}
+      shouldRender={(msg) => !!msg}
+      viewType={viewType}
+    />
   );
 };
 export default SearchMessages;


### PR DESCRIPTION
# Brief Title

Memoized `debouncedSearch` with `useCallback` to prevent re-creation on each render

## Acceptance Criteria fulfillment

- [x] Ensure searchMessages is only called once after typing stops by debouncing the API call effectively.
- [x] Refactor useEffect dependencies to prevent redundant re-renders in the SearchMessages component.

Fixes #650 

## Video/Screenshots

https://github.com/user-attachments/assets/5383b878-7e16-4225-b8a8-fb8411181057

Continuous API calls have been fixed 
## PR Test Details


**Note**: The PR will be ready for live testing at https://rocketchat.github.io/EmbeddedChat/pulls/pr-<pr_number> after approval.


