### PR TITLE
Feat: Added User Roles Type Filtering for Admins & Displayed User Roles Next to Member Info (Admin View)

### DIFF
--- a/packages/react/src/views/RoomMembers/RoomMember.js
+++ b/packages/react/src/views/RoomMembers/RoomMember.js
@@ -46,6 +46,11 @@ const RoomMembers = ({ members }) => {
   const [roleFilter, setRoleFilter] = useState('all');
   const [filteredMembersByRole, setFilteredMembersByRole] = useState(members);
 
+  const [adminUserIds, setAdminUserIds] = useState(new Set());
+  const [ownerUserIds, setOwnerUserIds] = useState(new Set());
+  const [moderatorUserIds, setModeratorsUserIds] = useState(new Set());
+  const [leaderUserIds, setLeaderUserIds] = useState(new Set());
+
   const [roleData, setRoleData] = useState({
     admin: [],
     all: [],
@@ -61,6 +66,18 @@ const RoomMembers = ({ members }) => {
       const leaderRes = await RCInstance.getUsersInRole('leader');
       const moderatorRes = await RCInstance.getUsersInRole('moderator');
       const ownerRes = await RCInstance.getUsersInRole('owner');
+
+      const adminIds = new Set(adminRes.users.map((user) => user._id));
+      setAdminUserIds(adminIds);
+
+      const OwnerIds = new Set(ownerRes.users.map((user) => user._id));
+      setOwnerUserIds(OwnerIds);
+
+      const ModeratorsIds = new Set(moderatorRes.users.map((user) => user._id));
+      setModeratorsUserIds(ModeratorsIds);
+
+      const LeaderIds = new Set(leaderRes.users.map((user) => user._id));
+      setLeaderUserIds(LeaderIds);
 
       setRoleData({
         admin: adminRes.users || [],
@@ -109,6 +126,22 @@ const RoomMembers = ({ members }) => {
       )
     );
   }, [searchTerm, filteredMembersByRole]);
+
+  const isAdminId = (userId) => {
+    return adminUserIds.has(userId);
+  };
+
+  const isOwnerId = (userId) => {
+    return ownerUserIds.has(userId);
+  };
+
+  const isModeratorId = (userId) => {
+    return moderatorUserIds.has(userId);
+  };
+
+  const isLeaderId = (userId) => {
+    return leaderUserIds.has(userId);
+  };
 
   return (
     <ViewComponent
@@ -183,6 +216,10 @@ const RoomMembers = ({ members }) => {
                         user={member}
                         host={host}
                         key={member._id}
+                        isAdmin={isAdminId(member._id)}
+                        isOwner={isOwnerId(member._id)}
+                        isModerator={isModeratorId(member._id)}
+                        isLeader={isLeaderId(member._id)}
                       />
                     </>
                   ))

--- a/packages/react/src/views/RoomMembers/RoomMember.js
+++ b/packages/react/src/views/RoomMembers/RoomMember.js
@@ -163,7 +163,13 @@ const RoomMembers = ({ members }) => {
       }
     });
 
-    setFilteredMembersByRole(filteredMembersList);
+    const uniqueMembers = Array.from(
+      new Map(
+        filteredMembersList.map((member) => [member._id, member])
+      ).values()
+    );
+
+    setFilteredMembersByRole(uniqueMembers);
   };
 
   return (

--- a/packages/react/src/views/RoomMembers/RoomMemberItem.js
+++ b/packages/react/src/views/RoomMembers/RoomMemberItem.js
@@ -1,16 +1,33 @@
 import React, { useContext, useEffect, useState } from 'react';
 import PropTypes from 'prop-types';
 import { css } from '@emotion/react';
-import { Box, Icon, Avatar } from '@embeddedchat/ui-elements';
+import { Box, Icon, Avatar, useTheme } from '@embeddedchat/ui-elements';
 import RCContext from '../../context/RCInstance';
-import { RoomMemberItemStyles as styles } from './RoomMembers.styles';
+import { RoomMemberItemStyles } from './RoomMembers.styles';
 import useSetExclusiveState from '../../hooks/useSetExclusiveState';
 import { useUserStore } from '../../store';
 
-const RoomMemberItem = ({ user, host }) => {
+const RoomMemberItem = ({
+  user,
+  host,
+  isAdmin,
+  isOwner,
+  isModerator,
+  isLeader,
+}) => {
   const { RCInstance } = useContext(RCContext);
   const [userStatus, setUserStatus] = useState('');
   const avatarUrl = new URL(`avatar/${user.username}`, host).toString();
+
+  const { theme } = useTheme();
+  const styles = RoomMemberItemStyles(theme);
+
+  const adminRole = isAdmin ? <Box css={styles.adminTag}>Admin</Box> : null;
+  const ownerRole = isOwner ? <Box css={styles.ownerTag}>Owner</Box> : null;
+  const moderatorRole = isModerator ? (
+    <Box css={styles.moderatorTag}>Moderator</Box>
+  ) : null;
+  const leaderRole = isLeader ? <Box css={styles.leaderTag}>Leader</Box> : null;
 
   useEffect(() => {
     const getStatus = async () => {
@@ -26,6 +43,7 @@ const RoomMemberItem = ({ user, host }) => {
 
     getStatus();
   }, [RCInstance]);
+
   const setExclusiveState = useSetExclusiveState();
   const { setShowCurrentUserInfo, setCurrentUser } = useUserStore((state) => ({
     setShowCurrentUserInfo: state.setShowCurrentUserInfo,
@@ -36,6 +54,7 @@ const RoomMemberItem = ({ user, host }) => {
     setExclusiveState(setShowCurrentUserInfo);
     setCurrentUser(user);
   };
+
   return (
     <Box
       css={styles.container}
@@ -62,7 +81,8 @@ const RoomMemberItem = ({ user, host }) => {
           <Icon name={userStatus} size="1.25rem" css={styles.icon} />
         )}
         <Box is="span">
-          {user.name} ({user.username})
+          {user.name} ({user.username}) {adminRole} {ownerRole} {moderatorRole}{' '}
+          {leaderRole}
         </Box>
       </Box>
     </Box>

--- a/packages/react/src/views/RoomMembers/RoomMembers.styles.js
+++ b/packages/react/src/views/RoomMembers/RoomMembers.styles.js
@@ -25,6 +25,8 @@ export const getRoomMemberStyles = (theme) => {
       margin-top: 1rem;
       margin-bottom: 2.5rem;
       position: relative;
+      background-color: ${theme.colors.background};
+      width: 100%;
     `,
     textInput: css`
       flex: 1;

--- a/packages/react/src/views/RoomMembers/RoomMembers.styles.js
+++ b/packages/react/src/views/RoomMembers/RoomMembers.styles.js
@@ -55,20 +55,68 @@ export const getRoomMemberStyles = (theme) => {
   return styles;
 };
 
-export const RoomMemberItemStyles = {
-  container: css`
-    width: 100%;
-    padding-bottom: 8px;
-    padding-top: 8px;
-    display: flex;
-    align-items: center;
-  `,
+export const RoomMemberItemStyles = (theme) => {
+  const styles = {
+    container: css`
+      width: 100%;
+      padding-bottom: 8px;
+      padding-top: 8px;
+      display: flex;
+      align-items: center;
+    `,
 
-  icon: css`
-    padding: 0.125em;
-    margin-right: 0.5rem;
-    align-self: center;
-  `,
+    icon: css`
+      padding: 0.125em;
+      margin-right: 0.5rem;
+      align-self: center;
+    `,
+
+    adminTag: css`
+      background-color: ${theme.colors.primary};
+      color: ${theme.colors.primaryForeground};
+      padding: 0.2rem 0.5rem;
+      border-radius: ${theme.radius};
+      font-size: 0.5rem;
+      font-weight: bold;
+      margin-left: 0.3rem;
+      display: inline-block;
+    `,
+
+    ownerTag: css`
+      background-color: ${theme.invertedColors.primary};
+      color: ${theme.invertedColors.primaryForeground};
+      padding: 0.2rem 0.5rem;
+      border-radius: ${theme.radius};
+      font-size: 0.5rem;
+      font-weight: bold;
+      margin-left: 0.3rem;
+      display: inline-block;
+    `,
+
+    moderatorTag: css`
+      background-color: ${theme.colors.secondary};
+      color: ${theme.colors.secondaryForeground};
+      padding: 0.2rem 0.5rem;
+      border-radius: ${theme.radius};
+      font-size: 0.5rem;
+      font-weight: bold;
+      margin-left: 0.3rem;
+      display: inline-block;
+    `,
+
+    leaderTag: css`
+      background-color: ${theme.invertedColors.secondary};
+      color: ${theme.invertedColors.secondaryForeground};
+      padding: 0.2rem 0.5rem;
+      border-radius: ${theme.radius};
+      font-size: 0.5rem;
+      font-weight: bold;
+      margin-left: 0.3rem;
+      display: inline-block;
+    `,
+  };
+
+  return styles;
 };
 
 export const InviteMemberStyles = {

--- a/packages/react/src/views/RoomMembers/RoomMembers.styles.js
+++ b/packages/react/src/views/RoomMembers/RoomMembers.styles.js
@@ -20,6 +20,12 @@ export const getRoomMemberStyles = (theme) => {
       position: relative;
       margin-top: 1rem;
     `,
+    filterContainer: css`
+      border-radius: ${theme.radius};
+      margin-top: 1rem;
+      margin-bottom: 2.5rem;
+      position: relative;
+    `,
     textInput: css`
       flex: 1;
       border: none;


### PR DESCRIPTION
# Brief Title
User Roles Type Filtering for Admins

## Acceptance Criteria fulfillment

- [X] Added a dropdown filter to select specific user roles (Admin, Leader, Moderator, Owner)
- [X] Implemented dynamic filtering logic to show only selected user roles.
- [X] Default state of the filter is set to "All", displaying all user roles until a specific filter is selected.
- [X] Displayed the corresponding user role next to the member info in the members' list UI, for each role except for the only user role.

Fixes #742

## Video/Screenshots



https://github.com/user-attachments/assets/296ce4c7-4aa9-40b0-95f8-b4cd90201698




## PR Test Details

**Note**: The PR will be ready for live testing at https://rocketchat.github.io/EmbeddedChat/pulls/pr-743 after approval. Contributors are requested to replace `<pr_number>` with the actual PR number.
