### PR TITLE
Fixed the errors occured due to statically setting the values of various permissions

### DIFF
--- a/packages/react/src/hooks/useFetchChatData.js
+++ b/packages/react/src/hooks/useFetchChatData.js
@@ -20,9 +20,6 @@ const useFetchChatData = (showRoles) => {
   const isUserAuthenticated = useUserStore(
     (state) => state.isUserAuthenticated
   );
-  const setViewUserInfoPermissions = useUserStore(
-    (state) => state.setViewUserInfoPermissions
-  );
 
   const getMessagesAndRoles = useCallback(
     async (anonymousMode) => {
@@ -71,9 +68,6 @@ const useFetchChatData = (showRoles) => {
 
           setMemberRoles(rolesObj);
         }
-
-        const permissions = await RCInstance.permissionInfo();
-        setViewUserInfoPermissions(permissions.update[70]);
       } catch (e) {
         console.error(e);
       }

--- a/packages/react/src/hooks/useRCAuth.js
+++ b/packages/react/src/hooks/useRCAuth.js
@@ -25,9 +25,6 @@ export const useRCAuth = () => {
   );
   const setPassword = useUserStore((state) => state.setPassword);
   const setEmailorUser = useUserStore((state) => state.setEmailorUser);
-  const setUserPinPermissions = useUserStore(
-    (state) => state.setUserPinPermissions
-  );
   const setEditMessagePermissions = useMessageStore(
     (state) => state.setEditMessagePermissions
   );
@@ -68,7 +65,6 @@ export const useRCAuth = () => {
           setIsTotpModalOpen(false);
           setEmailorUser(null);
           setPassword(null);
-          setUserPinPermissions(permissions.update[150]);
           setEditMessagePermissions(permissions.update[28]);
           dispatchToastMessage({
             type: 'success',

--- a/packages/react/src/views/EmbeddedChat.js
+++ b/packages/react/src/views/EmbeddedChat.js
@@ -84,13 +84,7 @@ const EmbeddedChat = (props) => {
   }));
 
   const setIsLoginIn = useLoginStore((state) => state.setIsLoginIn);
-  const setUserPinPermissions = useUserStore(
-    (state) => state.setUserPinPermissions
-  );
 
-  const setEditMessagePermissions = useMessageStore(
-    (state) => state.setEditMessagePermissions
-  );
   if (isClosable && !setClosableState) {
     throw Error(
       'Please provide a setClosableState to props when isClosable = true'
@@ -132,9 +126,6 @@ const EmbeddedChat = (props) => {
       setIsLoginIn(true);
       try {
         await RCInstance.autoLogin(auth);
-        const permissions = await RCInstance.permissionInfo();
-        setUserPinPermissions(permissions.update[150]);
-        setEditMessagePermissions(permissions.update[28]);
       } catch (error) {
         console.error(error);
       } finally {

--- a/packages/react/src/views/Message/Message.js
+++ b/packages/react/src/views/Message/Message.js
@@ -75,8 +75,6 @@ const Message = ({
   const theme = useTheme();
   const styles = getMessageStyles(theme);
   const bubbleStyles = useBubbleStyles(isMe);
-  const pinRoles = new Set(pinPermissions);
-  const editMessageRoles = new Set(editMessagePermissions);
 
   const variantStyles =
     !isInSidebar && variantOverrides === 'bubble' ? bubbleStyles : {};
@@ -262,8 +260,6 @@ const Message = ({
                     isEditing={editMessage._id === message._id}
                     authenticatedUserId={authenticatedUserId}
                     userRoles={userRoles}
-                    pinRoles={pinRoles}
-                    editMessageRoles={editMessageRoles}
                     handleCopyMessage={handleCopyMessage}
                     handleCopyMessageLink={handleCopyMessageLink}
                     handleOpenThread={handleOpenThread}

--- a/packages/react/src/views/Message/MessageToolbox.js
+++ b/packages/react/src/views/Message/MessageToolbox.js
@@ -74,14 +74,6 @@ export const MessageToolbox = ({
     setShowDeleteModal(false);
   };
 
-  const isAllowedToPin = userRoles.some((role) => pinRoles.has(role));
-
-  const isAllowedToEditMessage = userRoles.some((role) =>
-    editMessageRoles.has(role)
-  )
-    ? true
-    : message.u._id === authenticatedUserId;
-
   const isVisibleForMessageType =
     message.files?.[0].type !== 'audio/mpeg' &&
     message.files?.[0].type !== 'video/mp4';
@@ -129,14 +121,14 @@ export const MessageToolbox = ({
         id: 'pin',
         onClick: () => handlePinMessage(message),
         iconName: message.pinned ? 'pin-filled' : 'pin',
-        visible: !isThreadMessage && isAllowedToPin,
+        visible: !isThreadMessage,
       },
       edit: {
         label: 'Edit',
         id: 'edit',
         onClick: () => handleEditMessage(message),
         iconName: 'edit',
-        visible: isAllowedToEditMessage && isVisibleForMessageType,
+        visible: isVisibleForMessageType,
         color: isEditing ? 'secondary' : 'default',
         ghost: !isEditing,
       },
@@ -183,7 +175,8 @@ export const MessageToolbox = ({
       handleEditMessage,
       handlerReportMessage,
       handleCopyMessage,
-      isAllowedToPin,
+      handleCopyMessageLink,
+      isVisibleForMessageType,
     ]
   );
 


### PR DESCRIPTION
I have observed and encountered these errors like `Cannot read the properties of undefined reading('150') or ('28') or ('70')` on the integrating the EmbeddedChat to a react application. Due to these errors the EmbeddedChat is not properly rendering on integration side. One demo on the integration of embeddedchat is `e2e-react` you can see these error over there also if you haven't integrated yet to any of the website.

## Video/Screenshots
![Screenshot from 2025-01-02 15-44-18](https://github.com/user-attachments/assets/706b9427-432b-4035-8e89-ac4319c66d2b)
![Screenshot from 2025-01-02 15-45-34](https://github.com/user-attachments/assets/5d68e3e6-2ae7-4d88-af40-26caaca011f4)
![Screenshot from 2025-01-02 15-48-39](https://github.com/user-attachments/assets/81644c57-1c09-46db-937c-784155fc9284)
![Screenshot from 2025-01-02 15-52-30](https://github.com/user-attachments/assets/5eef6f0f-8808-4619-a87a-18c976d5faf6)
![Screenshot from 2025-01-02 15-53-14](https://github.com/user-attachments/assets/f1955b0a-2c80-4ba3-8ad3-5ac8b3a514a7)
![Screenshot from 2025-01-02 15-54-18](https://github.com/user-attachments/assets/dac97389-3c61-47f6-a789-5059f1cd3246)

As there will be new release of EmbeddedChat very very soon and till then there shouldn't be any broken output so I have removed that buggy code. Contributors are requested to come with dynamic and optimal approach when solving these kind of issues and also should use the latest stable release of RocketChat server.

Thank you

