### PR TITLE
fix: quote message window content display and markdown issues

### DIFF
--- a/packages/react/src/views/AttachmentHandler/TextAttachment.js
+++ b/packages/react/src/views/AttachmentHandler/TextAttachment.js
@@ -3,6 +3,7 @@ import { css } from '@emotion/react';
 import PropTypes from 'prop-types';
 import { Box, Avatar, useTheme } from '@embeddedchat/ui-elements';
 import RCContext from '../../context/RCInstance';
+import { Markdown } from '../Markdown';
 
 const TextAttachment = ({ attachment, type, variantStyles = {} }) => {
   const { RCInstance } = useContext(RCContext);
@@ -62,11 +63,19 @@ const TextAttachment = ({ attachment, type, variantStyles = {} }) => {
           white-space: pre-line;
         `}
       >
-        {attachment?.text
-          ? attachment.text[0] === '['
-            ? attachment.text.match(/\n(.*)/)?.[1] || ''
-            : attachment.text
-          : ''}
+        {attachment?.text ? (
+          attachment.text[0] === '[' ? (
+            attachment.text.match(/\n(.*)/)?.[1] || ''
+          ) : (
+            <Markdown
+              body={attachment.text}
+              md={attachment.md}
+              isReaction={false}
+            />
+          )
+        ) : (
+          ''
+        )}
         {attachment?.attachments &&
           attachment.attachments.map((nestedAttachment, index) => (
             <Box
@@ -125,11 +134,19 @@ const TextAttachment = ({ attachment, type, variantStyles = {} }) => {
                   white-space: pre-line;
                 `}
               >
-                {nestedAttachment?.text
-                  ? nestedAttachment.text[0] === '['
-                    ? nestedAttachment.text.match(/\n(.*)/)?.[1] || ''
-                    : nestedAttachment.text
-                  : ''}
+                {nestedAttachment?.text ? (
+                  nestedAttachment.text[0] === '[' ? (
+                    nestedAttachment.text.match(/\n(.*)/)?.[1] || ''
+                  ) : (
+                    <Markdown
+                      body={nestedAttachment.text}
+                      md={nestedAttachment.md}
+                      isReaction={false}
+                    />
+                  )
+                ) : (
+                  ''
+                )}
               </Box>
             </Box>
           ))}

--- a/packages/react/src/views/Message/MessageToolbox.js
+++ b/packages/react/src/views/Message/MessageToolbox.js
@@ -1,4 +1,4 @@
-import React, { useState, useMemo } from 'react';
+import React, { useState, useContext, useMemo } from 'react';
 import {
   Box,
   Modal,
@@ -9,10 +9,12 @@ import {
   appendClassNames,
   useTheme,
 } from '@embeddedchat/ui-elements';
+import RCContext from '../../context/RCInstance';
 import { EmojiPicker } from '../EmojiPicker';
 import { getMessageToolboxStyles } from './Message.styles';
 import SurfaceMenu from '../SurfaceMenu/SurfaceMenu';
 import { Markdown } from '../Markdown';
+import Attachment from '../AttachmentHandler/Attachment';
 
 export const MessageToolbox = ({
   className = '',
@@ -59,6 +61,8 @@ export const MessageToolbox = ({
     className,
     style
   );
+  const { RCInstance } = useContext(RCContext);
+  const instanceHost = RCInstance.getHost();
   const { theme } = useTheme();
   const styles = getMessageToolboxStyles(theme);
   const surfaceItems =
@@ -269,13 +273,61 @@ export const MessageToolbox = ({
           </Modal.Header>
           <Modal.Content
             style={{
-              overflow: 'hidden',
-              textOverflow: 'ellipsis',
-              whiteSpace: 'nowrap',
-              padding: '0 0.5rem 0.5rem',
+              overflow: 'scroll',
+              whiteSpace: 'wrap',
+              padding: '1rem',
+              maxHeight: '50vh',
             }}
           >
-            <Markdown body={message} isReaction={false} />
+            {message.file ? (
+              message.file.type.startsWith('image/') ? (
+                <div>
+                  <img
+                    src={`${instanceHost}/file-upload/${message.file._id}/${message.file.name}`}
+                    alt={message.file.name}
+                    style={{ maxWidth: '100px', maxHeight: '100px' }}
+                  />
+                  <div>{`${message.file.name} (${(
+                    message.file.size / 1024
+                  ).toFixed(2)} kB)`}</div>
+                </div>
+              ) : message.file.type.startsWith('video/') ? (
+                <video
+                  controls
+                  style={{ maxWidth: '100%', maxHeight: '200px' }}
+                >
+                  <source
+                    src={`${instanceHost}/file-upload/${message.file._id}/${message.file.name}`}
+                    type={message.file.type}
+                  />
+                  Your browser does not support the video tag.
+                </video>
+              ) : message.file.type.startsWith('audio/') ? (
+                <audio controls style={{ maxWidth: '100%' }}>
+                  <source
+                    src={`${instanceHost}/file-upload/${message.file._id}/${message.file.name}`}
+                    type={message.file.type}
+                  />
+                  Your browser does not support the audio element.
+                </audio>
+              ) : (
+                <Markdown body={message} md={message.md} isReaction={false} />
+              )
+            ) : (
+              <Markdown body={message} md={message.md} isReaction={false} />
+            )}
+            {message.attachments &&
+              message.attachments.length > 0 &&
+              message.msg &&
+              message.msg[0] === '[' &&
+              message.attachments.map((attachment, index) => (
+                <Attachment
+                  key={index}
+                  attachment={attachment}
+                  type={attachment.type}
+                  host={instanceHost}
+                />
+              ))}
           </Modal.Content>
           <Modal.Footer>
             <Button type="secondary" onClick={handleOnClose}>

--- a/packages/react/src/views/QuoteMessage/QuoteMessage.js
+++ b/packages/react/src/views/QuoteMessage/QuoteMessage.js
@@ -85,7 +85,7 @@ const QuoteMessage = ({ className = '', style = {}, message }) => {
           ) : (
             <Box css={styles.message}>
               {message.msg ? (
-                <Markdown body={message} isReaction={false} />
+                <Markdown body={message} md={message.md} isReaction={false} />
               ) : (
                 `${message.file?.name} (${
                   message.file?.size ? (message.file.size / 1024).toFixed(2) : 0
@@ -96,7 +96,7 @@ const QuoteMessage = ({ className = '', style = {}, message }) => {
         ) : message?.msg[0] === '[' ? (
           message?.msg.match(/\n(.*)/)[1]
         ) : (
-          <Markdown body={message} isReaction={false} />
+          <Markdown body={message} md={message.md} isReaction={false} />
         )}
         {message.attachments &&
           message.attachments.length > 0 &&


### PR DESCRIPTION
# Brief Title

## Acceptance Criteria fulfillment

- [ ] Passed an `md` prop for markdown components inside the delete modal and quote messages.
- [ ] Rendered Quote messages with markdown
- [ ]  Included message content inside the delete message modal.

Fixes #773 

## Video/Screenshots
[Screencast from 2025-01-02 22-10-23.webm](https://github.com/user-attachments/assets/9581de58-2d02-4765-98cf-e386a330b319)


## PR Test Details

**Note**: The PR will be ready for live testing at https://rocketchat.github.io/EmbeddedChat/pulls/pr-774 after approval. Contributors are requested to replace `<pr_number>` with the actual PR number.
