### PR TITLE
Fix: Display emoji in visual format and enable send icon on emoji selection

### DIFF
--- a/packages/react/src/views/ChatInput/ChatInput.js
+++ b/packages/react/src/views/ChatInput/ChatInput.js
@@ -33,6 +33,7 @@ import { getChatInputStyles } from './ChatInput.styles';
 import useShowCommands from '../../hooks/useShowCommands';
 import useSearchMentionUser from '../../hooks/useSearchMentionUser';
 import formatSelection from '../../lib/formatSelection';
+import { parseEmoji } from '../../lib/emoji';
 
 const ChatInput = ({ scrollToBottom }) => {
   const { styleOverrides, classNames } = useComponentOverrides('ChatInput');
@@ -148,10 +149,6 @@ const ChatInput = ({ scrollToBottom }) => {
       }
     });
   }, [RCInstance, isChannelPrivate, setMembersHandler]);
-
-  const trigger = (val) => {
-    setDisableButton(!val.trim().length);
-  };
 
   useEffect(() => {
     if (editMessage.attachments) {
@@ -365,14 +362,16 @@ const ChatInput = ({ scrollToBottom }) => {
     setData(event.target.files[0]);
   };
 
-  const onTextChange = (e) => {
+  const onTextChange = (e, val) => {
     sendTypingStart();
-    const message = e.target.value;
-    messageRef.current.value = message;
+    const message = val || e.target.value;
+    messageRef.current.value = parseEmoji(message);
     setDisableButton(!messageRef.current.value.length);
-    handleNewLine(e, false);
-    searchMentionUser(message);
-    showCommands(e);
+    if (e !== null) {
+      handleNewLine(e, false);
+      searchMentionUser(message);
+      showCommands(e);
+    }
   };
 
   const handleFocus = () => {
@@ -535,7 +534,7 @@ const ChatInput = ({ scrollToBottom }) => {
           <ChatInputFormattingToolbar
             messageRef={messageRef}
             inputRef={inputRef}
-            triggerButton={trigger}
+            triggerButton={onTextChange}
           />
         )}
       </Box>

--- a/packages/react/src/views/ChatInput/ChatInput.js
+++ b/packages/react/src/views/ChatInput/ChatInput.js
@@ -25,7 +25,6 @@ import useAttachmentWindowStore from '../../store/attachmentwindow';
 import MembersList from '../Mentions/MembersList';
 import { TypingUsers } from '../TypingUsers';
 import createPendingMessage from '../../lib/createPendingMessage';
-import { parseEmoji } from '../../lib/emoji';
 import { CommandsList } from '../CommandList';
 import useSettingsStore from '../../store/settingsStore';
 import ChannelState from '../ChannelState/ChannelState';
@@ -149,6 +148,10 @@ const ChatInput = ({ scrollToBottom }) => {
       }
     });
   }, [RCInstance, isChannelPrivate, setMembersHandler]);
+
+  const trigger = (val) => {
+    setDisableButton(!val.trim().length);
+  };
 
   useEffect(() => {
     if (editMessage.attachments) {
@@ -365,7 +368,7 @@ const ChatInput = ({ scrollToBottom }) => {
   const onTextChange = (e) => {
     sendTypingStart();
     const message = e.target.value;
-    messageRef.current.value = parseEmoji(message);
+    messageRef.current.value = message;
     setDisableButton(!messageRef.current.value.length);
     handleNewLine(e, false);
     searchMentionUser(message);
@@ -532,6 +535,7 @@ const ChatInput = ({ scrollToBottom }) => {
           <ChatInputFormattingToolbar
             messageRef={messageRef}
             inputRef={inputRef}
+            triggerButton={trigger}
           />
         )}
       </Box>

--- a/packages/react/src/views/ChatInput/ChatInputFormattingToolbar.js
+++ b/packages/react/src/views/ChatInput/ChatInputFormattingToolbar.js
@@ -15,10 +15,12 @@ import AudioMessageRecorder from './AudioMessageRecorder';
 import VideoMessageRecorder from './VideoMessageRecoder';
 import { getChatInputFormattingToolbarStyles } from './ChatInput.styles';
 import formatSelection from '../../lib/formatSelection';
+import { parseEmoji } from '../../lib/emoji';
 
 const ChatInputFormattingToolbar = ({
   messageRef,
   inputRef,
+  triggerButton,
   optionConfig = {
     surfaceItems: ['emoji', 'formatter', 'audio', 'video', 'file'],
     formatters: ['bold', 'italic', 'strike', 'code', 'multiline'],
@@ -46,7 +48,12 @@ const ChatInputFormattingToolbar = ({
 
   const handleEmojiClick = (emojiEvent) => {
     const [emoji] = emojiEvent.names;
-    messageRef.current.value += ` :${emoji.replace(/[\s-]+/g, '_')}: `;
+    const message = `${messageRef.current.value} :${emoji.replace(
+      /[\s-]+/g,
+      '_'
+    )}: `;
+    messageRef.current.value = parseEmoji(message);
+    triggerButton?.(message);
   };
 
   const chatToolMap = {

--- a/packages/react/src/views/ChatInput/ChatInputFormattingToolbar.js
+++ b/packages/react/src/views/ChatInput/ChatInputFormattingToolbar.js
@@ -15,7 +15,6 @@ import AudioMessageRecorder from './AudioMessageRecorder';
 import VideoMessageRecorder from './VideoMessageRecoder';
 import { getChatInputFormattingToolbarStyles } from './ChatInput.styles';
 import formatSelection from '../../lib/formatSelection';
-import { parseEmoji } from '../../lib/emoji';
 
 const ChatInputFormattingToolbar = ({
   messageRef,
@@ -52,8 +51,7 @@ const ChatInputFormattingToolbar = ({
       /[\s-]+/g,
       '_'
     )}: `;
-    messageRef.current.value = parseEmoji(message);
-    triggerButton?.(message);
+    triggerButton?.(null, message);
   };
 
   const chatToolMap = {


### PR DESCRIPTION
# Brief Title
Fix emoji display format and enable send icon on emoji selection

## Acceptance Criteria fulfillment

- [x] Emoji should display in visual format within the input box on selection.
- [x] Send icon should be enabled upon selecting an emoji.

Fixes #662

## Video/Screenshots

https://github.com/user-attachments/assets/6647b85a-8e6e-4391-9cea-f0692a92332a


## PR Test Details

**Note**: The PR will be ready for live testing at [https://rocketchat.github.io/EmbeddedChat/pulls/pr-663](https://rocketchat.github.io/EmbeddedChat/pulls/pr-663) after approval. Contributors are requested to replace `<pr_number>` with the actual PR number.
