### PR TITLE
Display user roles (Admin, Leader, Moderator, Owner) next to message headers

### DIFF
--- a/packages/react/src/views/ChatLayout/ChatLayout.js
+++ b/packages/react/src/views/ChatLayout/ChatLayout.js
@@ -38,7 +38,7 @@ const ChatLayout = () => {
   const { classNames, styleOverrides } = useComponentOverrides('ChatBody');
   const { RCInstance, ECOptions } = useRCContext();
   const anonymousMode = ECOptions?.anonymousMode;
-  const showRoles = ECOptions?.anonymousMode;
+  const showRoles = ECOptions?.showRoles;
   const setStarredMessages = useStarredMessageStore(
     (state) => state.setStarredMessages
   );


### PR DESCRIPTION
# Brief Title
Add user role display feature in EmbeddedChat messages

## Acceptance Criteria fulfillment

- [x]  Display roles (Admin, Leader, Moderator, Owner) next to message headers.
- [x] Fetch showRoles permission correctly

Fixes #737 

## Video/Screenshots


https://github.com/user-attachments/assets/bb55f6cb-95b4-49e1-b384-9761fc932b31


## PR Test Details

**Note**: The PR will be ready for live testing at https://rocketchat.github.io/EmbeddedChat/pulls/pr-738 after approval. Contributors are requested to replace `<pr_number>` with the actual PR number.
