### PR TITLE
Added file size in attached docs in and made usernames clickable.

### DIFF
--- a/packages/react/src/views/AttachmentHandler/AttachmentMetadata.js
+++ b/packages/react/src/views/AttachmentHandler/AttachmentMetadata.js
@@ -2,7 +2,7 @@ import React from 'react';
 import { css } from '@emotion/react';
 import { ActionButton, Box } from '@embeddedchat/ui-elements';
 
-const AttachmentMetadata = ({ attachment, url, variantStyles = {} }) => {
+const AttachmentMetadata = ({ attachment, url, variantStyles = {}, msg }) => {
   const handleDownload = async () => {
     try {
       const response = await fetch(url);
@@ -33,21 +33,29 @@ const AttachmentMetadata = ({ attachment, url, variantStyles = {} }) => {
         variantStyles.attachmentMetaContainer,
       ]}
     >
-      {attachment.description && (
-        <p
-          css={[
-            css`
-              margin: 9px 0 0;
-              display: flex;
-              flex-direction: row;
-              align-items: center;
-              flex-wrap: wrap;
-            `,
-          ]}
-        >
-          {attachment.description}
-        </p>
-      )}
+      <div
+        css={
+          attachment.description !== ''
+            ? [
+                css`
+                  margin: 10px 0px;
+                  display: flex;
+                flex-direction: row;
+                align-items: center;
+                flex-wrap: wrap;
+                `,
+              ]
+            : css`
+                margin: -7px 0px;
+              `
+        }
+      >
+        {msg ? (
+          <Markdown body={msg} md={attachment.descriptionMd} />
+        ) : (
+          attachment.description
+        )}
+      </div>
       <Box
         css={css`
           display: flex;
@@ -58,11 +66,23 @@ const AttachmentMetadata = ({ attachment, url, variantStyles = {} }) => {
       >
         {attachment.title && (
           <p
-            css={css`
-              margin: 0;
-              font-size: 14px;
-              opacity: 0.7;
-            `}
+          css={
+            attachment.description
+              ? [
+                  css`
+                    margin: 0px;
+                    font-size: 14px;
+                    opacity: 0.7;
+                    flex-wrap: wrap;
+
+                  `,
+                ]
+              : css`
+                  margin: 22px 0 15px 0;
+                  font-size: 14px;
+                  opacity: 0.7;
+                `
+          }
           >
             {attachment.title}
           </p>
@@ -70,7 +90,8 @@ const AttachmentMetadata = ({ attachment, url, variantStyles = {} }) => {
 
         <Box
           css={css`
-            margin: 0;
+            margin-top: 7px;
+            margin-left: 5px;
             font-size: 14px;
             opacity: 0.7;
           `}
@@ -79,6 +100,7 @@ const AttachmentMetadata = ({ attachment, url, variantStyles = {} }) => {
           {attachment.image_size
             ? (attachment.image_size / 1024).toFixed(2)
             : 0}
+            {' '} 
           kB)
         </Box>
 

--- a/packages/react/src/views/AttachmentHandler/AttachmentMetadata.js
+++ b/packages/react/src/views/AttachmentHandler/AttachmentMetadata.js
@@ -27,7 +27,7 @@ const AttachmentMetadata = ({ attachment, url, variantStyles = {} }) => {
       css={[
         css`
           display: flex;
-          margin-top: 10px;
+          margin-top: 7px;
           flex-direction: column;
         `,
         variantStyles.attachmentMetaContainer,

--- a/packages/react/src/views/AttachmentHandler/AttachmentMetadata.js
+++ b/packages/react/src/views/AttachmentHandler/AttachmentMetadata.js
@@ -67,6 +67,21 @@ const AttachmentMetadata = ({ attachment, url, variantStyles = {} }) => {
             {attachment.title}
           </p>
         )}
+
+        <Box
+          css={css`
+            margin: 0;
+            font-size: 14px;
+            opacity: 0.7;
+          `}
+        >
+          (
+          {attachment.image_size
+            ? (attachment.image_size / 1024).toFixed(2)
+            : 0}
+          kB)
+        </Box>
+
         <ActionButton
           ghost
           icon="download"

--- a/packages/react/src/views/AttachmentHandler/AttachmentMetadata.js
+++ b/packages/react/src/views/AttachmentHandler/AttachmentMetadata.js
@@ -27,36 +27,46 @@ const AttachmentMetadata = ({ attachment, url, variantStyles = {} }) => {
       css={[
         css`
           display: flex;
+          margin-top: 10px;
           flex-direction: column;
         `,
         variantStyles.attachmentMetaContainer,
       ]}
     >
-      <p
-        css={[
-          css`
-            margin: 9px 0 0;
-          `,
-        ]}
-      >
-        {attachment.description}
-      </p>
+      {attachment.description && (
+        <p
+          css={[
+            css`
+              margin: 9px 0 0;
+              display: flex;
+              flex-direction: row;
+              align-items: center;
+              flex-wrap: wrap;
+            `,
+          ]}
+        >
+          {attachment.description}
+        </p>
+      )}
       <Box
         css={css`
           display: flex;
           flex-direction: row;
           align-items: center;
+          flex-wrap: wrap;
         `}
       >
-        <p
-          css={css`
-            margin: 0;
-            font-size: 14px;
-            opacity: 0.7;
-          `}
-        >
-          {attachment.title}
-        </p>
+        {attachment.title && (
+          <p
+            css={css`
+              margin: 0;
+              font-size: 14px;
+              opacity: 0.7;
+            `}
+          >
+            {attachment.title}
+          </p>
+        )}
         <ActionButton
           ghost
           icon="download"


### PR DESCRIPTION
# Brief Title

## Acceptance Criteria fulfillment

- [x] attached docs now showing file size.
- [x] usernames inside attached docs are also showing userInfo on click


Fixes #779 

## Video/Screenshots
Behaviour after fix
[Screencast from 2025-01-03 01-00-40.webm](https://github.com/user-attachments/assets/c0f8c28f-fa86-4894-a878-e19c93c418dd)

## PR Test Details

**Note**: The PR will be ready for live testing at https://rocketchat.github.io/EmbeddedChat/pulls/pr-<pr_number> after approval. Contributors are requested to replace `<pr_number>` with the actual PR number.
