### PR TITLE
Made message box responsive and fixed alignment

### DIFF
--- a/packages/react/src/views/ChatBody/ChatBody.styles.js
+++ b/packages/react/src/views/ChatBody/ChatBody.styles.js
@@ -9,7 +9,7 @@ export const getChatbodyStyles = () => {
       overflow-x: hidden;
       display: flex;
       flex-direction: column-reverse;
-      max-height: 600px;
+      max-height: 100%;
       position: relative;
       padding-top: 70px;
       margin-top: 0.25rem;

--- a/packages/react/src/views/ChatInput/ChatInput.styles.js
+++ b/packages/react/src/views/ChatInput/ChatInput.styles.js
@@ -22,6 +22,9 @@ export const getChatInputStyles = (theme) => {
       justify-content: center;
       flex-direction: row;
       padding: 0.5rem;
+      @media (max-width: 383px) {
+        min-height: 100px;
+      }
     `,
 
     iconCursor: css`
@@ -51,6 +54,9 @@ export const getChatInputStyles = (theme) => {
       &::placeholder {
         padding-left: 5px;
       }
+      @media (max-width: 383px) {
+        font-size: 18px;
+      }
     `,
   };
 
@@ -68,9 +74,12 @@ export const getChatInputFormattingToolbarStyles = ({ theme, mode }) => {
         : lighten(theme.colors.background, 1)};
       display: flex;
       position: relative;
-      flex-direction: row;
-      gap: 0.375rem;
+      gap: 0.1rem;
       border-radius: 0 0 ${theme.radius} ${theme.radius};
+      @media (max-width: 383px) {
+        display: grid;
+        grid-template-columns: repeat(5, 0.2fr);
+      }
     `,
   };
   return styles;

--- a/packages/react/src/views/ChatLayout/ChatLayout.styles.js
+++ b/packages/react/src/views/ChatLayout/ChatLayout.styles.js
@@ -12,6 +12,7 @@ const styles = {
     flex: 1;
     flex-direction: column;
     position: relative;
+    min-width: 0;
   `,
 
   sidebar: css`


### PR DESCRIPTION
# Brief Title
Made message box responsive and fixed alignment

## Acceptance Criteria fulfillment

- [ ] Set the min-width of the chat layout to 0 to improve responsiveness.
- [ ] Updated the chat formatter tool to use display: grid for better layout handling on screens narrower than 383px.
- [ ] Aligned the message box to the bottom by setting the chat body max-height to 100%.

Fixes # (issue)
#616 , #629 
## Video/Screenshots

[message-box.webm](https://github.com/user-attachments/assets/cf6c175c-fdd1-4542-9d48-b90e40b895da)

## PR Test Details

**Note**: The PR will be ready for live testing at https://rocketchat.github.io/EmbeddedChat/pulls/pr-664 after approval. Contributors are requested to replace `<pr_number>` with the actual PR number.
