### PR TITLE
FEAT: added functionality for popups can act as modals on mobile devices

### DIFF
--- a/packages/ui-elements/src/components/ToastBar/ToastBar.styles.js
+++ b/packages/ui-elements/src/components/ToastBar/ToastBar.styles.js
@@ -45,6 +45,19 @@ export const getToastBarContainerStyles = (theme) => {
       border-radius: ${theme.radius};
       animation: ${animation} ${2000}ms ease-in-out forwards;
     `,
+    modalContainer: css`
+      position: fixed;
+      top: 0;
+      left: 0;
+      width: 100%;
+      height: 100%;
+      background-color: rgba(0, 0, 0, 0.5);
+      display: flex;
+      align-items: center;
+      justify-content: center;
+      z-index: ${theme.zIndex?.toastbar || 1600};
+      animation: ${animation} 2000ms ease-in-out forwards;
+    `,
   };
   return styles;
 };

--- a/packages/ui-elements/src/components/ToastBar/ToastContainer.js
+++ b/packages/ui-elements/src/components/ToastBar/ToastContainer.js
@@ -29,8 +29,9 @@ const ToastContainer = () => {
     return null;
   }
 
+  const isMobile = window.innerWidth <= 768;
   return (
-    <Box css={styles.container} style={positionStyle}>
+    <Box css={isMobile ? styles.modalContainer : styles.container} style={positionStyle}>
       <ToastBar toast={currentToast} onClose={onClose} />
     </Box>
   );


### PR DESCRIPTION
# Brief Title
FEAT: added functionality for popups can act as modals on mobile devices

## Acceptance Criteria fulfillment
- [x] Currently, the popups are strictly positioned. A more flexible positioning system is implemented. On mobile devices, these popups act as modals.

Fixes #629

## Video/Screenshots
https://github.com/user-attachments/assets/82027036-43f9-4e33-b3f8-04e0789b0fa6

and 

https://github.com/user-attachments/assets/db20300c-5665-4789-93c8-b332f6dd4e76

## PR Test Details

**Note**: The PR will be ready for live testing at https://rocketchat.github.io/EmbeddedChat/pulls/pr-690 after approval. Contributors are requested to replace `<pr_number>` with the actual PR number.
