### PR TITLE
feat: insert links in chat

### DIFF
--- a/packages/layout_editor/src/store/chatInputItemsStore.js
+++ b/packages/layout_editor/src/store/chatInputItemsStore.js
@@ -1,7 +1,7 @@
 import { create } from 'zustand';
 
 const useChatInputItemsStore = create((set) => ({
-  surfaceItems: ['emoji', 'formatter', 'audio', 'video', 'file'],
+  surfaceItems: ['emoji', 'formatter', 'link', 'audio', 'video', 'file'],
   formatters: ['bold', 'italic', 'strike', 'code', 'multiline'],
   setSurfaceItems: (items) => set({ surfaceItems: items }),
   setFormatters: (items) => set({ formatters: items }),

--- a/packages/layout_editor/src/views/ChatInput/ChatInputToolbar.jsx
+++ b/packages/layout_editor/src/views/ChatInput/ChatInputToolbar.jsx
@@ -41,6 +41,13 @@ const ChatInputToolbar = () => {
         iconName: 'emoji',
         visible: true,
       },
+      link: {
+        label: 'Insert Link',
+        id: 'link',
+        onClick: () => {},
+        iconName: 'link',
+        visible: true,
+      },
       audio: {
         label: 'Audio Message',
         id: 'audio',
@@ -61,7 +68,7 @@ const ChatInputToolbar = () => {
         onClick: () => {},
         iconName: 'attachment',
         visible: true,
-      },
+      },      
       formatter: {
         label: 'Formatter',
         id: 'formatter',

--- a/packages/layout_editor/src/views/ChatInput/ChatInputToolbar.jsx
+++ b/packages/layout_editor/src/views/ChatInput/ChatInputToolbar.jsx
@@ -42,7 +42,7 @@ const ChatInputToolbar = () => {
         visible: true,
       },
       link: {
-        label: 'Insert Link',
+        label: 'Link',
         id: 'link',
         onClick: () => {},
         iconName: 'link',

--- a/packages/layout_editor/src/views/ThemeLab/LayoutSetting.jsx
+++ b/packages/layout_editor/src/views/ThemeLab/LayoutSetting.jsx
@@ -217,6 +217,15 @@ const LayoutSetting = () => {
         iconName: 'emoji',
         visible: true,
       },
+      link: {
+        label: 'Insert Link',
+        id: 'link',
+        onClick: () => {
+          addInputSurfaceItem('link');
+        },
+        iconName: 'link',
+        visible: true,
+      },
       audio: {
         label: 'Audio Message',
         id: 'audio',
@@ -243,7 +252,7 @@ const LayoutSetting = () => {
         },
         iconName: 'attachment',
         visible: true,
-      },
+      },      
       formatter: {
         label: 'Formatter',
         id: 'formatter',

--- a/packages/layout_editor/src/views/ThemeLab/LayoutSetting.jsx
+++ b/packages/layout_editor/src/views/ThemeLab/LayoutSetting.jsx
@@ -218,7 +218,7 @@ const LayoutSetting = () => {
         visible: true,
       },
       link: {
-        label: 'Insert Link',
+        label: 'Link',
         id: 'link',
         onClick: () => {
           addInputSurfaceItem('link');

--- a/packages/react/src/views/ChatInput/ChatInput.styles.js
+++ b/packages/react/src/views/ChatInput/ChatInput.styles.js
@@ -103,3 +103,31 @@ export const getCommonRecorderStyles = (theme) => {
 
   return styles;
 };
+
+
+export const getInsertLinkModalStyles = (theme) => {
+  const styles = {
+    inputWithFormattingBox: css`
+      border: 1px solid ${theme.colors.border};
+      border-radius: ${theme.radius};
+      margin: 0.5rem 1rem;
+      &.focused {
+        border: ${`1.5px solid ${theme.colors.ring}`};
+      }
+    `,
+    modalHeader: css`
+      padding: 0 0.5rem;  
+    `,
+    modalContent: css`
+      display: flex;
+      flex-direction: column;
+      gap: 0.5rem;
+      margin: 1rem 0;
+    `,
+    modalFooter: css`
+      padding: 0.75rem 1rem;  
+    `,
+  };
+
+  return styles;
+};

--- a/packages/react/src/views/ChatInput/ChatInput.styles.js
+++ b/packages/react/src/views/ChatInput/ChatInput.styles.js
@@ -104,7 +104,6 @@ export const getCommonRecorderStyles = (theme) => {
   return styles;
 };
 
-
 export const getInsertLinkModalStyles = (theme) => {
   const styles = {
     inputWithFormattingBox: css`
@@ -116,7 +115,7 @@ export const getInsertLinkModalStyles = (theme) => {
       }
     `,
     modalHeader: css`
-      padding: 0 0.5rem;  
+      padding: 0 0.5rem;
     `,
     modalContent: css`
       display: flex;
@@ -125,7 +124,7 @@ export const getInsertLinkModalStyles = (theme) => {
       margin: 1rem 0;
     `,
     modalFooter: css`
-      padding: 0.75rem 1rem;  
+      padding: 0.75rem 1rem;
     `,
   };
 

--- a/packages/react/src/views/ChatInput/ChatInputFormattingToolbar.js
+++ b/packages/react/src/views/ChatInput/ChatInputFormattingToolbar.js
@@ -15,13 +15,14 @@ import AudioMessageRecorder from './AudioMessageRecorder';
 import VideoMessageRecorder from './VideoMessageRecoder';
 import { getChatInputFormattingToolbarStyles } from './ChatInput.styles';
 import formatSelection from '../../lib/formatSelection';
+import InsertLinkToolBox from './InsertLinkToolBox';
 
 const ChatInputFormattingToolbar = ({
   messageRef,
   inputRef,
   triggerButton,
   optionConfig = {
-    surfaceItems: ['emoji', 'formatter', 'audio', 'video', 'file'],
+    surfaceItems: ['emoji', 'formatter', 'link', 'audio', 'video', 'file'],
     formatters: ['bold', 'italic', 'strike', 'code', 'multiline'],
   },
 }) => {
@@ -40,6 +41,7 @@ const ChatInputFormattingToolbar = ({
   );
 
   const [isEmojiOpen, setEmojiOpen] = useState(false);
+  const [isInsertLinkOpen, setInsertLinkOpen] = useState(false);
 
   const handleClickToOpenFiles = () => {
     inputRef.current.click();
@@ -53,6 +55,22 @@ const ChatInputFormattingToolbar = ({
     )}: `;
     triggerButton?.(null, message);
   };
+
+  const handleAddLink = (linkText, linkUrl) => {
+    if(!linkText || !linkUrl) {
+      setInsertLinkOpen(false);
+      return;
+    }
+
+    const start = messageRef.current.selectionStart;
+    const end = messageRef.current.selectionEnd;
+    const msg = messageRef.current.value;
+    const hyperlink = '[' + linkText + '](' + linkUrl + ')';
+    const message = msg.slice(0, start) + hyperlink + msg.slice(end);
+    
+    triggerButton?.(null, message);
+    setInsertLinkOpen(false);
+  }
 
   const chatToolMap = {
     emoji: (
@@ -88,6 +106,20 @@ const ChatInputFormattingToolbar = ({
           onClick={handleClickToOpenFiles}
         >
           <Icon name="attachment" size="1.25rem" />
+        </ActionButton>
+      </Tooltip>
+    ),
+    link: (
+      <Tooltip text="Link" position="top" key="link">
+        <ActionButton
+          square
+          ghost
+          disabled={isRecordingMessage}
+          onClick={() => {
+            setInsertLinkOpen(true);
+          }}
+        >
+          <Icon name="link" size="1.25rem" />
         </ActionButton>
       </Tooltip>
     ),
@@ -136,6 +168,15 @@ const ChatInputFormattingToolbar = ({
           `}
         />
       )}
+
+      {isInsertLinkOpen && (
+        <InsertLinkToolBox
+          selectedText={window.getSelection().toString()}
+          handleAddLink={handleAddLink}
+          onClose={() => setInsertLinkOpen(false)}
+        />
+      )}
+
     </Box>
   );
 };

--- a/packages/react/src/views/ChatInput/ChatInputFormattingToolbar.js
+++ b/packages/react/src/views/ChatInput/ChatInputFormattingToolbar.js
@@ -57,7 +57,7 @@ const ChatInputFormattingToolbar = ({
   };
 
   const handleAddLink = (linkText, linkUrl) => {
-    if(!linkText || !linkUrl) {
+    if (!linkText || !linkUrl) {
       setInsertLinkOpen(false);
       return;
     }
@@ -65,12 +65,12 @@ const ChatInputFormattingToolbar = ({
     const start = messageRef.current.selectionStart;
     const end = messageRef.current.selectionEnd;
     const msg = messageRef.current.value;
-    const hyperlink = '[' + linkText + '](' + linkUrl + ')';
+    const hyperlink = `[${linkText}](${linkUrl})`;
     const message = msg.slice(0, start) + hyperlink + msg.slice(end);
-    
+
     triggerButton?.(null, message);
     setInsertLinkOpen(false);
-  }
+  };
 
   const chatToolMap = {
     emoji: (
@@ -176,7 +176,6 @@ const ChatInputFormattingToolbar = ({
           onClose={() => setInsertLinkOpen(false)}
         />
       )}
-
     </Box>
   );
 };

--- a/packages/react/src/views/ChatInput/InsertLinkToolBox.js
+++ b/packages/react/src/views/ChatInput/InsertLinkToolBox.js
@@ -1,4 +1,4 @@
-import React, {useState} from 'react';
+import React, { useState } from 'react';
 import { Modal, Input, Button, useTheme } from '@embeddedchat/ui-elements';
 import { getInsertLinkModalStyles } from './ChatInput.styles';
 
@@ -11,7 +11,7 @@ const InsertLinkToolBox = ({
   const styles = getInsertLinkModalStyles(theme);
   const [linkText, setLinkText] = useState(selectedText || 'Text');
   const [linkUrl, setLinkUrl] = useState(null);
- 
+
   const handleLinkTextOnChange = (e) => {
     setLinkText(e.target.value);
   };
@@ -22,22 +22,20 @@ const InsertLinkToolBox = ({
   return (
     <Modal>
       <Modal.Header css={styles.modalHeader}>
-        <Modal.Title>
-          Add link
-        </Modal.Title>
+        <Modal.Title>Add link</Modal.Title>
         <Modal.Close onClick={onClose} />
       </Modal.Header>
       <Modal.Content css={styles.modalContent}>
         <Input
-            type='text'
-            onChange={handleLinkTextOnChange}
-            value={linkText}
-            css={styles.inputWithFormattingBox}
+          type="text"
+          onChange={handleLinkTextOnChange}
+          value={linkText}
+          css={styles.inputWithFormattingBox}
         />
         <Input
-          type='text'
+          type="text"
           onChange={handleLinkUrlOnChange}
-          placeholder='URL'
+          placeholder="URL"
           css={styles.inputWithFormattingBox}
         />
       </Modal.Content>

--- a/packages/react/src/views/ChatInput/InsertLinkToolBox.js
+++ b/packages/react/src/views/ChatInput/InsertLinkToolBox.js
@@ -1,0 +1,56 @@
+import React, {useState} from 'react';
+import { Modal, Input, Button, useTheme } from '@embeddedchat/ui-elements';
+import { getInsertLinkModalStyles } from './ChatInput.styles';
+
+const InsertLinkToolBox = ({
+  handleAddLink,
+  selectedText,
+  onClose = () => {},
+}) => {
+  const { theme } = useTheme();
+  const styles = getInsertLinkModalStyles(theme);
+  const [linkText, setLinkText] = useState(selectedText || 'Text');
+  const [linkUrl, setLinkUrl] = useState(null);
+ 
+  const handleLinkTextOnChange = (e) => {
+    setLinkText(e.target.value);
+  };
+  const handleLinkUrlOnChange = (e) => {
+    setLinkUrl(e.target.value);
+  };
+
+  return (
+    <Modal>
+      <Modal.Header css={styles.modalHeader}>
+        <Modal.Title>
+          Add link
+        </Modal.Title>
+        <Modal.Close onClick={onClose} />
+      </Modal.Header>
+      <Modal.Content css={styles.modalContent}>
+        <Input
+            type='text'
+            onChange={handleLinkTextOnChange}
+            value={linkText}
+            css={styles.inputWithFormattingBox}
+        />
+        <Input
+          type='text'
+          onChange={handleLinkUrlOnChange}
+          placeholder='URL'
+          css={styles.inputWithFormattingBox}
+        />
+      </Modal.Content>
+      <Modal.Footer css={styles.modalFooter}>
+        <Button type="secondary" onClick={onClose}>
+          Cancel
+        </Button>
+        <Button type="primary" onClick={() => handleAddLink(linkText, linkUrl)}>
+          Add
+        </Button>
+      </Modal.Footer>
+    </Modal>
+  );
+};
+
+export default InsertLinkToolBox;

--- a/packages/react/src/views/EmojiPicker/EmojiPicker.js
+++ b/packages/react/src/views/EmojiPicker/EmojiPicker.js
@@ -32,7 +32,7 @@ const CustomEmojiPicker = ({
       height="auto"
       width="auto"
     >
-      <Box css={styles.emojiPicker}>
+      <Box css={styles.inputBox}>
         <EmojiPicker
           height={350}
           width={300}


### PR DESCRIPTION
# Brief Title
Add 'Link' option in the ChatInput Box

## Acceptance Criteria fulfillment

 - [x] An icon for adding 'Link' is available in the ChatInput box.
 - [x] Clicking the 'Link' button opens a modal for users to input the link text and URL.
 - [x] The input link is correctly formatted and added to the message, ensuring it's clickable and visually distinct.

Fixes #678 

## Video/Screenshots

https://github.com/user-attachments/assets/be7e568a-d847-494c-bda2-9789f1557bcc

## PR Test Details

**Note**: The PR will be ready for live testing at https://rocketchat.github.io/EmbeddedChat/pulls/pr-<pr_number> after approval. Contributors are requested to replace `<pr_number>` with the actual PR number.
