### PR TITLE
Fix: Editing of Audio, Video and File Message

### DIFF
--- a/packages/react/src/views/Message/Message.js
+++ b/packages/react/src/views/Message/Message.js
@@ -114,6 +114,23 @@ const Message = ({
     }
   };
 
+  const handleEditMessage = () => {
+
+    if(message.msg == '' && message.files[0]) {
+      dispatchToastMessage({
+        type: 'error',
+        message: 'Editing Audio/Video/File messages is not supported at the moment.',
+      });
+      return;
+    }
+
+    if (editMessage._id === message._id) {
+      setEditMessage({});
+    } else {
+      setEditMessage(message);
+    }
+  };
+
   const handleDeleteMessage = async (msg) => {
     const res = await RCInstance.deleteMessage(msg._id);
 
@@ -213,13 +230,7 @@ const Message = ({
                     handleDeleteMessage={handleDeleteMessage}
                     handleStarMessage={handleStarMessage}
                     handlePinMessage={handlePinMessage}
-                    handleEditMessage={() => {
-                      if (editMessage._id === message._id) {
-                        setEditMessage({});
-                      } else {
-                        setEditMessage(message);
-                      }
-                    }}
+                    handleEditMessage={handleEditMessage}
                     handleQuoteMessage={() => addQuoteMessage(message)}
                     handleEmojiClick={handleEmojiClick}
                     handlerReportMessage={() => {

--- a/packages/react/src/views/Message/Message.js
+++ b/packages/react/src/views/Message/Message.js
@@ -114,23 +114,6 @@ const Message = ({
     }
   };
 
-  const handleEditMessage = () => {
-
-    if(message.msg == '' && message.files[0]) {
-      dispatchToastMessage({
-        type: 'error',
-        message: 'Editing Audio/Video/File messages is not supported at the moment.',
-      });
-      return;
-    }
-
-    if (editMessage._id === message._id) {
-      setEditMessage({});
-    } else {
-      setEditMessage(message);
-    }
-  };
-
   const handleDeleteMessage = async (msg) => {
     const res = await RCInstance.deleteMessage(msg._id);
 
@@ -230,7 +213,13 @@ const Message = ({
                     handleDeleteMessage={handleDeleteMessage}
                     handleStarMessage={handleStarMessage}
                     handlePinMessage={handlePinMessage}
-                    handleEditMessage={handleEditMessage}
+                    handleEditMessage={() => {
+                      if (editMessage._id === message._id) {
+                        setEditMessage({});
+                      } else {
+                        setEditMessage(message);
+                      }
+                    }}
                     handleQuoteMessage={() => addQuoteMessage(message)}
                     handleEmojiClick={handleEmojiClick}
                     handlerReportMessage={() => {

--- a/packages/react/src/views/Message/MessageToolbox.js
+++ b/packages/react/src/views/Message/MessageToolbox.js
@@ -75,11 +75,17 @@ export const MessageToolbox = ({
   };
 
   const isAllowedToPin = userRoles.some((role) => pinRoles.has(role));
+
   const isAllowedToEditMessage = userRoles.some((role) =>
     editMessageRoles.has(role)
   )
     ? true
     : message.u._id === authenticatedUserId;
+
+  const isVisibleForMessageType =
+    message.files?.[0].type !== 'audio/mpeg' &&
+    message.files?.[0].type !== 'video/mp4';
+
   const options = useMemo(
     () => ({
       reply: {
@@ -130,10 +136,7 @@ export const MessageToolbox = ({
         id: 'edit',
         onClick: () => handleEditMessage(message),
         iconName: 'edit',
-        visible:
-          isAllowedToEditMessage &&
-          message.files?.[0].type !== 'audio/mpeg' &&
-          message.files?.[0].type !== 'video/mp4',
+        visible: isAllowedToEditMessage && isVisibleForMessageType,
         color: isEditing ? 'secondary' : 'default',
         ghost: !isEditing,
       },

--- a/packages/react/src/views/Message/MessageToolbox.js
+++ b/packages/react/src/views/Message/MessageToolbox.js
@@ -120,7 +120,7 @@ export const MessageToolbox = ({
         id: 'edit',
         onClick: () => handleEditMessage(message),
         iconName: 'edit',
-        visible: message.u._id === authenticatedUserId,
+        visible: (message.u._id === authenticatedUserId) && (message.files?.[0].type !== 'audio/mpeg') && (message.files?.[0].type !== 'video/mp4'),
         color: isEditing ? 'secondary' : 'default',
         ghost: !isEditing,
       },

--- a/packages/react/src/views/Message/MessageToolbox.js
+++ b/packages/react/src/views/Message/MessageToolbox.js
@@ -75,15 +75,11 @@ export const MessageToolbox = ({
   };
 
   const isAllowedToPin = userRoles.some((role) => pinRoles.has(role));
-
   const isAllowedToEditMessage = userRoles.some((role) =>
     editMessageRoles.has(role)
   )
     ? true
-    : message.u._id === authenticatedUserId &&
-      message.files?.[0].type !== 'audio/mpeg' &&
-      message.files?.[0].type !== 'video/mp4';
-
+    : message.u._id === authenticatedUserId;
   const options = useMemo(
     () => ({
       reply: {
@@ -134,7 +130,10 @@ export const MessageToolbox = ({
         id: 'edit',
         onClick: () => handleEditMessage(message),
         iconName: 'edit',
-        visible: isAllowedToEditMessage,
+        visible:
+          isAllowedToEditMessage &&
+          message.files?.[0].type !== 'audio/mpeg' &&
+          message.files?.[0].type !== 'video/mp4',
         color: isEditing ? 'secondary' : 'default',
         ghost: !isEditing,
       },

--- a/packages/react/src/views/Message/MessageToolbox.js
+++ b/packages/react/src/views/Message/MessageToolbox.js
@@ -120,7 +120,10 @@ export const MessageToolbox = ({
         id: 'edit',
         onClick: () => handleEditMessage(message),
         iconName: 'edit',
-        visible: (message.u._id === authenticatedUserId) && (message.files?.[0].type !== 'audio/mpeg') && (message.files?.[0].type !== 'video/mp4'),
+        visible:
+          message.u._id === authenticatedUserId &&
+          message.files?.[0].type !== 'audio/mpeg' &&
+          message.files?.[0].type !== 'video/mp4',
         color: isEditing ? 'secondary' : 'default',
         ghost: !isEditing,
       },


### PR DESCRIPTION
# Brief Title
Updated handleEditMessage functionality, and added validation for audio, video, and file message

When a user sends an audio/video/file message in the chat and clicks on the "Edit" option, they can record another audio or video/upload new file. However, the User should not be able to edit audio or video, or file messages. Instead, they can delete the message and send a new one

## Acceptance Criteria fulfillment

- [x] When the user attempts to edit an audio/video/file message, a popup will appear stating 'Editing Audio/Video/File messages is not supported at the moment.''

Fixes #696
Fixes #698

## Screenshots
![Screenshot (1448)](https://github.com/user-attachments/assets/525732aa-bee4-4aa3-966f-c1e79a850c14)
and
![Screenshot (1450)](https://github.com/user-attachments/assets/17385172-2b3b-4ce0-a8a5-9f215bd714ad)


## PR Test Details

**Note**: The PR will be ready for live testing at https://rocketchat.github.io/EmbeddedChat/pulls/pr-697 after approval.