### PR TITLE
fix: user action messages

### DIFF
--- a/packages/react/src/views/EmbeddedChat.js
+++ b/packages/react/src/views/EmbeddedChat.js
@@ -279,7 +279,6 @@ EmbeddedChat.propTypes = {
   channelName: PropTypes.string,
   anonymousMode: PropTypes.bool,
   toastBarPosition: PropTypes.string,
-  showUsername: PropTypes.bool,
   showRoles: PropTypes.bool,
   showAvatar: PropTypes.bool,
   enableThreads: PropTypes.bool,

--- a/packages/react/src/views/EmbeddedChat.js
+++ b/packages/react/src/views/EmbeddedChat.js
@@ -279,6 +279,7 @@ EmbeddedChat.propTypes = {
   channelName: PropTypes.string,
   anonymousMode: PropTypes.bool,
   toastBarPosition: PropTypes.string,
+  showUsername: PropTypes.bool,
   showRoles: PropTypes.bool,
   showAvatar: PropTypes.bool,
   enableThreads: PropTypes.bool,

--- a/packages/react/src/views/Message/Message.js
+++ b/packages/react/src/views/Message/Message.js
@@ -205,7 +205,10 @@ const Message = ({
             isPinned={isPinned}
           />
         )}
-        <MessageBodyContainer variantStyles={variantStyles}>
+        <MessageBodyContainer
+          variantStyles={variantStyles}
+          style={{ maxWidth: message?.t ? '90%' : null }}
+        >
           {shouldShowHeader && (
             <MessageHeader
               message={message}

--- a/packages/react/src/views/Message/MessageHeader.js
+++ b/packages/react/src/views/Message/MessageHeader.js
@@ -68,6 +68,18 @@ const MessageHeader = ({
         return 'unarchived room';
       case 'room-allowed-reacting':
         return 'allowed reactions';
+      case 'room_changed_announcement':
+        return `changed announcement to: ${
+          message?.msg && message.msg.length > 0 ? message.msg : '(none)'
+        }`;
+      case 'room_changed_description':
+        return `changed description to: ${
+          message?.msg && message.msg.length > 0 ? message.msg : '(none)'
+        }`;
+      case 'room_changed_topic':
+        return `changed topic to: ${
+          message?.msg && message.msg.length > 0 ? message.msg : '(none)'
+        }`;
       default:
         return '';
     }


### PR DESCRIPTION
# Brief Title

This update ensures that user action messages are displayed when the room's topic, announcement, or description is updated. Additionally, it introduces styling changes for better alignment and includes a showUsername prop in Storybook for testing.

## Acceptance Criteria fulfillment

- [ ] Added 3 new cases in the existing switch case to handle topic, announcement, and description updates.
- [ ] Styled `MessageBodyContainer` to set max-width to 90% for proper alignment


Fixes #745 

## Video/Screenshots
[Screencast from 2024-12-28 13-45-07.webm](https://github.com/user-attachments/assets/de869ca4-eba7-4b84-92bc-7e7fc14d8772)

## PR Test Details

**Note**: The PR will be ready for live testing at https://rocketchat.github.io/EmbeddedChat/pulls/pr-746 after approval. Contributors are requested to replace `<pr_number>` with the actual PR number.
