### PR TITLE
implemented lazy loading to the desired components

### DIFF
--- a/packages/layout_editor/src/views/ChatHeader/ChatHeader.jsx
+++ b/packages/layout_editor/src/views/ChatHeader/ChatHeader.jsx
@@ -1,7 +1,7 @@
 import React, { useState, useMemo } from 'react';
+import { Suspense, lazy } from 'react';
 import { Heading, Box, Icon, useTheme } from '@embeddedchat/ui-elements';
 import { getChatHeaderStyles } from './ChatHeader.styles';
-import { Menu } from '../../components/SortableMenu';
 import SurfaceItem from '../../components/SurfaceMenu/SurfaceItem';
 import {
   DndContext,
@@ -18,6 +18,11 @@ import MenuItem from '../../components/SortableMenu/MenuItem';
 import SurfaceMenu from '../../components/SurfaceMenu/SurfaceMenu';
 import useHeaderItemsStore from '../../store/headerItemsStore';
 
+const Menu = lazy(() =>
+  import('../../components/SortableMenu').then((module) => ({
+    default: module.Menu,
+  }))
+);
 const ChatHeader = () => {
   const styles = getChatHeaderStyles(useTheme());
   const { surfaceItems, menuItems, setSurfaceItems, setMenuItems } =
@@ -267,7 +272,9 @@ const ChatHeader = () => {
               />
             )}
             {menuOptions.length > 0 && (
-              <Menu options={menuOptions} onRemove={removeMenuItem} />
+              <Suspense fallback={<div>Loading...</div>}>
+                <Menu options={menuOptions} onRemove={removeMenuItem} />
+              </Suspense>
             )}
           </Box>
           {createPortal(

--- a/packages/layout_editor/src/views/Message/Message.jsx
+++ b/packages/layout_editor/src/views/Message/Message.jsx
@@ -1,17 +1,23 @@
 import React from 'react';
+import { Suspense, lazy } from 'react';
 import PropTypes from 'prop-types';
 import { format } from 'date-fns';
 import { Box, useTheme } from '@embeddedchat/ui-elements';
 import { Markdown } from '../Markdown';
 import MessageHeader from './MessageHeader';
 import { MessageBody } from './MessageBody';
-import { MessageToolbox } from './MessageToolbox';
 import { MessageDivider } from './MessageDivider';
 import MessageAvatarContainer from './MessageAvatarContainer';
 import MessageBodyContainer from './MessageBodyContainer';
 import { getMessageStyles } from './Message.styles';
 import useBubbleStyles from './BubbleVariant/useBubbleStyles';
 import useLayoutStore from '../../store/layoutStore';
+
+const MessageToolbox = lazy(() =>
+  import('./MessageToolbox').then((module) => ({
+    default: module.MessageToolbox,
+  }))
+);
 
 const Message = ({
   message,
@@ -65,7 +71,9 @@ const Message = ({
                 <Markdown body={message} isReaction={false} />
 
                 {!message.t && message._id === '62vhmKJGNoxgvLL7M' ? (
-                  <MessageToolbox variantStyles={variantStyles} />
+                  <Suspense fallback={<div>Loading...</div>}>
+                    <MessageToolbox variantStyles={variantStyles} />
+                  </Suspense>
                 ) : (
                   <></>
                 )}

--- a/packages/react/src/views/ChatInput/ChatInputFormattingToolbar.js
+++ b/packages/react/src/views/ChatInput/ChatInputFormattingToolbar.js
@@ -1,4 +1,5 @@
 import React, { useState } from 'react';
+import { lazy,Suspense } from 'react';
 import { css } from '@emotion/react';
 import {
   Box,
@@ -8,13 +9,14 @@ import {
   useComponentOverrides,
   useTheme,
 } from '@embeddedchat/ui-elements';
-import { EmojiPicker } from '../EmojiPicker/index';
 import { useMessageStore } from '../../store';
 import { formatter } from '../../lib/textFormat';
-import AudioMessageRecorder from './AudioMessageRecorder';
 import VideoMessageRecorder from './VideoMessageRecoder';
 import { getChatInputFormattingToolbarStyles } from './ChatInput.styles';
 import formatSelection from '../../lib/formatSelection';
+
+const EmojiPicker = lazy(()=>import("../EmojiPicker/index").then(module=>({default:module.EmojiPicker})));
+const AudioMessageRecorder = lazy(()=>import("./AudioMessageRecorder").then(module=>({default:module.AudioMessageRecorder})));
 
 const ChatInputFormattingToolbar = ({
   messageRef,
@@ -71,7 +73,9 @@ const ChatInputFormattingToolbar = ({
     ),
     audio: (
       <Tooltip text="Audio Message" position="top" key="audio">
+        <Suspense fallback={<div>Loading...</div>}>
         <AudioMessageRecorder />
+        </Suspense>
       </Tooltip>
     ),
     video: (
@@ -122,6 +126,7 @@ const ChatInputFormattingToolbar = ({
       {surfaceItems.map((key) => chatToolMap[key])}
 
       {isEmojiOpen && (
+        <Suspense fallback={<div>Loading...</div>}>
         <EmojiPicker
           key="emoji-picker"
           handleEmojiClick={(emoji) => {
@@ -135,6 +140,7 @@ const ChatInputFormattingToolbar = ({
             left: 1.85rem;
           `}
         />
+        </Suspense>
       )}
     </Box>
   );

--- a/packages/react/src/views/Message/Message.js
+++ b/packages/react/src/views/Message/Message.js
@@ -1,4 +1,5 @@
 import React, { memo, useContext } from 'react';
+import {Suspense,lazy} from 'react';
 import PropTypes from 'prop-types';
 import { format } from 'date-fns';
 import {
@@ -8,7 +9,6 @@ import {
   appendClassNames,
   useTheme,
 } from '@embeddedchat/ui-elements';
-import { Attachments } from '../AttachmentHandler';
 import { Markdown } from '../Markdown';
 import MessageHeader from './MessageHeader';
 import { useMessageStore, useUserStore } from '../../store';
@@ -16,7 +16,6 @@ import RCContext from '../../context/RCInstance';
 import { MessageBody } from './MessageBody';
 import { MessageReactions } from './MessageReactions';
 import { MessageMetrics } from './MessageMetrics';
-import { MessageToolbox } from './MessageToolbox';
 import { MessageDivider } from './MessageDivider';
 import MessageAvatarContainer from './MessageAvatarContainer';
 import MessageBodyContainer from './MessageBodyContainer';
@@ -24,6 +23,9 @@ import { LinkPreview } from '../LinkPreview';
 import { getMessageStyles } from './Message.styles';
 import useBubbleStyles from './BubbleVariant/useBubbleStyles';
 import UiKitMessageBlock from './uiKit/UiKitMessageBlock';
+
+const MessageToolbox = lazy(()=>import("./MessageToolbox").then(module=>({default:module.MessageToolbox})));
+const Attachments = lazy(()=>import("../AttachmentHandler").then(module=>({default:module.Attachments})));
 
 const Message = ({
   message,
@@ -178,10 +180,12 @@ const Message = ({
                 {message.attachments && message.attachments.length > 0 ? (
                   <>
                     <Markdown body={message} isReaction={false} />
+                    <Suspense fallback={<div>Loading...</div>}>
                     <Attachments
                       attachments={message.attachments}
                       variantStyles={variantStyles}
                     />
+                    </Suspense>
                   </>
                 ) : (
                   <Markdown body={message} isReaction={false} />
@@ -196,6 +200,7 @@ const Message = ({
                 )}
 
                 {!message.t && showToolbox ? (
+                  <Suspense fallback={<div>Loading...</div>}>
                   <MessageToolbox
                     message={message}
                     isEditing={editMessage._id === message._id}
@@ -219,7 +224,7 @@ const Message = ({
                     }}
                     isThreadMessage={type === 'thread'}
                     variantStyles={variantStyles}
-                  />
+                  /></Suspense>
                 ) : (
                   <></>
                 )}
@@ -250,11 +255,13 @@ const Message = ({
           ) : (
             <>
               {message.attachments && (
+                <Suspense fallback={<div>Loading...</div>}>
                 <Attachments
                   attachments={message.attachments}
                   type={message.t}
                   variantStyles={variantStyles}
                 />
+                </Suspense>
               )}
             </>
           )}


### PR DESCRIPTION
# Brief Title
implemented lazy loading

## Acceptance Criteria fulfillment
- [x] MessageToolbox in Message.js
- [x] Menu in ChatHeader.js
- [x] EmojiPicker in ChatInputFormattingToolbar.js
- [x] AudioMessageRecorder in ChatInputFormattingToolbar.js
- [x] ThreadHeader in ChatHeader.js
- [x] Attachments in Message.js

#Fixes Issue #383

## PR Test Details
I have used react lazy, and suspense to ensure the components are rendered upon there first render and the initial bundle size is reduced
This pull request introduces code-splitting and lazy loading for several components across different parts of the application to improve performance by reducing the initial load time. The changes primarily involve the use of React's `lazy` and `Suspense` for dynamic imports.

Lazy loading and code-splitting:

* [`packages/layout_editor/src/views/ChatHeader/ChatHeader.jsx`](diffhunk://#diff-cc7c1bc78242c4929e8ef1760f84697efbea23dbcc9b136340b5ffb1add88449R2-L4): Added lazy loading for the `Menu` component and wrapped its usage with `Suspense`. [[1]](diffhunk://#diff-cc7c1bc78242c4929e8ef1760f84697efbea23dbcc9b136340b5ffb1add88449R2-L4) [[2]](diffhunk://#diff-cc7c1bc78242c4929e8ef1760f84697efbea23dbcc9b136340b5ffb1add88449R21-R25) [[3]](diffhunk://#diff-cc7c1bc78242c4929e8ef1760f84697efbea23dbcc9b136340b5ffb1add88449R275-R277)
* [`packages/layout_editor/src/views/Message/Message.jsx`](diffhunk://#diff-d354ead063452d8945bc510b6dd2957f55a28654cfd3e597fdc2d100a2043c0cR2-R21): Added lazy loading for the `MessageToolbox` component and wrapped its usage with `Suspense`. [[1]](diffhunk://#diff-d354ead063452d8945bc510b6dd2957f55a28654cfd3e597fdc2d100a2043c0cR2-R21) [[2]](diffhunk://#diff-d354ead063452d8945bc510b6dd2957f55a28654cfd3e597fdc2d100a2043c0cR74-R76)
* [`packages/react/src/views/ChatInput/ChatInputFormattingToolbar.js`](diffhunk://#diff-cf73d1e427def16fda2b9849769d5c29433468faa9726f262beff41b90b779f0R2): Added lazy loading for the `EmojiPicker` and `AudioMessageRecorder` components and wrapped their usage with `Suspense`. [[1]](diffhunk://#diff-cf73d1e427def16fda2b9849769d5c29433468faa9726f262beff41b90b779f0R2) [[2]](diffhunk://#diff-cf73d1e427def16fda2b9849769d5c29433468faa9726f262beff41b90b779f0L11-R20) [[3]](diffhunk://#diff-cf73d1e427def16fda2b9849769d5c29433468faa9726f262beff41b90b779f0R76-R78) [[4]](diffhunk://#diff-cf73d1e427def16fda2b9849769d5c29433468faa9726f262beff41b90b779f0R129) [[5]](diffhunk://#diff-cf73d1e427def16fda2b9849769d5c29433468faa9726f262beff41b90b779f0R143)
* [`packages/react/src/views/Message/Message.js`](diffhunk://#diff-5d5a10a80a2ae0188dd9296e1c76d9e65e46718c0dc3b7aff0de3142fffdf1e2R2): Added lazy loading for the `Attachments` and `MessageToolbox` components and wrapped their usage with `Suspense`. [[1]](diffhunk://#diff-5d5a10a80a2ae0188dd9296e1c76d9e65e46718c0dc3b7aff0de3142fffdf1e2R2) [[2]](diffhunk://#diff-5d5a10a80a2ae0188dd9296e1c76d9e65e46718c0dc3b7aff0de3142fffdf1e2L11-L19) [[3]](diffhunk://#diff-5d5a10a80a2ae0188dd9296e1c76d9e65e46718c0dc3b7aff0de3142fffdf1e2R27-R29) [[4]](diffhunk://#diff-5d5a10a80a2ae0188dd9296e1c76d9e65e46718c0dc3b7aff0de3142fffdf1e2R183-R188) [[5]](diffhunk://#diff-5d5a10a80a2ae0188dd9296e1c76d9e65e46718c0dc3b7aff0de3142fffdf1e2R203) [[6]](diffhunk://#diff-5d5a10a80a2ae0188dd9296e1c76d9e65e46718c0dc3b7aff0de3142fffdf1e2L222-R227) [[7]](diffhunk://#diff-5d5a10a80a2ae0188dd9296e1c76d9e65e46718c0dc3b7aff0de3142fffdf1e2R258-R264)

**Note**: The PR will be ready for live testing at https://rocketchat.github.io/EmbeddedChat/pulls/pr-<pr_number> after approval. Contributors are requested to replace `<pr_number>` with the actual PR number.
