### PR TITLE
Fix: The 'Copy' option functionality is now working for File messages

### DIFF
--- a/packages/react/src/views/Message/Message.js
+++ b/packages/react/src/views/Message/Message.js
@@ -122,16 +122,8 @@ const Message = ({
     const textToCopy =
       msg.msg ||
       (msg.attachments && msg.attachments[0]
-        ? msg.attachments[0].description
+        ? msg.attachments[0].description || msg.attachments[0].title
         : '');
-
-    if (!textToCopy) {
-      dispatchToastMessage({
-        type: 'error',
-        message: 'No message or attachment description available to copy',
-      });
-      return;
-    }
 
     try {
       await navigator.clipboard.writeText(textToCopy);

--- a/packages/react/src/views/Message/Message.js
+++ b/packages/react/src/views/Message/Message.js
@@ -119,20 +119,32 @@ const Message = ({
   };
 
   const handleCopyMessage = async (msg) => {
-    navigator.clipboard
-      .writeText(msg.msg)
-      .then(() => {
-        dispatchToastMessage({
-          type: 'success',
-          message: 'Message copied successfully',
-        });
-      })
-      .catch(() => {
-        dispatchToastMessage({
-          type: 'error',
-          message: 'Error in copying message',
-        });
+    const textToCopy =
+      msg.msg ||
+      (msg.attachments && msg.attachments[0]
+        ? msg.attachments[0].description
+        : '');
+
+    if (!textToCopy) {
+      dispatchToastMessage({
+        type: 'error',
+        message: 'No message or attachment description available to copy',
       });
+      return;
+    }
+
+    try {
+      await navigator.clipboard.writeText(textToCopy);
+      dispatchToastMessage({
+        type: 'success',
+        message: 'Message copied successfully',
+      });
+    } catch (error) {
+      dispatchToastMessage({
+        type: 'error',
+        message: 'Error in copying message',
+      });
+    }
   };
 
   const getMessageLink = async (id) => {


### PR DESCRIPTION
# Brief Title
The 'Copy' option functionality is now working for File messages

## Acceptance Criteria fulfillment

- [X] 'Copy' option copying the respective File description
- [X] If the File description is not present then a popup appears saying 'No message or attachment description available to copy'

Fixes #715

## Video/Screenshots

https://github.com/user-attachments/assets/50711826-e0bd-4c9f-9975-cd42bd004e40


## PR Test Details

**Note**: The PR will be ready for live testing at https://rocketchat.github.io/EmbeddedChat/pulls/pr-716 after approval. Contributors are requested to replace `<pr_number>` with the actual PR number.
