### PR TITLE
Fix: Disabled buttons both visually and functionally

### DIFF
--- a/packages/react/src/views/ChatInput/AudioMessageRecorder.js
+++ b/packages/react/src/views/ChatInput/AudioMessageRecorder.js
@@ -11,7 +11,7 @@ import RCContext from '../../context/RCInstance';
 import useMessageStore from '../../store/messageStore';
 import { getCommonRecorderStyles } from './ChatInput.styles';
 
-const AudioMessageRecorder = () => {
+const AudioMessageRecorder = ({ disabled }) => {
   const videoRef = useRef(null);
   const { theme } = useTheme();
   const styles = getCommonRecorderStyles(theme);
@@ -49,6 +49,7 @@ const AudioMessageRecorder = () => {
   };
 
   const handleRecordButtonClick = () => {
+    if (disabled) return;
     setRecordState('recording');
     try {
       start();
@@ -139,7 +140,12 @@ const AudioMessageRecorder = () => {
 
   if (state === 'idle') {
     return (
-      <ActionButton ghost square onClick={handleRecordButtonClick}>
+      <ActionButton
+        ghost
+        square
+        disabled={disabled}
+        onClick={handleRecordButtonClick}
+      >
         <Icon size="1.25rem" name="mic" />
       </ActionButton>
     );

--- a/packages/react/src/views/ChatInput/ChatInputFormattingToolbar.js
+++ b/packages/react/src/views/ChatInput/ChatInputFormattingToolbar.js
@@ -62,6 +62,7 @@ const ChatInputFormattingToolbar = ({
           ghost
           disabled={isRecordingMessage}
           onClick={() => {
+            if (isRecordingMessage) return;
             setEmojiOpen(true);
           }}
         >
@@ -71,12 +72,12 @@ const ChatInputFormattingToolbar = ({
     ),
     audio: (
       <Tooltip text="Audio Message" position="top" key="audio">
-        <AudioMessageRecorder />
+        <AudioMessageRecorder disabled={isRecordingMessage} />
       </Tooltip>
     ),
     video: (
       <Tooltip text="Video Message" position="top" key="video">
-        <VideoMessageRecorder />
+        <VideoMessageRecorder disabled={isRecordingMessage} />
       </Tooltip>
     ),
     file: (
@@ -85,7 +86,10 @@ const ChatInputFormattingToolbar = ({
           square
           ghost
           disabled={isRecordingMessage}
-          onClick={handleClickToOpenFiles}
+          onClick={() => {
+            if (isRecordingMessage) return;
+            handleClickToOpenFiles();
+          }}
         >
           <Icon name="attachment" size="1.25rem" />
         </ActionButton>
@@ -100,6 +104,7 @@ const ChatInputFormattingToolbar = ({
             disabled={isRecordingMessage}
             ghost
             onClick={() => {
+              if (isRecordingMessage) return;
               formatSelection(messageRef, item.pattern);
             }}
           >

--- a/packages/react/src/views/ChatInput/VideoMessageRecoder.js
+++ b/packages/react/src/views/ChatInput/VideoMessageRecoder.js
@@ -18,7 +18,7 @@ import RCContext from '../../context/RCInstance';
 import useMessageStore from '../../store/messageStore';
 import { getCommonRecorderStyles } from './ChatInput.styles';
 
-const VideoMessageRecorder = () => {
+const VideoMessageRecorder = ({ disabled }) => {
   const videoRef = useRef(null);
   const { theme } = useTheme();
   const styles = getCommonRecorderStyles(theme);
@@ -58,6 +58,7 @@ const VideoMessageRecorder = () => {
   };
 
   const handleRecordButtonClick = () => {
+    if (disabled) return;
     setRecordState('recording');
     try {
       start(videoRef.current);
@@ -155,7 +156,12 @@ const VideoMessageRecorder = () => {
   return (
     <>
       {state === 'idle' && (
-        <ActionButton ghost square onClick={handleRecordButtonClick}>
+        <ActionButton
+          ghost
+          square
+          disabled={disabled}
+          onClick={handleRecordButtonClick}
+        >
           <Icon size="1.25rem" name="video-recorder" />
         </ActionButton>
       )}


### PR DESCRIPTION
# Brief Title
Fix: Disabled buttons both visually and functionally. 

## Acceptance Criteria fulfillment

- [X] Buttons such as emoji, bold, italic, strikethrough, code, multiline, and upload file buttons should be visually disabled (with a no-entry cursor) and should not trigger any actions when clicked.
- [X] The video message button should also be disabled while an audio message is being recorded, and should not trigger a video message recording when clicked.

Fixes #735

## Video/Screenshots


https://github.com/user-attachments/assets/f4dc55e1-c882-4e5a-8ba1-9785e1208a46



## PR Test Details

**Note**: The PR will be ready for live testing at https://rocketchat.github.io/EmbeddedChat/pulls/pr-735 after approval. Contributors are requested to replace `<pr_number>` with the actual PR number.
