### PR TITLE
Feat: add edit room information feature

### DIFF
--- a/packages/react/src/hooks/useRCAuth.js
+++ b/packages/react/src/hooks/useRCAuth.js
@@ -5,6 +5,7 @@ import {
   useUserStore,
   totpModalStore,
   useLoginStore,
+  useChannelStore,
   useMessageStore,
 } from '../store';
 
@@ -30,6 +31,9 @@ export const useRCAuth = () => {
   );
   const setEditMessagePermissions = useMessageStore(
     (state) => state.setEditMessagePermissions
+  );
+  const setEditRoomInfoPermission = useChannelStore(
+    (state) => state.setEditRoomInfoPermission
   );
   const dispatchToastMessage = useToastBarDispatch();
 
@@ -70,6 +74,7 @@ export const useRCAuth = () => {
           setPassword(null);
           setUserPinPermissions(permissions.update[150]);
           setEditMessagePermissions(permissions.update[28]);
+          setEditRoomInfoPermission(permissions.update[36].roles);
           dispatchToastMessage({
             type: 'success',
             message: 'Successfully logged in',

--- a/packages/react/src/store/channelStore.js
+++ b/packages/react/src/store/channelStore.js
@@ -2,8 +2,11 @@ import { create } from 'zustand';
 
 const useChannelStore = create((set) => ({
   showChannelinfo: false,
+  editRoomInfoPermission: [],
   isChannelPrivate: false,
   isChannelReadOnly: false,
+  setEditRoomInfoPermission: (editRoomInfoPermission) =>
+    set(() => ({ editRoomInfoPermission })),
   setShowChannelinfo: (showChannelinfo) => set(() => ({ showChannelinfo })),
   channelInfo: {},
   setChannelInfo: (channelInfo) => set(() => ({ channelInfo })),

--- a/packages/react/src/views/ChatBody/ChatBody.js
+++ b/packages/react/src/views/ChatBody/ChatBody.js
@@ -6,6 +6,7 @@ import {
   Box,
   Throbber,
   useComponentOverrides,
+  Modal,
 } from '@embeddedchat/ui-elements';
 import RCContext from '../../context/RCInstance';
 import {
@@ -48,6 +49,8 @@ const ChatBody = ({
   const upsertMessage = useMessageStore((state) => state.upsertMessage);
   const removeMessage = useMessageStore((state) => state.removeMessage);
   const isChannelPrivate = useChannelStore((state) => state.isChannelPrivate);
+  const channelInfo = useChannelStore((state) => state.channelInfo);
+  const [isModalOpen, setIsModalOpen] = useState(false);
   const isLoginIn = useLoginStore((state) => state.isLoginIn);
 
   const [isThreadOpen, threadMainMessage] = useMessageStore((state) => [
@@ -204,6 +207,38 @@ const ChatBody = ({
 
   return (
     <>
+      {isModalOpen && (
+        <Modal>
+          <Modal.Header>
+            <Modal.Title>Announcement</Modal.Title>
+            <Modal.Close onClick={() => setIsModalOpen(false)} />
+          </Modal.Header>
+          <Modal.Content>
+            <Box
+              css={css`
+                min-height: 100px;
+              `}
+            >
+              {channelInfo?.announcement}
+            </Box>
+          </Modal.Content>
+        </Modal>
+      )}
+      {channelInfo?.announcement && (
+        <Box css={styles.announcementContainer}>
+          <Box
+            style={{
+              maxWidth: '50%',
+              overflow: 'hidden',
+              textOverflow: 'ellipsis',
+              cursor: 'pointer',
+            }}
+            onClick={() => setIsModalOpen(true)}
+          >
+            {channelInfo?.announcement}
+          </Box>
+        </Box>
+      )}
       <Box
         ref={messageListRef}
         css={styles.chatbodyContainer}

--- a/packages/react/src/views/ChatBody/ChatBody.styles.js
+++ b/packages/react/src/views/ChatBody/ChatBody.styles.js
@@ -14,6 +14,13 @@ export const getChatbodyStyles = () => {
       padding-top: 70px;
       margin-top: 0.25rem;
     `,
+    announcementContainer: css`
+      background-color: #a8c3eb;
+      height: 30px;
+      display: flex;
+      justify-content: center;
+      align-items: center;
+    `,
   };
 
   return styles;

--- a/packages/react/src/views/ChatHeader/ChatHeader.js
+++ b/packages/react/src/views/ChatHeader/ChatHeader.js
@@ -126,7 +126,10 @@ const ChatHeader = ({
   };
   const setCanSendMsg = useUserStore((state) => state.setCanSendMsg);
   const authenticatedUserId = useUserStore((state) => state.userId);
-
+  const getChannelAvatarURL = (channelname) => {
+    const host = RCInstance.getHost();
+    return `${host}/avatar/${channelname}`;
+  };
   const handleLogout = useCallback(async () => {
     try {
       await RCInstance.logout();
@@ -359,12 +362,12 @@ const ChatHeader = ({
                   {channelInfo.name || channelName || 'channelName'}
                 </Heading>
                 {fullScreen && (
-                  <p
+                  <div
                     className="ec-chat-header--channelDescription"
-                    css={styles.clearSpacing}
+                    style={{ fontSize: '0.75rem' }}
                   >
-                    {channelInfo.description || ''}
-                  </p>
+                    {channelInfo.topic || ''}
+                  </div>
                 )}
               </>
             ) : (
@@ -396,7 +399,6 @@ const ChatHeader = ({
           iconName="arrow-back"
         />
       )}
-
       {!isThreadOpen && filtered && (
         <DynamicHeader
           title={headerTitle}

--- a/packages/react/src/views/EmbeddedChat.js
+++ b/packages/react/src/views/EmbeddedChat.js
@@ -18,7 +18,12 @@ import {
 import { ChatLayout } from './ChatLayout';
 import { ChatHeader } from './ChatHeader';
 import { RCInstanceProvider } from '../context/RCInstance';
-import { useUserStore, useLoginStore, useMessageStore } from '../store';
+import {
+  useUserStore,
+  useLoginStore,
+  useMessageStore,
+  useChannelStore,
+} from '../store';
 import DefaultTheme from '../theme/DefaultTheme';
 import { getTokenStorage } from '../lib/auth';
 import { styles } from './EmbeddedChat.styles';
@@ -86,7 +91,9 @@ const EmbeddedChat = (props) => {
   const setUserPinPermissions = useUserStore(
     (state) => state.setUserPinPermissions
   );
-
+  const setEditRoomInfoPermission = useChannelStore(
+    (state) => state.setEditRoomInfoPermission
+  );
   const setEditMessagePermissions = useMessageStore(
     (state) => state.setEditMessagePermissions
   );
@@ -132,6 +139,7 @@ const EmbeddedChat = (props) => {
       try {
         await RCInstance.autoLogin(auth);
         const permissions = await RCInstance.permissionInfo();
+        setEditRoomInfoPermission(permissions.update[36].roles);
         setUserPinPermissions(permissions.update[150]);
         setEditMessagePermissions(permissions.update[28]);
       } catch (error) {

--- a/packages/react/src/views/RoomInformation/RoomInfoEdit.js
+++ b/packages/react/src/views/RoomInformation/RoomInfoEdit.js
@@ -1,0 +1,110 @@
+import React, { useState, useContext } from 'react';
+import { css } from '@emotion/react';
+import {
+  Box,
+  Input,
+  Button,
+  useToastBarDispatch,
+} from '@embeddedchat/ui-elements';
+import RCContext from '../../context/RCInstance';
+
+const RoomInfoEdit = ({ channelInfo, onSave }) => {
+  const Instance = useContext(RCContext);
+  const dispatchToastMessage = useToastBarDispatch();
+  const [name, setName] = useState(channelInfo.name);
+  const [topic, setTopic] = useState(channelInfo.topic);
+  const [announcement, setAnnouncement] = useState(channelInfo.announcement);
+  const [description, setDescription] = useState(channelInfo.description);
+
+  const handleSave = async () => {
+    if (!name.trim()) {
+      dispatchToastMessage({
+        type: 'error',
+        message: 'Room name is required',
+      });
+      return;
+    }
+    const updatedChannelInfo = {
+      name,
+      topic,
+      announcement,
+      description,
+    };
+    try {
+      await Instance.RCInstance.setRoomInfo(updatedChannelInfo);
+      onSave(updatedChannelInfo);
+      dispatchToastMessage({
+        type: 'success',
+        message: 'Room information updated successfully',
+      });
+    } catch (error) {
+      console.error('Error updating room info:', error);
+    }
+  };
+
+  return (
+    <Box
+      css={css`
+        padding: 1rem;
+        display: flex;
+        flex-direction: column;
+        gap: 10px;
+      `}
+    >
+      <Box
+        css={css`
+          font-weight: 900;
+        `}
+      >
+        Name
+      </Box>
+      <Input value={name} onChange={(e) => setName(e.target.value)} />
+
+      <Box
+        css={css`
+          font-weight: 900;
+        `}
+      >
+        Topic
+      </Box>
+      <Input value={topic} onChange={(e) => setTopic(e.target.value)} />
+
+      <Box
+        css={css`
+          font-weight: 900;
+        `}
+      >
+        Announcement
+      </Box>
+      <Input
+        value={announcement}
+        onChange={(e) => setAnnouncement(e.target.value)}
+      />
+
+      <Box
+        css={css`
+          font-weight: 900;
+        `}
+      >
+        Description
+      </Box>
+      <Input
+        value={description}
+        onChange={(e) => setDescription(e.target.value)}
+      />
+
+      <Button
+        onClick={handleSave}
+        style={{
+          position: 'sticky',
+          backgroundColor: '#156ff5',
+          fontWeight: '600',
+        }}
+      >
+        Save
+      </Button>
+    </Box>
+  );
+};
+
+export default RoomInfoEdit;

--- a/packages/react/src/views/RoomInformation/RoomInformation.js
+++ b/packages/react/src/views/RoomInformation/RoomInformation.js
@@ -1,29 +1,49 @@
-import React, { useContext } from 'react';
+import React, { useContext, useState } from 'react';
 import { css } from '@emotion/react';
 import {
   Box,
   Avatar,
   Sidebar,
   Popup,
+  Button,
   useComponentOverrides,
 } from '@embeddedchat/ui-elements';
 import RCContext from '../../context/RCInstance';
-import { useChannelStore } from '../../store';
+import { useChannelStore, useUserStore } from '../../store';
 import useSetExclusiveState from '../../hooks/useSetExclusiveState';
+import { getRoomStyles } from './RoomInformation.styles';
+import RoomInfoEdit from './RoomInfoEdit';
 
-const Roominfo = () => {
+const RoomInformation = () => {
   const { RCInstance } = useContext(RCContext);
-
-  const channelInfo = useChannelStore((state) => state.channelInfo);
+  const styles = getRoomStyles();
+  const { channelInfo, setChannelInfo, editRoomInfoPermission } =
+    useChannelStore();
+  const editRoles = new Set(editRoomInfoPermission);
   const { variantOverrides } = useComponentOverrides('RoomMember');
   const viewType = variantOverrides.viewType || 'Sidebar';
   const setExclusiveState = useSetExclusiveState();
+  const [isEditing, setIsEditing] = useState(false);
+  const userRoles = useUserStore((state) => state.roles);
   const getChannelAvatarURL = (channelname) => {
     const host = RCInstance.getHost();
     return `${host}/avatar/${channelname}`;
   };
 
+  const handleSave = (updatedChannelInfo) => {
+    const updatedInfo = {
+      ...channelInfo,
+      name: updatedChannelInfo.name,
+      description: updatedChannelInfo.description,
+      announcement: updatedChannelInfo.announcement,
+      topic: updatedChannelInfo.topic,
+    };
+    setChannelInfo(updatedInfo);
+    setIsEditing(false);
+  };
+
   const ViewComponent = viewType === 'Popup' ? Popup : Sidebar;
+  const isAllowedToEdit = userRoles.some((role) => editRoles.has(role));
 
   return (
     <ViewComponent
@@ -31,50 +51,104 @@ const Roominfo = () => {
       iconName="info"
       onClose={() => setExclusiveState(null)}
       style={{ width: '400px', zIndex: window.innerWidth <= 780 ? 1 : null }}
-      {...(viewType === 'Popup'
-        ? {
-            isPopupHeader: true,
-          }
-        : {})}
+      {...(viewType === 'Popup' ? { isPopupHeader: true } : {})}
     >
-      <Box
-        css={css`
-          padding: 0 1rem 1rem;
-          margin: 0 auto;
-          overflow: auto;
-        `}
-      >
-        <Avatar size="100%" url={getChannelAvatarURL(channelInfo.name)} />
-        <Box
-          css={css`
-            margin: 16px;
-          `}
-        >
-          <Box
-            css={css`
-              margin-block: 16px;
-              font-size: 1.25rem;
-            `}
-          >
-            # {channelInfo.name}
-          </Box>
-          <Box
-            css={css`
-              margin-block: 5px;
-            `}
-          >
-            Description
-          </Box>
-          <Box
-            css={css`
-              opacity: 0.5rem;
-            `}
-          >
-            {channelInfo.description}
-          </Box>
-        </Box>
+      <Box css={styles.container}>
+        {!isEditing ? (
+          <>
+            <Avatar size="100%" url={getChannelAvatarURL(channelInfo.name)} />
+
+            <Box
+              css={css`
+                margin: 16px;
+                display: flex;
+                flex-direction: column;
+                gap: 5px;
+              `}
+            >
+              <Box
+                css={css`
+                  margin-block: 16px;
+                  font-size: 1.25rem;
+                `}
+              >
+                # {channelInfo.name}
+              </Box>
+              {channelInfo.description && (
+                <>
+                  <Box
+                    css={css`
+                      margin-block: 5px;
+                      font-weight: 900;
+                    `}
+                  >
+                    Description
+                  </Box>
+                  <Box
+                    css={css`
+                      opacity: 0.5rem;
+                    `}
+                  >
+                    {channelInfo.description}
+                  </Box>
+                </>
+              )}
+              {channelInfo.announcement && (
+                <>
+                  <Box
+                    css={css`
+                      margin-block: 5px;
+                      font-weight: 900;
+                    `}
+                  >
+                    Announcement
+                  </Box>
+                  <Box
+                    css={css`
+                      opacity: 0.5rem;
+                    `}
+                  >
+                    {channelInfo.announcement}
+                  </Box>
+                </>
+              )}
+              {channelInfo.topic && (
+                <>
+                  <Box
+                    css={css`
+                      margin-block: 5px;
+                      font-weight: 900;
+                    `}
+                  >
+                    Topic
+                  </Box>
+                  <Box
+                    css={css`
+                      opacity: 0.5rem;
+                    `}
+                  >
+                    {channelInfo.topic}
+                  </Box>
+                </>
+              )}
+            </Box>
+            {isAllowedToEdit && (
+              <Button
+                onClick={() => setIsEditing(true)}
+                css={css`
+                  margin-top: 10px;
+                `}
+              >
+                Edit Room Info
+              </Button>
+            )}
+          </>
+        ) : (
+          <RoomInfoEdit channelInfo={channelInfo} onSave={handleSave} />
+        )}
       </Box>
     </ViewComponent>
   );
 };
-export default Roominfo;
+
+export default RoomInformation;

--- a/packages/react/src/views/RoomInformation/RoomInformation.styles.js
+++ b/packages/react/src/views/RoomInformation/RoomInformation.styles.js
@@ -1,0 +1,12 @@
+import { css } from '@emotion/react';
+
+export const getRoomStyles = () => {
+  const styles = {
+    container: css`
+      padding: 0 1rem 1rem;
+      margin: 0 auto;
+      overflow: auto;
+    `,
+  };
+  return styles;
+};


### PR DESCRIPTION
# Brief Title
Allow users with edit permissions to edit room information

## Acceptance Criteria fulfillment

- [ ] Add functionality to edit room name, description, topic, and announcement.
- [ ] Implement a modal to display the announcement.
- [ ] Ensure edit option is only visible to users with edit permission

Fixes #731 

## Video/Screenshots
[Screencast from 2024-12-25 14-54-06.webm](https://github.com/user-attachments/assets/732d7c1f-f9bf-46ea-b9d7-c8b2a8132caa)

## PR Test Details

**Note**: The PR will be ready for live testing at https://rocketchat.github.io/EmbeddedChat/pulls/pr-732 after approval. Contributors are requested to replace `<pr_number>` with the actual PR number.
