### PR TITLE
Added a validation check for pr approval in the deploy-pr workflow

### DIFF
--- a/.github/workflows/build-pr.yml
+++ b/.github/workflows/build-pr.yml
@@ -46,6 +46,15 @@ jobs:
         run: yarn build
         working-directory: packages/docs/
 
+      - name: Save PR Number
+        run: echo "${{ github.event.pull_request.number }}" > pr_number.txt
+
+      - name: Upload PR Number Artifact
+        uses: actions/upload-artifact@v4
+        with:
+          name: pr-number
+          path: pr_number.txt
+
       - name: Prepare Build Folder
         run: |
           mkdir -p build/pulls/pr-${{github.event.pull_request.number}}/

--- a/.github/workflows/build-pr.yml
+++ b/.github/workflows/build-pr.yml
@@ -12,7 +12,7 @@ env:
   LAYOUT_EDITOR_BASE_URL: "/EmbeddedChat/pulls/pr-${{github.event.pull_request.number}}/layout_editor"
   DOCS_BASE_URL: "/EmbeddedChat/pulls/pr-${{github.event.pull_request.number}}/docs"
   STORYBOOK_RC_HOST: "https://demo.qa.rocket.chat"
-  
+
 jobs:
   build:
     if: github.event.review.state == 'approved' && (github.event.review.author_association == 'COLLABORATOR' || github.event.review.author_association == 'OWNER')
@@ -21,6 +21,15 @@ jobs:
     steps:
       - name: Checkout code
         uses: actions/checkout@v2
+
+      - name: Get user
+        run: echo "${{ github.event.pull_request.head.repo.owner.login }}" > user.txt
+
+      - name: Upload Artifacts
+        uses: actions/upload-artifact@v4
+        with:
+          name: user
+          path: user.txt
 
       - name: Setup Node.js
         uses: actions/setup-node@v4

--- a/.github/workflows/build-pr.yml
+++ b/.github/workflows/build-pr.yml
@@ -46,15 +46,6 @@ jobs:
         run: yarn build
         working-directory: packages/docs/
 
-      - name: Save PR Number
-        run: echo "${{ github.event.pull_request.number }}" > pr_number.txt
-
-      - name: Upload PR Number Artifact
-        uses: actions/upload-artifact@v4
-        with:
-          name: pr-number
-          path: pr_number.txt
-
       - name: Prepare Build Folder
         run: |
           mkdir -p build/pulls/pr-${{github.event.pull_request.number}}/

--- a/.github/workflows/deploy-pr.yml
+++ b/.github/workflows/deploy-pr.yml
@@ -1,28 +1,38 @@
 name: Deploy PR-Preview
-
 on:
   workflow_run:
     workflows: ["Build PR-Preview"]
     types:
       - completed
-
 permissions:
   contents: write
   pages: write
-
 jobs:
   deploy:
     if: github.event.workflow_run.conclusion == 'success'
     runs-on: ubuntu-latest
-
     steps:
+      - uses: actions/download-artifact@v4
+        with:
+          name: user
+          path: .
+          github-token: ${{github.token}}
+          repository: ${{github.repository}}
+          run-id: ${{github.event.workflow_run.id}}
+
+      - name: Get user
+        id: get_user
+        run: |
+          USER=$(cat user.txt)
+          echo "USER=$USER" >> $GITHUB_ENV
+
       - name: Get Pull Request Number
         id: get_pr_number
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
         run: |
           PR_NUMBER=$(curl -s -H "Authorization: token $GITHUB_TOKEN" \
-            "https://api.github.com/repos/${{ github.repository }}/pulls?head=${{ github.repository_owner }}:${{ github.head_ref }}" \
+             "https://api.github.com/repos/${{ github.repository }}/pulls?head=${{env.USER}}:${{ github.event.workflow_run.head_branch }}" \
             | jq -r '.[0].number')
           echo "PR_NUMBER=$PR_NUMBER" >> $GITHUB_ENV
 

--- a/.github/workflows/deploy-pr.yml
+++ b/.github/workflows/deploy-pr.yml
@@ -55,6 +55,7 @@ jobs:
           fi
 
       - uses: actions/download-artifact@v4
+        if: success()
         with:
           name: github-pages
           path: build/
@@ -63,6 +64,7 @@ jobs:
           run-id: ${{github.event.workflow_run.id}}
 
       - name: Deploy to GitHub Pages
+        if: success()
         uses: crazy-max/ghaction-github-pages@v2
         with:
           target_branch: gh-deploy

--- a/.github/workflows/deploy-pr.yml
+++ b/.github/workflows/deploy-pr.yml
@@ -16,6 +16,44 @@ jobs:
     runs-on: ubuntu-latest
 
     steps:
+
+      - name: Download PR Number Artifact
+        uses: actions/download-artifact@v4
+        with:
+          name: pr-number
+          path: .
+          github-token: ${{github.token}}
+          repository: ${{github.repository}}
+          run-id: ${{github.event.workflow_run.id}}
+
+      - name: Check PR Approval Status
+        id: approval_check
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        run: |
+          PR_NUMBER=$(cat pr_number.txt)
+
+          RESPONSE=$(curl -s -H "Authorization: token $GITHUB_TOKEN" \
+            "https://api.github.com/repos/${{ github.repository }}/pulls/$PR_NUMBER/reviews")
+
+          if ! echo "$RESPONSE" | jq . > /dev/null 2>&1; then
+            echo "Error: Invalid JSON response from GitHub API."
+            exit 1
+          fi
+
+          LATEST_REVIEW=$(echo "$RESPONSE" | jq 'sort_by(.submitted_at) | last')
+
+          STATE=$(echo "$LATEST_REVIEW" | jq -r '.state')
+          AUTHOR_ASSOCIATION=$(echo "$LATEST_REVIEW" | jq -r '.author_association')
+
+          echo "Latest review state: $STATE"
+          echo "Author association: $AUTHOR_ASSOCIATION"
+
+          if [ "$STATE" != "APPROVED" ] || { [ "$AUTHOR_ASSOCIATION" != "COLLABORATOR" ] && [ "$AUTHOR_ASSOCIATION" != "OWNER" ]; }; then
+            echo "The latest review is not an approved review from a collaborator or owner. Exiting."
+            exit 1
+          fi
+
       - uses: actions/download-artifact@v4
         with:
           name: github-pages

--- a/.github/workflows/deploy-pr.yml
+++ b/.github/workflows/deploy-pr.yml
@@ -16,22 +16,22 @@ jobs:
     runs-on: ubuntu-latest
 
     steps:
-
-      - name: Download PR Number Artifact
-        uses: actions/download-artifact@v4
-        with:
-          name: pr-number
-          path: .
-          github-token: ${{github.token}}
-          repository: ${{github.repository}}
-          run-id: ${{github.event.workflow_run.id}}
+      - name: Get Pull Request Number
+        id: get_pr_number
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        run: |
+          PR_NUMBER=$(curl -s -H "Authorization: token $GITHUB_TOKEN" \
+            "https://api.github.com/repos/${{ github.repository }}/pulls?head=${{ github.repository_owner }}:${{ github.head_ref }}" \
+            | jq -r '.[0].number')
+          echo "PR_NUMBER=$PR_NUMBER" >> $GITHUB_ENV
 
       - name: Check PR Approval Status
         id: approval_check
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
         run: |
-          PR_NUMBER=$(cat pr_number.txt)
+          PR_NUMBER=${{ env.PR_NUMBER }}
 
           RESPONSE=$(curl -s -H "Authorization: token $GITHUB_TOKEN" \
             "https://api.github.com/repos/${{ github.repository }}/pulls/$PR_NUMBER/reviews")


### PR DESCRIPTION
This Pull request adds an additional pr approval check in `deploy-pr.yml` workflow. This adds validation to ensure the deploy-pr workflow runs only after PRs are approved by collaborators or owners. The GitHub API is used to verify approval status, preventing unauthorized deployments from forked repositories.

## Acceptance Criteria fulfillment

- [x] Add an approval validation check in the `deploy-pr` workflow

## Videos/Screenshots
N/A