### PR TITLE
Fix: Hidden the copy option for audio and video messages

### DIFF
--- a/packages/react/src/views/Message/MessageToolbox.js
+++ b/packages/react/src/views/Message/MessageToolbox.js
@@ -75,11 +75,17 @@ export const MessageToolbox = ({
   };
 
   const isAllowedToPin = userRoles.some((role) => pinRoles.has(role));
+
   const isAllowedToEditMessage = userRoles.some((role) =>
     editMessageRoles.has(role)
   )
     ? true
     : message.u._id === authenticatedUserId;
+  
+  const isVisibleForMessageType =
+    message.files?.[0].type !== 'audio/mpeg' &&
+    message.files?.[0].type !== 'video/mp4';
+  
   const options = useMemo(
     () => ({
       reply: {

--- a/packages/react/src/views/Message/MessageToolbox.js
+++ b/packages/react/src/views/Message/MessageToolbox.js
@@ -81,11 +81,11 @@ export const MessageToolbox = ({
   )
     ? true
     : message.u._id === authenticatedUserId;
-  
+
   const isVisibleForMessageType =
     message.files?.[0].type !== 'audio/mpeg' &&
     message.files?.[0].type !== 'video/mp4';
-  
+
   const options = useMemo(
     () => ({
       reply: {
@@ -145,7 +145,7 @@ export const MessageToolbox = ({
         id: 'copy',
         onClick: () => handleCopyMessage(message),
         iconName: 'copy',
-        visible: true,
+        visible: isVisibleForMessageType,
       },
       link: {
         label: 'Copy link',


### PR DESCRIPTION
# Brief Title
Hidden the copy option for audio and video messages

## Acceptance Criteria fulfillment

- [x] Hidden the copy option for audio and video messages.

Fixes #713

## Video/Screenshots

https://github.com/user-attachments/assets/9dde9b6a-ec2e-475f-bb78-287fc58a33e2


## PR Test Details

**Note**: The PR will be ready for live testing at https://rocketchat.github.io/EmbeddedChat/pulls/pr-714 after approval. Contributors are requested to replace `<pr_number>` with the actual PR number.
