### PR TITLE
Fix: Sidebar starred messages fetched by api to include thread messages.

### DIFF
--- a/packages/react/src/hooks/useFetchChatData.js
+++ b/packages/react/src/hooks/useFetchChatData.js
@@ -5,6 +5,7 @@ import {
   useChannelStore,
   useMemberStore,
   useMessageStore,
+  useStarredMessageStore,
 } from '../store';
 
 const useFetchChatData = (showRoles) => {
@@ -13,6 +14,7 @@ const useFetchChatData = (showRoles) => {
   const isChannelPrivate = useChannelStore((state) => state.isChannelPrivate);
   const setMessages = useMessageStore((state) => state.setMessages);
   const setAdmins = useMemberStore((state) => state.setAdmins);
+  const setStarredMessages=useStarredMessageStore((state)=>state.setStarredMessages)
   const isUserAuthenticated = useUserStore(
     (state) => state.isUserAuthenticated
   );
@@ -78,9 +80,29 @@ const useFetchChatData = (showRoles) => {
       setAdmins,
       setMemberRoles,
     ]
+    
   );
 
-  return getMessagesAndRoles;
+  const getStarredMessages = useCallback(
+    async (anonymousMode) => {
+      console.log("asjlndlkas")
+      if (isUserAuthenticated) {
+        try {
+          if (!isUserAuthenticated && !anonymousMode) {
+            return;
+          }
+          const { messages } = await RCInstance.getStarredMessages();
+          console.log("starred messages", messages);
+          setStarredMessages(messages);
+        } catch (e) {
+          console.error(e);
+        }
+      }
+    },
+    [isUserAuthenticated, RCInstance, setStarredMessages]
+  );
+
+  return { getMessagesAndRoles, getStarredMessages };
 };
 
 export default useFetchChatData;

--- a/packages/react/src/hooks/useFetchChatData.js
+++ b/packages/react/src/hooks/useFetchChatData.js
@@ -14,7 +14,9 @@ const useFetchChatData = (showRoles) => {
   const isChannelPrivate = useChannelStore((state) => state.isChannelPrivate);
   const setMessages = useMessageStore((state) => state.setMessages);
   const setAdmins = useMemberStore((state) => state.setAdmins);
-  const setStarredMessages=useStarredMessageStore((state)=>state.setStarredMessages)
+  const setStarredMessages = useStarredMessageStore(
+    (state) => state.setStarredMessages
+  );
   const isUserAuthenticated = useUserStore(
     (state) => state.isUserAuthenticated
   );
@@ -80,19 +82,16 @@ const useFetchChatData = (showRoles) => {
       setAdmins,
       setMemberRoles,
     ]
-    
   );
 
   const getStarredMessages = useCallback(
     async (anonymousMode) => {
-      console.log("asjlndlkas")
       if (isUserAuthenticated) {
         try {
           if (!isUserAuthenticated && !anonymousMode) {
             return;
           }
           const { messages } = await RCInstance.getStarredMessages();
-          console.log("starred messages", messages);
           setStarredMessages(messages);
         } catch (e) {
           console.error(e);

--- a/packages/react/src/store/starredMessageStore.js
+++ b/packages/react/src/store/starredMessageStore.js
@@ -3,8 +3,8 @@ import { create } from 'zustand';
 const useStarredMessageStore = create((set) => ({
   showStarred: false,
   setShowStarred: (showStarred) => set(() => ({ showStarred })),
-  starredMessages:[],
-  setStarredMessages:(messages)=>set(()=>({starredMessages:messages}))
+  starredMessages: [],
+  setStarredMessages: (messages) => set(() => ({ starredMessages: messages })),
 }));
 
 export default useStarredMessageStore;

--- a/packages/react/src/store/starredMessageStore.js
+++ b/packages/react/src/store/starredMessageStore.js
@@ -3,6 +3,8 @@ import { create } from 'zustand';
 const useStarredMessageStore = create((set) => ({
   showStarred: false,
   setShowStarred: (showStarred) => set(() => ({ showStarred })),
+  starredMessages:[],
+  setStarredMessages:(messages)=>set(()=>({starredMessages:messages}))
 }));
 
 export default useStarredMessageStore;

--- a/packages/react/src/views/ChatBody/ChatBody.js
+++ b/packages/react/src/views/ChatBody/ChatBody.js
@@ -103,7 +103,6 @@ const ChatBody = ({
 
   const addMessage = useCallback(
     (message) => {
-      console.log("message from listener",message)
       if (message.u.username !== username) {
         const isScrolledUp = messageListRef?.current?.scrollTop !== 0;
         if (isScrolledUp && !('pinned' in message) && !('starred' in message)) {

--- a/packages/react/src/views/ChatBody/ChatBody.js
+++ b/packages/react/src/views/ChatBody/ChatBody.js
@@ -69,7 +69,7 @@ const ChatBody = ({
 
   const username = useUserStore((state) => state.username);
 
-  const getMessagesAndRoles = useFetchChatData(showRoles);
+  const { getMessagesAndRoles } = useFetchChatData(showRoles);
 
   const getThreadMessages = useCallback(async () => {
     if (isUserAuthenticated && threadMainMessage?._id) {
@@ -103,6 +103,7 @@ const ChatBody = ({
 
   const addMessage = useCallback(
     (message) => {
+      console.log("message from listener",message)
       if (message.u.username !== username) {
         const isScrolledUp = messageListRef?.current?.scrollTop !== 0;
         if (isScrolledUp && !('pinned' in message) && !('starred' in message)) {

--- a/packages/react/src/views/ChatHeader/ChatHeader.js
+++ b/packages/react/src/views/ChatHeader/ChatHeader.js
@@ -86,7 +86,7 @@ const ChatHeader = ({
   );
 
   const dispatchToastMessage = useToastBarDispatch();
-  const getMessagesAndRoles = useFetchChatData(showRoles);
+  const { getMessagesAndRoles } = useFetchChatData(showRoles);
   const setMessageLimit = useSettingsStore((state) => state.setMessageLimit);
 
   const avatarUrl = useUserStore((state) => state.avatarUrl);

--- a/packages/react/src/views/ChatLayout/ChatLayout.js
+++ b/packages/react/src/views/ChatLayout/ChatLayout.js
@@ -1,4 +1,4 @@
-import React, { useRef } from 'react';
+import React, { useEffect, useRef, useCallback, useState } from 'react';
 import { Box, useComponentOverrides } from '@embeddedchat/ui-elements';
 import styles from './ChatLayout.styles';
 import {
@@ -36,9 +36,11 @@ import useUiKitStore from '../../store/uiKitStore';
 const ChatLayout = () => {
   const messageListRef = useRef(null);
   const { classNames, styleOverrides } = useComponentOverrides('ChatBody');
-  const { ECOptions } = useRCContext();
+  const { RCInstance,ECOptions } = useRCContext();
   const anonymousMode = ECOptions?.anonymousMode;
   const showRoles = ECOptions?.anonymousMode;
+  const setStarredMessages=useStarredMessageStore((state)=>state.setStarredMessages)
+  const starredMessages=useStarredMessageStore((state)=>state.starredMessages)
   const showSidebar = useSidebarStore((state) => state.showSidebar);
   const showMentions = useMentionsStore((state) => state.showMentions);
   const showAllFiles = useFileStore((state) => state.showAllFiles);
@@ -57,6 +59,9 @@ const ChatLayout = () => {
   const attachmentWindowOpen = useAttachmentWindowStore(
     (state) => state.attachmentWindowOpen
   );
+  const isUserAuthenticated = useUserStore(
+    (state) => state.isUserAuthenticated
+  );
   const { data, handleDrag, handleDragDrop } = useDropBox();
   const { uiKitContextualBarOpen, uiKitContextualBarData } = useUiKitStore(
     (state) => ({
@@ -72,7 +77,27 @@ const ChatLayout = () => {
       });
     }
   };
-
+  const getStarredMessages = useCallback(async () => {
+    if (isUserAuthenticated) {
+      try {
+        if (!isUserAuthenticated && !anonymousMode) {
+          return;
+        }
+        const { messages } = await RCInstance.getStarredMessages();
+        console.log("starred messages",messages)
+        setStarredMessages(messages)
+      } catch (e) {
+        console.error(e);
+      }
+    }
+  }, [
+    isUserAuthenticated,
+    anonymousMode,
+    RCInstance
+  ]);
+  useEffect(()=>{
+    getStarredMessages()
+  },[showSidebar])
   return (
     <Box
       css={styles.layout}
@@ -103,7 +128,7 @@ const ChatLayout = () => {
           {showAllFiles && <FileGallery />}
           {showMentions && <MentionedMessages />}
           {showPinned && <PinnedMessages />}
-          {showStarred && <StarredMessages />}
+          {showStarred && <StarredMessages/>}
           {showCurrentUserInfo && <UserInformation />}
           {uiKitContextualBarOpen && (
             <UiKitContextualBar

--- a/packages/react/src/views/ChatLayout/ChatLayout.js
+++ b/packages/react/src/views/ChatLayout/ChatLayout.js
@@ -36,11 +36,15 @@ import useUiKitStore from '../../store/uiKitStore';
 const ChatLayout = () => {
   const messageListRef = useRef(null);
   const { classNames, styleOverrides } = useComponentOverrides('ChatBody');
-  const { RCInstance,ECOptions } = useRCContext();
+  const { RCInstance, ECOptions } = useRCContext();
   const anonymousMode = ECOptions?.anonymousMode;
   const showRoles = ECOptions?.anonymousMode;
-  const setStarredMessages=useStarredMessageStore((state)=>state.setStarredMessages)
-  const starredMessages=useStarredMessageStore((state)=>state.starredMessages)
+  const setStarredMessages = useStarredMessageStore(
+    (state) => state.setStarredMessages
+  );
+  const starredMessages = useStarredMessageStore(
+    (state) => state.starredMessages
+  );
   const showSidebar = useSidebarStore((state) => state.showSidebar);
   const showMentions = useMentionsStore((state) => state.showMentions);
   const showAllFiles = useFileStore((state) => state.showAllFiles);
@@ -84,20 +88,15 @@ const ChatLayout = () => {
           return;
         }
         const { messages } = await RCInstance.getStarredMessages();
-        console.log("starred messages",messages)
-        setStarredMessages(messages)
+        setStarredMessages(messages);
       } catch (e) {
         console.error(e);
       }
     }
-  }, [
-    isUserAuthenticated,
-    anonymousMode,
-    RCInstance
-  ]);
-  useEffect(()=>{
-    getStarredMessages()
-  },[showSidebar])
+  }, [isUserAuthenticated, anonymousMode, RCInstance]);
+  useEffect(() => {
+    getStarredMessages();
+  }, [showSidebar]);
   return (
     <Box
       css={styles.layout}
@@ -128,7 +127,7 @@ const ChatLayout = () => {
           {showAllFiles && <FileGallery />}
           {showMentions && <MentionedMessages />}
           {showPinned && <PinnedMessages />}
-          {showStarred && <StarredMessages/>}
+          {showStarred && <StarredMessages />}
           {showCurrentUserInfo && <UserInformation />}
           {uiKitContextualBarOpen && (
             <UiKitContextualBar

--- a/packages/react/src/views/Message/Message.js
+++ b/packages/react/src/views/Message/Message.js
@@ -57,7 +57,7 @@ const Message = ({
   );
   const setQuoteMessage = useMessageStore((state) => state.setQuoteMessage);
   const openThread = useMessageStore((state) => state.openThread);
-  const {getStarredMessages}=useFetchChatData()
+  const { getStarredMessages } = useFetchChatData();
   const dispatchToastMessage = useToastBarDispatch();
   const { editMessage, setEditMessage } = useMessageStore((state) => ({
     editMessage: state.editMessage,

--- a/packages/react/src/views/Message/Message.js
+++ b/packages/react/src/views/Message/Message.js
@@ -24,6 +24,7 @@ import { LinkPreview } from '../LinkPreview';
 import { getMessageStyles } from './Message.styles';
 import useBubbleStyles from './BubbleVariant/useBubbleStyles';
 import UiKitMessageBlock from './uiKit/UiKitMessageBlock';
+import useFetchChatData from '../../hooks/useFetchChatData';
 
 const Message = ({
   message,
@@ -56,7 +57,7 @@ const Message = ({
   );
   const setQuoteMessage = useMessageStore((state) => state.setQuoteMessage);
   const openThread = useMessageStore((state) => state.openThread);
-
+  const {getStarredMessages}=useFetchChatData()
   const dispatchToastMessage = useToastBarDispatch();
   const { editMessage, setEditMessage } = useMessageStore((state) => ({
     editMessage: state.editMessage,
@@ -87,6 +88,7 @@ const Message = ({
         message: 'Message unstarred',
       });
     }
+    getStarredMessages();
   };
 
   const handlePinMessage = async (msg) => {

--- a/packages/react/src/views/MessageAggregators/StarredMessages.js
+++ b/packages/react/src/views/MessageAggregators/StarredMessages.js
@@ -1,23 +1,28 @@
-import React, { useCallback } from 'react';
+import React, { useCallback, useEffect } from 'react';
 import { useComponentOverrides } from '@embeddedchat/ui-elements';
-import { useUserStore } from '../../store';
+import { useStarredMessageStore, useUserStore } from '../../store';
 import { MessageAggregator } from './common/MessageAggregator';
 
 const StarredMessages = () => {
   const authenticatedUserId = useUserStore((state) => state.userId);
   const { variantOverrides } = useComponentOverrides('StarredMessages');
   const viewType = variantOverrides.viewType || 'Sidebar';
+  const starredMessages=useStarredMessageStore((state)=>state.starredMessages)
   const shouldRender = useCallback(
     (msg) =>
       msg.starred &&
       msg.starred.some((star) => star._id === authenticatedUserId),
     [authenticatedUserId]
   );
+  useEffect(()=>{
+    console.log("star",starredMessages)
+  },[starredMessages])
   return (
     <MessageAggregator
       title="Starred Messages"
       iconName="star"
       noMessageInfo="No Starred Messages"
+      messageList={starredMessages}
       shouldRender={shouldRender}
       viewType={viewType}
     />

--- a/packages/react/src/views/MessageAggregators/StarredMessages.js
+++ b/packages/react/src/views/MessageAggregators/StarredMessages.js
@@ -7,22 +7,21 @@ const StarredMessages = () => {
   const authenticatedUserId = useUserStore((state) => state.userId);
   const { variantOverrides } = useComponentOverrides('StarredMessages');
   const viewType = variantOverrides.viewType || 'Sidebar';
-  const starredMessages=useStarredMessageStore((state)=>state.starredMessages)
+  const starredMessages = useStarredMessageStore(
+    (state) => state.starredMessages
+  );
   const shouldRender = useCallback(
     (msg) =>
       msg.starred &&
       msg.starred.some((star) => star._id === authenticatedUserId),
     [authenticatedUserId]
   );
-  useEffect(()=>{
-    console.log("star",starredMessages)
-  },[starredMessages])
   return (
     <MessageAggregator
       title="Starred Messages"
       iconName="star"
       noMessageInfo="No Starred Messages"
-      messageList={starredMessages}
+      fetchedMessageList={starredMessages}
       shouldRender={shouldRender}
       viewType={viewType}
     />

--- a/packages/react/src/views/MessageAggregators/common/MessageAggregator.js
+++ b/packages/react/src/views/MessageAggregators/common/MessageAggregator.js
@@ -44,7 +44,7 @@ export const MessageAggregator = ({
 
   const noMessages = messageList?.length === 0 || !messageRendered;
   const ViewComponent = viewType === 'Popup' ? Popup : Sidebar;
-  
+
   return (
     <ViewComponent
       title={title}

--- a/packages/react/src/views/MessageAggregators/common/MessageAggregator.js
+++ b/packages/react/src/views/MessageAggregators/common/MessageAggregator.js
@@ -16,7 +16,7 @@ export const MessageAggregator = ({
   iconName,
   noMessageInfo,
   shouldRender,
-  messageList,
+  fetchedMessageList,
   searchProps,
   searchFiltered,
   fetching,
@@ -33,19 +33,18 @@ export const MessageAggregator = ({
     [messages, threadMessages]
   );
   const [messageRendered, setMessageRendered] = useState(false);
-  const { loading } = useSetMessageList(
-    searchFiltered || allMessages,
-    shouldRender
-  );
+  const { loading, messageList } = fetchedMessageList
+    ? { loading: false, messageList: fetchedMessageList }
+    : useSetMessageList(searchFiltered || allMessages, shouldRender);
 
   const isMessageNewDay = (current, previous) =>
     !previous ||
-    !shouldRender(previous) ||
+    (fetchedMessageList && shouldRender(previous)) ||
     !isSameDay(new Date(current.ts), new Date(previous.ts));
 
   const noMessages = messageList?.length === 0 || !messageRendered;
   const ViewComponent = viewType === 'Popup' ? Popup : Sidebar;
-  console.log("messages",messages)
+  
   return (
     <ViewComponent
       title={title}
@@ -74,7 +73,7 @@ export const MessageAggregator = ({
 
           {messageList.map((msg, index, arr) => {
             const newDay = isMessageNewDay(msg, arr[index - 1]);
-            if (!messageRendered && shouldRender(msg)) {
+            if (!messageRendered && fetchedMessageList && shouldRender(msg)) {
               setMessageRendered(true);
             }
 

--- a/packages/react/src/views/MessageAggregators/common/MessageAggregator.js
+++ b/packages/react/src/views/MessageAggregators/common/MessageAggregator.js
@@ -16,6 +16,7 @@ export const MessageAggregator = ({
   iconName,
   noMessageInfo,
   shouldRender,
+  messageList,
   searchProps,
   searchFiltered,
   fetching,
@@ -32,7 +33,7 @@ export const MessageAggregator = ({
     [messages, threadMessages]
   );
   const [messageRendered, setMessageRendered] = useState(false);
-  const { loading, messageList } = useSetMessageList(
+  const { loading } = useSetMessageList(
     searchFiltered || allMessages,
     shouldRender
   );
@@ -44,7 +45,7 @@ export const MessageAggregator = ({
 
   const noMessages = messageList?.length === 0 || !messageRendered;
   const ViewComponent = viewType === 'Popup' ? Popup : Sidebar;
-
+  console.log("messages",messages)
   return (
     <ViewComponent
       title={title}

--- a/packages/react/src/views/MessageAggregators/common/MessageAggregator.js
+++ b/packages/react/src/views/MessageAggregators/common/MessageAggregator.js
@@ -33,13 +33,14 @@ export const MessageAggregator = ({
     [messages, threadMessages]
   );
   const [messageRendered, setMessageRendered] = useState(false);
-  const { loading, messageList } = fetchedMessageList
-    ? { loading: false, messageList: fetchedMessageList }
-    : useSetMessageList(searchFiltered || allMessages, shouldRender);
+  const { loading, messageList } = useSetMessageList(
+    fetchedMessageList || searchFiltered || allMessages,
+    shouldRender
+  );
 
   const isMessageNewDay = (current, previous) =>
     !previous ||
-    (fetchedMessageList && shouldRender(previous)) ||
+    shouldRender(previous) ||
     !isSameDay(new Date(current.ts), new Date(previous.ts));
 
   const noMessages = messageList?.length === 0 || !messageRendered;
@@ -73,7 +74,7 @@ export const MessageAggregator = ({
 
           {messageList.map((msg, index, arr) => {
             const newDay = isMessageNewDay(msg, arr[index - 1]);
-            if (!messageRendered && fetchedMessageList && shouldRender(msg)) {
+            if (!messageRendered && shouldRender(msg)) {
               setMessageRendered(true);
             }
 


### PR DESCRIPTION
# Brief Title
Make thread starred messages appear in the sidebar.

## Acceptance Criteria fulfillment

- [ ] Fetch the response from getStarredMessages api instead of filtering it from the messages.
- [ ] Show it in the sidebar menu without breaking other functionalities.

Fixes #668

## Video/Screenshots

https://github.com/user-attachments/assets/a1e5642d-b4b5-425e-adfa-07c90203af9b

Realtime updation


https://github.com/user-attachments/assets/0c493e2a-2691-42b3-a2f1-ef760ee5b324




## PR Test Details

**Note**: The PR will be ready for live testing at https://rocketchat.github.io/EmbeddedChat/pulls/pr-669 after approval. Contributors are requested to replace `<pr_number>` with the actual PR number.
