### PR TITLE
Fix: Hide pin/unpin icon for non-admin users in group chats

### DIFF
--- a/packages/react/src/views/Message/Message.js
+++ b/packages/react/src/views/Message/Message.js
@@ -50,7 +50,7 @@ const Message = ({
   showAvatar = ECOptions?.showAvatar && showAvatar;
 
   const authenticatedUserId = useUserStore((state) => state.userId);
-  const userRoles = useUserStore((state) => state.roles)
+  const userRoles = useUserStore((state) => state.roles);
   const authenticatedUserUsername = useUserStore((state) => state.username);
   const [setMessageToReport, toggleShowReportMessage] = useMessageStore(
     (state) => [state.setMessageToReport, state.toggleShowReportMessage]

--- a/packages/react/src/views/Message/Message.js
+++ b/packages/react/src/views/Message/Message.js
@@ -50,6 +50,7 @@ const Message = ({
   showAvatar = ECOptions?.showAvatar && showAvatar;
 
   const authenticatedUserId = useUserStore((state) => state.userId);
+  const userRoles = useUserStore((state) => state.roles)
   const authenticatedUserUsername = useUserStore((state) => state.username);
   const [setMessageToReport, toggleShowReportMessage] = useMessageStore(
     (state) => [state.setMessageToReport, state.toggleShowReportMessage]
@@ -200,6 +201,7 @@ const Message = ({
                     message={message}
                     isEditing={editMessage._id === message._id}
                     authenticatedUserId={authenticatedUserId}
+                    userRoles={userRoles}
                     handleOpenThread={handleOpenThread}
                     handleDeleteMessage={handleDeleteMessage}
                     handleStarMessage={handleStarMessage}

--- a/packages/react/src/views/Message/MessageToolbox.js
+++ b/packages/react/src/views/Message/MessageToolbox.js
@@ -21,6 +21,7 @@ export const MessageToolbox = ({
   style = {},
   isThreadMessage = false,
   authenticatedUserId,
+  userRoles,
   handleOpenThread,
   handleEmojiClick,
   handlePinMessage,
@@ -110,7 +111,7 @@ export const MessageToolbox = ({
         id: 'pin',
         onClick: () => handlePinMessage(message),
         iconName: message.pinned ? 'pin-filled' : 'pin',
-        visible: !isThreadMessage,
+        visible: !isThreadMessage && userRoles.includes('admin'),
       },
       edit: {
         label: 'Edit',


### PR DESCRIPTION
# Brief Title
Fix: Hide pin/unpin icon for non-admin users in group chats

## Acceptance Criteria fulfillment

- [x] Ensure the pin/unpin icon is visible only to admins in group chats.
- [x] Remove the pin/unpin icon from the UI for non-admin users.

Fixes #672 

## Video/Screenshots

https://github.com/user-attachments/assets/0f7cc61d-ea1b-4965-b3e1-674bb7708fcc


## PR Test Details

**Note**: The PR will be ready for live testing at https://rocketchat.github.io/EmbeddedChat/pulls/pr-673 after approval. Contributors are requested to replace `<pr_number>` with the actual PR number.
