### PR TITLE
BUG: Removed extra top space for audio and video messages to improve UI consistency

### DIFF
--- a/packages/react/src/views/AttachmentHandler/AttachmentMetadata.js
+++ b/packages/react/src/views/AttachmentHandler/AttachmentMetadata.js
@@ -32,15 +32,7 @@ const AttachmentMetadata = ({ attachment, url, variantStyles = {} }) => {
         variantStyles.attachmentMetaContainer,
       ]}
     >
-      <p
-        css={[
-          css`
-            margin: 9px 0 0;
-          `,
-        ]}
-      >
-        {attachment.description}
-      </p>
+      <p css={[css``]}>{attachment.description}</p>
       <Box
         css={css`
           display: flex;

--- a/packages/react/src/views/AttachmentHandler/AudioAttachment.js
+++ b/packages/react/src/views/AttachmentHandler/AudioAttachment.js
@@ -21,7 +21,6 @@ const AudioAttachment = ({ attachment, host, type, author, variantStyles }) => {
           css`
             line-height: 0;
             border-radius: inherit;
-            padding: 0.5rem;
           `,
           (type ? variantStyles.pinnedContainer : '') ||
             css`

--- a/packages/react/src/views/AttachmentHandler/VideoAttachment.js
+++ b/packages/react/src/views/AttachmentHandler/VideoAttachment.js
@@ -37,7 +37,6 @@ const VideoAttachment = ({
           css`
             line-height: 0;
             border-radius: inherit;
-            padding: 0.5rem;
           `,
           (type ? variantStyles.pinnedContainer : '') ||
             css`


### PR DESCRIPTION
# Brief Title
Removed Extra Space Above Audio and Video Messages

## Acceptance Criteria fulfillment

- [X] Remove the unnecessary space above audio and video messages to make the UI consistent with text and file messages.
- [X] Verify that the change does not introduce any issues with other message types or UI elements.

Fixes #727

## Video/Screenshots


https://github.com/user-attachments/assets/db905263-3187-4e12-81ea-bdb789952665



## PR Test Details

**Note**: The PR will be ready for live testing at https://rocketchat.github.io/EmbeddedChat/pulls/pr-728 after approval. Contributors are requested to replace `<pr_number>` with the actual PR number.
