### PR TITLE
Fix: permission issues for video and audio message

### DIFF
--- a/packages/react/src/views/ChatInput/AudioMessageRecorder.js
+++ b/packages/react/src/views/ChatInput/AudioMessageRecorder.js
@@ -5,7 +5,13 @@ import React, {
   useContext,
   useRef,
 } from 'react';
-import { Box, Icon, ActionButton, useTheme } from '@embeddedchat/ui-elements';
+import {
+  Box,
+  Icon,
+  ActionButton,
+  useTheme,
+  useToastBarDispatch,
+} from '@embeddedchat/ui-elements';
 import { useMediaRecorder } from '../../hooks/useMediaRecorder';
 import RCContext from '../../context/RCInstance';
 import useMessageStore from '../../store/messageStore';
@@ -26,6 +32,7 @@ const AudioMessageRecorder = () => {
   const [file, setFile] = useState(null);
   const [isRecorded, setIsRecorded] = useState(false);
   const threadId = useMessageStore((_state) => _state.threadMainMessage?._id);
+  const dispatchToastMessage = useToastBarDispatch();
   const onStop = (audioChunks) => {
     const audioBlob = new Blob(audioChunks, { type: 'audio/mpeg' });
     const fileName = 'Audio record.mp3';
@@ -48,9 +55,11 @@ const AudioMessageRecorder = () => {
     setRecordState('idle');
   };
 
-  const handleRecordButtonClick = () => {
-    setRecordState('recording');
+  const handleRecordButtonClick = async () => {
     try {
+      await navigator.mediaDevices.getUserMedia({ audio: true });
+
+      setRecordState('recording');
       start();
       toogleRecordingMessage();
       const startTime = new Date();
@@ -70,6 +79,10 @@ const AudioMessageRecorder = () => {
       );
     } catch (error) {
       console.log(error);
+      dispatchToastMessage({
+        type: 'error',
+        message: 'Unable to access the microphone. Please grant permissions.',
+      });
       setRecordState('idle');
     }
   };

--- a/packages/react/src/views/ChatInput/VideoMessageRecoder.js
+++ b/packages/react/src/views/ChatInput/VideoMessageRecoder.js
@@ -12,6 +12,7 @@ import {
   ActionButton,
   Modal,
   useTheme,
+  useToastBarDispatch,
 } from '@embeddedchat/ui-elements';
 import { useMediaRecorder } from '../../hooks/useMediaRecorder';
 import RCContext from '../../context/RCInstance';
@@ -34,7 +35,7 @@ const VideoMessageRecorder = () => {
   const [file, setFile] = useState(null);
   const [isRecorded, setIsRecorded] = useState(false);
   const threadId = useMessageStore((_state) => _state.threadMainMessage?._id);
-
+  const dispatchToastMessage = useToastBarDispatch();
   const onStop = (videoChunks) => {
     const videoBlob = new Blob(videoChunks, { type: 'video/mp4' });
     const fileName = 'Video record.mp4';
@@ -57,9 +58,10 @@ const VideoMessageRecorder = () => {
     setRecordState('idle');
   };
 
-  const handleRecordButtonClick = () => {
-    setRecordState('recording');
+  const handleRecordButtonClick = async () => {
     try {
+      await navigator.mediaDevices.getUserMedia({ audio: true, video: true });
+      setRecordState('recording');
       start(videoRef.current);
       toogleRecordingMessage();
       const startTime = new Date();
@@ -78,7 +80,11 @@ const VideoMessageRecorder = () => {
         }, 1000)
       );
     } catch (error) {
-      console.log(error);
+      dispatchToastMessage({
+        type: 'error',
+        message:
+          'Unable to access microphone or camera. Please grant permissions.',
+      });
       setRecordState('idle');
     }
   };


### PR DESCRIPTION
# Brief Title
Prevent audio icon from changing its state and video icon to display modal if permissions are not granated and display an error toastbar message 

## Acceptance Criteria fulfillment

- [ ] Ensure the recorder does not start without microphone or camera permissions.
- [ ] Display an error message via the toast bar when permissions are missing.
- [ ] Prevent the recording state from changing if permissions are denied.

Fixes #729 

## Video/Screenshots
[Screencast from 2024-12-24 17-38-01.webm](https://github.com/user-attachments/assets/06024232-ea5d-4c74-bbf3-bd47fa056371)

## PR Test Details

**Note**: The PR will be ready for live testing at https://rocketchat.github.io/EmbeddedChat/pulls/pr-<pr_number> after approval. Contributors are requested to replace `<pr_number>` with the actual PR number.
