### PR TITLE
FEAT: Added draft-saving feature for messages, which automatically sends them when the internet is restored.

### DIFF
--- a/packages/react/src/lib/createPendingMessage.js
+++ b/packages/react/src/lib/createPendingMessage.js
@@ -53,4 +53,193 @@ const createPendingMessage = (
   };
 };
 
-export default createPendingMessage;
+const createPendingAudioMessage = (
+  file,
+  user = {
+    _id: undefined,
+    username: undefined,
+    name: undefined,
+  }
+) => {
+  const now = new Date();
+  return {
+    isPending: true,
+    _id: `ec_${createRandomId()}`,
+    rid: 'GENERAL',
+    msg: '',
+    ts: now.toISOString(),
+    u: {
+      _id: user._id,
+      username: user.username,
+      name: user.name,
+    },
+    _updatedAt: now.toISOString(),
+    urls: [],
+    mentions: [],
+    channels: [],
+    file: {
+      _id: file._id,
+      name: file.name,
+      type: file.type,
+      size: file.size,
+      format: file.format || '',
+    },
+    files: [
+      {
+        _id: file._id,
+        name: file.name,
+        type: file.type,
+        size: file.size,
+        format: file.format || '',
+      },
+    ],
+    attachments: [
+      {
+        ts: '1970-01-01T00:00:00.000Z',
+        title: file.name,
+        title_link: `/file-upload/${file._id}/${encodeURIComponent(file.name)}`,
+        title_link_download: true,
+        audio_url: `/file-upload/${file._id}/${encodeURIComponent(file.name)}`,
+        audio_type: file.type,
+        audio_size: file.size,
+        type: 'file',
+        description: '',
+      },
+    ],
+    md: [],
+  };
+};
+
+const createPendingVideoMessage = (
+  file,
+  user = {
+    _id: undefined,
+    username: undefined,
+    name: undefined,
+  }
+) => {
+  const now = new Date();
+  return {
+    isPending: true,
+    _id: `ec_${createRandomId()}`,
+    rid: 'GENERAL',
+    msg: '',
+    ts: now.toISOString(),
+    u: {
+      _id: user._id,
+      username: user.username,
+      name: user.name,
+    },
+    _updatedAt: now.toISOString(),
+    urls: [],
+    mentions: [],
+    channels: [],
+    file: {
+      _id: file._id,
+      name: file.name,
+      type: file.type,
+      size: file.size,
+      format: file.format || '',
+    },
+    files: [
+      {
+        _id: file._id,
+        name: file.name,
+        type: file.type,
+        size: file.size,
+        format: file.format || '',
+      },
+    ],
+    attachments: [
+      {
+        ts: '1970-01-01T00:00:00.000Z',
+        title: file.name,
+        title_link: `/file-upload/${file._id}/${encodeURIComponent(file.name)}`,
+        title_link_download: true,
+        video_url: `/file-upload/${file._id}/${encodeURIComponent(file.name)}`,
+        video_type: file.type,
+        video_size: file.size,
+        type: 'file',
+        description: '',
+      },
+    ],
+    md: [],
+  };
+};
+
+const createPendingFileMessage = (
+  file,
+  user = {
+    _id: undefined,
+    username: undefined,
+    name: undefined,
+  },
+  description = 'Hahahaha'
+) => {
+  const now = new Date();
+  return {
+    isPending: true,
+    _id: `ec_${createRandomId()}`,
+    rid: 'GENERAL',
+    msg: '',
+    ts: now.toISOString(),
+    u: {
+      _id: user._id,
+      username: user.username,
+      name: user.name,
+    },
+    _updatedAt: now.toISOString(),
+    urls: [],
+    mentions: [],
+    channels: [],
+    file: {
+      _id: '',
+      name: file.name,
+      type: file.type,
+      size: file.size,
+      format: file.format || '',
+    },
+    files: [
+      {
+        _id: '',
+        name: file.name,
+        type: file.type,
+        size: file.size,
+        format: file.format || '',
+      },
+    ],
+    attachments: [
+      {
+        ts: '1970-01-01T00:00:00.000Z',
+        title: file.name,
+        title_link: `/file-upload/${file.name}/${encodeURIComponent(
+          file.name
+        )}`,
+        title_link_download: true,
+        type: 'file',
+        description,
+        format: file.format || '',
+        size: file.size,
+        descriptionMd: [
+          {
+            type: 'PARAGRAPH',
+            value: [
+              {
+                type: 'PLAIN_TEXT',
+                value: description,
+              },
+            ],
+          },
+        ],
+      },
+    ],
+    md: [],
+  };
+};
+
+export {
+  createPendingMessage,
+  createPendingAudioMessage,
+  createPendingVideoMessage,
+  createPendingFileMessage,
+};

--- a/packages/react/src/views/ChatInput/ChatInput.js
+++ b/packages/react/src/views/ChatInput/ChatInput.js
@@ -1,4 +1,4 @@
-import React, { useState, useRef, useEffect } from 'react';
+import React, { useState, useRef, useEffect, useContext } from 'react';
 import { css } from '@emotion/react';
 import {
   Box,
@@ -24,7 +24,7 @@ import ChatInputFormattingToolbar from './ChatInputFormattingToolbar';
 import useAttachmentWindowStore from '../../store/attachmentwindow';
 import MembersList from '../Mentions/MembersList';
 import { TypingUsers } from '../TypingUsers';
-import createPendingMessage from '../../lib/createPendingMessage';
+import { createPendingMessage } from '../../lib/createPendingMessage';
 import { CommandsList } from '../CommandList';
 import useSettingsStore from '../../store/settingsStore';
 import ChannelState from '../ChannelState/ChannelState';
@@ -58,6 +58,7 @@ const ChatInput = ({ scrollToBottom }) => {
   const [showCommandList, setShowCommandList] = useState(false);
   const [filteredCommands, setFilteredCommands] = useState([]);
   const [isMsgLong, setIsMsgLong] = useState(false);
+  const [messageQueue, setMessageQueue] = useState([]);
 
   const {
     isUserAuthenticated,
@@ -162,6 +163,42 @@ const ChatInput = ({ scrollToBottom }) => {
     }
   }, [editMessage]);
 
+  useEffect(() => {
+    const handleOnline = async () => {
+      if (navigator.onLine && messageQueue.length > 0) {
+        for (let i = 0; i < messageQueue.length; i++) {
+          const pendingMessage = JSON.parse(messageQueue[i]);
+          const res = await RCInstance.sendMessage(
+            {
+              msg: pendingMessage.msg,
+              _id: pendingMessage._id,
+            },
+            ECOptions.enableThreads ? threadId : undefined
+          );
+          if (res.success) {
+            clearQuoteMessages();
+            replaceMessage(pendingMessage, res.message);
+          }
+        }
+        setMessageQueue([]);
+        localStorage.removeItem('pendingMessage');
+      }
+    };
+
+    window.addEventListener('online', handleOnline);
+    return () => {
+      window.removeEventListener('online', handleOnline);
+    };
+  }, [messageQueue]);
+
+  useEffect(() => {
+    const pendingMessage = localStorage.getItem('pendingMessage');
+    if (pendingMessage) {
+      messageRef.current.value = JSON.parse(pendingMessage).msg || '';
+      localStorage.removeItem('pendingMessage');
+    }
+  }, []);
+
   const getMessageLink = async (id) => {
     const host = RCInstance.getHost();
     const res = await RCInstance.channelInfo();
@@ -252,6 +289,21 @@ const ChatInput = ({ scrollToBottom }) => {
     }
   };
 
+  const handleOffline = (pendingMessage) => {
+    localStorage.removeItem('pendingMessage');
+    localStorage.setItem('pendingMessage', JSON.stringify(pendingMessage));
+
+    setMessageQueue((prevQueue) => [
+      ...prevQueue,
+      JSON.stringify(pendingMessage),
+    ]);
+
+    dispatchToastMessage({
+      type: 'info',
+      message: 'Message will be sent automatically once you are back online!',
+    });
+  };
+
   const handleSendNewMessage = async (message) => {
     messageRef.current.value = '';
     setDisableButton(true);
@@ -293,6 +345,11 @@ const ChatInput = ({ scrollToBottom }) => {
 
     upsertMessage(pendingMessage, ECOptions.enableThreads);
 
+    if (!navigator.onLine) {
+      handleOffline(pendingMessage);
+      return;
+    }
+
     const res = await RCInstance.sendMessage(
       {
         msg: pendingMessage.msg,
@@ -308,6 +365,14 @@ const ChatInput = ({ scrollToBottom }) => {
   };
 
   const handleEditMessage = async (message) => {
+    if (!navigator.onLine) {
+      dispatchToastMessage({
+        type: 'error',
+        message: 'Please try again after connecting to internet!',
+      });
+      return;
+    }
+
     messageRef.current.value = '';
     setDisableButton(true);
     const editMessageId = editMessage._id;


### PR DESCRIPTION
# Brief Title
Added draft-saving feature for messages, which automatically sends them when the internet is restored.

## Acceptance Criteria fulfillment

- [X] Add a draft-saving feature for messages, which automatically sends them when the internet is restored.
- [X]  If multiple messages are queued while offline, ensure that all of them are sent in order once the connection is restored, as long as the user remains on that screen.
- [X] There is no need to send the messages if the user closes the tab.
- [X] For the last unsent message that was typed, populate it back into the input box when the user returns to the page.

## Also added the following:
- [X] Added validation for the edit message functionality. When editing a message, if the internet is disconnected, a popup will appear saying, "Please try again after connecting to internet!".
- [X] Added the same validation for the send file message functionality. When sending a file, if the internet is disconnected, a popup will appear.
- [X] Added upsert message functionality for audio, video, and file messages, which was previously only available for text messages. This functionality ensures the UI remains consistent across online, offline, and slow internet scenarios.


Fixes #721

## Video/Screenshots

1. **Demo video:**  [click here](https://youtu.be/5n9FgXYpsik)

In the above video, I have not shown a demo for the video messages but that too works as expected. 


Upsert message functionality for file messages (consistent UI).
(To see the upsert message functionality for audio messages, refer to the demo video above.)


https://github.com/user-attachments/assets/3e75e9a0-70e4-4d87-83ae-87dfcf156af6


Validation for File Messages.


https://github.com/user-attachments/assets/64481555-b923-417e-8ef9-42dd326fb793



Validation for Edit Messages.


https://github.com/user-attachments/assets/3acb3ef8-d7d2-4f86-b22d-532405cf85f1



## PR Test Details

**Note**: The PR will be ready for live testing at https://rocketchat.github.io/EmbeddedChat/pulls/pr-722 after approval. Contributors are requested to replace `<pr_number>` with the actual PR number.
