### PR TITLE
Fix:  Restrict Pin Icon Visibility Based on User Permissions

### DIFF
--- a/packages/react/src/hooks/useRCAuth.js
+++ b/packages/react/src/hooks/useRCAuth.js
@@ -20,11 +20,13 @@ export const useRCAuth = () => {
   );
   const setPassword = useUserStore((state) => state.setPassword);
   const setEmailorUser = useUserStore((state) => state.setEmailorUser);
+  const setUserPermissions = useUserStore((state) => state.setUserPermissions);
   const dispatchToastMessage = useToastBarDispatch();
 
   const handleLogin = async (userOrEmail, password, code) => {
     try {
       const res = await RCInstance.login(userOrEmail, password, code);
+      const permissions = await RCInstance.permissionInfo();
       if (res.error === 'Unauthorized' || res.error === 403) {
         dispatchToastMessage({
           type: 'error',
@@ -56,6 +58,7 @@ export const useRCAuth = () => {
           setIsTotpModalOpen(false);
           setEmailorUser(null);
           setPassword(null);
+          setUserPermissions(permissions);
           dispatchToastMessage({
             type: 'success',
             message: 'Successfully logged in',

--- a/packages/react/src/hooks/useRCAuth.js
+++ b/packages/react/src/hooks/useRCAuth.js
@@ -20,7 +20,9 @@ export const useRCAuth = () => {
   );
   const setPassword = useUserStore((state) => state.setPassword);
   const setEmailorUser = useUserStore((state) => state.setEmailorUser);
-  const setUserPermissions = useUserStore((state) => state.setUserPermissions);
+  const setUserPinPermissions = useUserStore(
+    (state) => state.setUserPinPermissions
+  );
   const dispatchToastMessage = useToastBarDispatch();
 
   const handleLogin = async (userOrEmail, password, code) => {
@@ -58,7 +60,7 @@ export const useRCAuth = () => {
           setIsTotpModalOpen(false);
           setEmailorUser(null);
           setPassword(null);
-          setUserPermissions(permissions);
+          setUserPinPermissions(permissions.update[150]);
           dispatchToastMessage({
             type: 'success',
             message: 'Successfully logged in',

--- a/packages/react/src/store/userStore.js
+++ b/packages/react/src/store/userStore.js
@@ -27,11 +27,11 @@ const useUserStore = create((set) => ({
   setPassword: (password) => set(() => ({ password })),
   emailoruser: null,
   setEmailorUser: (emailoruser) => set(() => ({ emailoruser })),
-  roles: {},
+  roles: [],
   setRoles: (roles) => set((state) => ({ ...state, roles })),
-  userPermissions: {},
-  setUserPermissions: (userPermissions) =>
-    set((state) => ({ ...state, userPermissions })),
+  userPinPermissions: {},
+  setUserPinPermissions: (userPinPermissions) =>
+    set((state) => ({ ...state, userPinPermissions })),
   showCurrentUserInfo: false,
   setShowCurrentUserInfo: (showCurrentUserInfo) =>
     set(() => ({ showCurrentUserInfo })),

--- a/packages/react/src/store/userStore.js
+++ b/packages/react/src/store/userStore.js
@@ -29,6 +29,9 @@ const useUserStore = create((set) => ({
   setEmailorUser: (emailoruser) => set(() => ({ emailoruser })),
   roles: {},
   setRoles: (roles) => set((state) => ({ ...state, roles })),
+  userPermissions: {},
+  setUserPermissions: (userPermissions) =>
+    set((state) => ({ ...state, userPermissions })),
   showCurrentUserInfo: false,
   setShowCurrentUserInfo: (showCurrentUserInfo) =>
     set(() => ({ showCurrentUserInfo })),

--- a/packages/react/src/views/Message/Message.js
+++ b/packages/react/src/views/Message/Message.js
@@ -51,6 +51,10 @@ const Message = ({
 
   const authenticatedUserId = useUserStore((state) => state.userId);
   const authenticatedUserUsername = useUserStore((state) => state.username);
+  const userRoles = useUserStore((state) => state.roles);
+  const pinPermissions = useUserStore(
+    (state) => state.userPermissions.update[150].roles
+  );
   const [setMessageToReport, toggleShowReportMessage] = useMessageStore(
     (state) => [state.setMessageToReport, state.toggleShowReportMessage]
   );
@@ -67,6 +71,8 @@ const Message = ({
   const theme = useTheme();
   const styles = getMessageStyles(theme);
   const bubbleStyles = useBubbleStyles(isMe);
+  const pinRoles = new Set(pinPermissions);
+  const isAllowedToPin = userRoles.some((role) => pinRoles.has(role));
 
   const variantStyles =
     !isInSidebar && variantOverrides === 'bubble' ? bubbleStyles : {};
@@ -200,6 +206,7 @@ const Message = ({
                     message={message}
                     isEditing={editMessage._id === message._id}
                     authenticatedUserId={authenticatedUserId}
+                    isAllowedToPin={isAllowedToPin}
                     handleOpenThread={handleOpenThread}
                     handleDeleteMessage={handleDeleteMessage}
                     handleStarMessage={handleStarMessage}

--- a/packages/react/src/views/Message/Message.js
+++ b/packages/react/src/views/Message/Message.js
@@ -53,7 +53,7 @@ const Message = ({
   const authenticatedUserUsername = useUserStore((state) => state.username);
   const userRoles = useUserStore((state) => state.roles);
   const pinPermissions = useUserStore(
-    (state) => state.userPermissions.update[150].roles
+    (state) => state.userPinPermissions.roles
   );
   const [setMessageToReport, toggleShowReportMessage] = useMessageStore(
     (state) => [state.setMessageToReport, state.toggleShowReportMessage]
@@ -72,7 +72,6 @@ const Message = ({
   const styles = getMessageStyles(theme);
   const bubbleStyles = useBubbleStyles(isMe);
   const pinRoles = new Set(pinPermissions);
-  const isAllowedToPin = userRoles.some((role) => pinRoles.has(role));
 
   const variantStyles =
     !isInSidebar && variantOverrides === 'bubble' ? bubbleStyles : {};
@@ -206,7 +205,8 @@ const Message = ({
                     message={message}
                     isEditing={editMessage._id === message._id}
                     authenticatedUserId={authenticatedUserId}
-                    isAllowedToPin={isAllowedToPin}
+                    userRoles={userRoles}
+                    pinRoles={pinRoles}
                     handleOpenThread={handleOpenThread}
                     handleDeleteMessage={handleDeleteMessage}
                     handleStarMessage={handleStarMessage}

--- a/packages/react/src/views/Message/MessageToolbox.js
+++ b/packages/react/src/views/Message/MessageToolbox.js
@@ -21,6 +21,7 @@ export const MessageToolbox = ({
   style = {},
   isThreadMessage = false,
   authenticatedUserId,
+  isAllowedToPin,
   handleOpenThread,
   handleEmojiClick,
   handlePinMessage,
@@ -110,7 +111,7 @@ export const MessageToolbox = ({
         id: 'pin',
         onClick: () => handlePinMessage(message),
         iconName: message.pinned ? 'pin-filled' : 'pin',
-        visible: !isThreadMessage,
+        visible: !isThreadMessage && isAllowedToPin,
       },
       edit: {
         label: 'Edit',

--- a/packages/react/src/views/Message/MessageToolbox.js
+++ b/packages/react/src/views/Message/MessageToolbox.js
@@ -21,7 +21,8 @@ export const MessageToolbox = ({
   style = {},
   isThreadMessage = false,
   authenticatedUserId,
-  isAllowedToPin,
+  userRoles,
+  pinRoles,
   handleOpenThread,
   handleEmojiClick,
   handlePinMessage,
@@ -68,6 +69,7 @@ export const MessageToolbox = ({
     setShowDeleteModal(false);
   };
 
+  const isAllowedToPin = userRoles.some((role) => pinRoles.has(role));
   const options = useMemo(
     () => ({
       reply: {


### PR DESCRIPTION
# Brief Title

### Restrict Pin Icon Visibility Based on User Permissions

## Acceptance Criteria fulfillment

- [x]  Ensure users without permissions do not see the pin icon
- [x]  Verify pin icon visibility for users with admin-granted permissions.

Fixes #672 

## Video/Screenshots

Case 1:  When non-priviledged users are granted permission to pin/unpin messages

https://github.com/user-attachments/assets/9ed97726-bde6-4bc2-9686-3f2193bddd2d

Case 2: When non-priviledged users are not granted permission to pin/unpin messages

https://github.com/user-attachments/assets/aeb0f199-77da-4aa0-ba9b-56e91ed4262c


## PR Test Details

**Note**: The PR will be ready for live testing at https://rocketchat.github.io/EmbeddedChat/pulls/pr-674 after approval. Contributors are requested to replace `<pr_number>` with the actual PR number.
