### PR TITLE
fix: ensure pin permission changes reflect without requiring user logout

### DIFF
--- a/packages/react/src/views/EmbeddedChat.js
+++ b/packages/react/src/views/EmbeddedChat.js
@@ -83,6 +83,9 @@ const EmbeddedChat = (props) => {
   }));
 
   const setIsLoginIn = useLoginStore((state) => state.setIsLoginIn);
+  const setUserPinPermissions = useUserStore(
+    (state) => state.setUserPinPermissions
+  );
 
   if (isClosable && !setClosableState) {
     throw Error(
@@ -125,6 +128,8 @@ const EmbeddedChat = (props) => {
       setIsLoginIn(true);
       try {
         await RCInstance.autoLogin(auth);
+        const permissions = await RCInstance.permissionInfo();
+        setUserPinPermissions(permissions.update[150]);
       } catch (error) {
         console.error(error);
       } finally {


### PR DESCRIPTION
# Brief Title
Fix: Pin Permission Changes Not Reflected Without User Logout

## Acceptance Criteria fulfillment

- [x]  Pin permission changes made by the admin are now immediately reflected for the user after a page refresh.

- [x]  No need for the user to log out and log back in to see the updated permissions.

Fixes #679 

## Video/Screenshots

https://github.com/user-attachments/assets/6bde2e5c-06ae-4cfd-8974-d58fbcdb2b1e




## PR Test Details

**Note**: The PR will be ready for live testing at https://rocketchat.github.io/EmbeddedChat/pulls/pr-688 after approval. Contributors are requested to replace `<pr-number>` with the actual PR number.
