### PR TITLE
fix: display bio, nickname, and statusText in User Info modal; resolve permission issues for viewing full user info

### DIFF
--- a/packages/react/src/hooks/useFetchChatData.js
+++ b/packages/react/src/hooks/useFetchChatData.js
@@ -20,6 +20,9 @@ const useFetchChatData = (showRoles) => {
   const isUserAuthenticated = useUserStore(
     (state) => state.isUserAuthenticated
   );
+  const setViewUserInfoPermissions = useUserStore(
+    (state) => state.setViewUserInfoPermissions
+  );
 
   const getMessagesAndRoles = useCallback(
     async (anonymousMode) => {
@@ -68,6 +71,9 @@ const useFetchChatData = (showRoles) => {
 
           setMemberRoles(rolesObj);
         }
+
+        const permissions = await RCInstance.permissionInfo();
+        setViewUserInfoPermissions(permissions.update[70]);
       } catch (e) {
         console.error(e);
       }

--- a/packages/react/src/store/userStore.js
+++ b/packages/react/src/store/userStore.js
@@ -32,6 +32,9 @@ const useUserStore = create((set) => ({
   userPinPermissions: {},
   setUserPinPermissions: (userPinPermissions) =>
     set((state) => ({ ...state, userPinPermissions })),
+  viewUserInfoPermissions: {},
+  setViewUserInfoPermissions: (viewUserInfoPermissions) =>
+    set((state) => ({ ...state, viewUserInfoPermissions })),
   showCurrentUserInfo: false,
   setShowCurrentUserInfo: (showCurrentUserInfo) =>
     set(() => ({ showCurrentUserInfo })),

--- a/packages/react/src/views/UserInformation/UserInformation.js
+++ b/packages/react/src/views/UserInformation/UserInformation.js
@@ -28,9 +28,15 @@ const UserInformation = () => {
   const [currentUserInfo, setCurrentUserInfo] = useState({});
   const [isUserInfoFetched, setIsUserInfoFetched] = useState(false);
   const currentUser = useUserStore((state) => state.currentUser);
-  const authenticatedUserRoles = useUserStore((state) => state.roles);
+  const currentUserRoles = useUserStore((state) => state.roles);
+  const viewUserFullInfoRoles = useUserStore(
+    (state) => state.viewUserInfoPermissions.roles
+  );
   const authenticatedUserId = useUserStore((state) => state.userId);
-  const isAdmin = authenticatedUserRoles?.includes('admin');
+  const viewInfoRoles = new Set(viewUserFullInfoRoles);
+  const isAllowedToViewFullInfo = currentUserRoles.some((role) =>
+    viewInfoRoles.has(role)
+  );
   const getUserAvatarUrl = (username) => {
     const host = RCInstance.getHost();
     return `${host}/avatar/${username}`;
@@ -96,6 +102,24 @@ const UserInformation = () => {
               />
               {currentUserInfo?.username}
             </Box>
+            {currentUserInfo?.statusText && (
+              <Box
+                css={css`
+                  margin-bottom: 20px;
+                `}
+              >
+                {currentUserInfo?.statusText}
+              </Box>
+            )}
+            {currentUserInfo?.nickname && (
+              <UserInfoField
+                label="Nickname"
+                value={currentUserInfo?.nickname}
+                isAdmin={isAllowedToViewFullInfo}
+                authenticatedUserId={authenticatedUserId}
+                currentUserInfo={currentUserInfo}
+              />
+            )}
             {currentUserInfo?.roles?.length && (
               <UserInfoField
                 label="Roles"
@@ -113,7 +137,7 @@ const UserInformation = () => {
                     ))}
                   </Box>
                 }
-                isAdmin={isAdmin}
+                isAdmin={isAllowedToViewFullInfo}
                 authenticatedUserId={authenticatedUserId}
                 currentUserInfo={currentUserInfo}
               />
@@ -121,7 +145,7 @@ const UserInformation = () => {
             <UserInfoField
               label="Username"
               value={currentUserInfo?.username}
-              isAdmin={isAdmin}
+              isAdmin
               authenticatedUserId={authenticatedUserId}
               currentUserInfo={currentUserInfo}
             />
@@ -132,17 +156,26 @@ const UserInformation = () => {
                   ? 'Never'
                   : formatTimestamp(currentUserInfo.lastLogin)
               }
-              isAdmin={isAdmin}
+              isAdmin={isAllowedToViewFullInfo}
               authenticatedUserId={authenticatedUserId}
               currentUserInfo={currentUserInfo}
             />
             <UserInfoField
               label="Full Name"
               value={currentUserInfo.name}
-              isAdmin={isAdmin}
+              isAdmin={isAllowedToViewFullInfo}
               authenticatedUserId={authenticatedUserId}
               currentUserInfo={currentUserInfo}
             />
+            {currentUserInfo?.bio && (
+              <UserInfoField
+                label="Bio"
+                value={currentUserInfo?.bio}
+                isAdmin={isAllowedToViewFullInfo}
+                authenticatedUserId={authenticatedUserId}
+                currentUserInfo={currentUserInfo}
+              />
+            )}
             <UserInfoField
               label="Email"
               value={currentUserInfo.emails?.map((email, index) => (
@@ -158,14 +191,14 @@ const UserInformation = () => {
                   </Box>
                 </Box>
               ))}
-              isAdmin={isAdmin}
+              isAdmin={isAllowedToViewFullInfo}
               authenticatedUserId={authenticatedUserId}
               currentUserInfo={currentUserInfo}
             />
             <UserInfoField
               label="Created at"
               value={formatTimestamp(currentUserInfo.createdAt)}
-              isAdmin={isAdmin}
+              isAdmin={isAllowedToViewFullInfo}
               authenticatedUserId={authenticatedUserId}
               currentUserInfo={currentUserInfo}
             />


### PR DESCRIPTION
# Brief Title
Fix User Info Modal Issues and Permission Handling

## Acceptance Criteria fulfillment

- [x]  Ensure bio, nickname, and statusText are displayed in the User Info modal when set.
- [x] Allow normal users to view the username and statusText of other users.
- [x] Fix permission logic to allow normal users to access full user information when granted by admin.

Fixes #755 

## Video/Screenshots


https://github.com/user-attachments/assets/f871934b-a8b3-4efc-b375-a74ef545c62c



## PR Test Details

**Note**: The PR will be ready for live testing at https://rocketchat.github.io/EmbeddedChat/pulls/pr-756 after approval. Contributors are requested to replace `<pr_number>` with the actual PR number.
