### PR TITLE
Trim Whitespaces in Username/Email Fields in EmbeddedChat Login Form

### DIFF
--- a/packages/api/src/EmbeddedChatApi.ts
+++ b/packages/api/src/EmbeddedChatApi.ts
@@ -121,12 +121,12 @@ export default class EmbeddedChatApi {
     let credentials;
     if (!code) {
       credentials = credentials = {
-        user: userOrEmail,
+        user: userOrEmail.trim(),
         password,
       };
     } else {
       credentials = {
-        user: userOrEmail,
+        user: userOrEmail.trim(),
         password,
         code,
       };

--- a/packages/react/src/views/LoginForm/LoginForm.js
+++ b/packages/react/src/views/LoginForm/LoginForm.js
@@ -52,7 +52,7 @@ export default function LoginForm() {
   };
 
   const handleEdituserOrEmail = (e) => {
-    setUserOrEmail(e.target.value);
+    setUserOrEmail(e.target.value.trim());
   };
   const handleEditPassword = (e) => {
     setPassword(e.target.value);

--- a/packages/react/src/views/LoginForm/LoginForm.js
+++ b/packages/react/src/views/LoginForm/LoginForm.js
@@ -52,7 +52,7 @@ export default function LoginForm() {
   };
 
   const handleEdituserOrEmail = (e) => {
-    setUserOrEmail(e.target.value.trim());
+    setUserOrEmail(e.target.value);
   };
   const handleEditPassword = (e) => {
     setPassword(e.target.value);


### PR DESCRIPTION
# Brief Title
Trim Whitespaces in Username/Email Fields in EmbeddedChat Login Form

## Acceptance Criteria Fulfillment

- [x] Task 1: Add logic to trim whitespaces in username/email fields on login form submission.
- [x] Task 2: Test and verify that users can log in successfully even with accidental spaces.

Fixes #656 

## Video/Screenshots

https://github.com/user-attachments/assets/5303abd9-294c-4b1f-a697-5d0b8841eaba

I did not trim for passwords because while registering on rocket chat , they allow having whitespaces after some `password` has been written

## PR Test Details
**Note**: The PR will be ready for live testing at https://rocketchat.github.io/EmbeddedChat/pulls/pr-<pr_number> after approval.
