### PR TITLE
Add "Pin Message" Option in Reply-in-Thread Modal

### DIFF
--- a/packages/react/src/views/Message/MessageToolbox.js
+++ b/packages/react/src/views/Message/MessageToolbox.js
@@ -113,7 +113,7 @@ export const MessageToolbox = ({
         id: 'pin',
         onClick: () => handlePinMessage(message),
         iconName: message.pinned ? 'pin-filled' : 'pin',
-        visible: !isThreadMessage && isAllowedToPin,
+        visible: isAllowedToPin,
       },
       edit: {
         label: 'Edit',


### PR DESCRIPTION
# Brief Title

## Acceptance Criteria fulfillment

-Implemented the "Pin Message" option in the "Reply in Thread" modal.
- Ensured the pinned message functionality integrates seamlessly with the existing pinning mechanism in the main chat.


Fixes #703 

## Video/Screenshots

https://github.com/user-attachments/assets/65c9a1f1-b486-4641-82f1-385b5d21054c



## PR Test Details

**Note**: The PR will be ready for live testing at https://rocketchat.github.io/EmbeddedChat/pulls/pr-<pr_number> after approval. Contributors are requested to replace `<pr_number>` with the actual PR number.
