### PR TITLE
fix: ensure Admin role tag is visible to all users in channel messages

### DIFF
--- a/packages/api/src/EmbeddedChatApi.ts
+++ b/packages/api/src/EmbeddedChatApi.ts
@@ -605,6 +605,41 @@ export default class EmbeddedChatApi {
     }
   }
 
+  async getUserRoles() {
+    try {
+      const { userId, authToken } = (await this.auth.getCurrentUser()) || {};
+      const response = await fetch(
+        `${this.host}/api/v1/method.call/getUserRoles`,
+        {
+          body: JSON.stringify({
+            message: JSON.stringify({
+              msg: "method",
+              id: null,
+              method: "getUserRoles",
+              params: [],
+            }),
+          }),
+          headers: {
+            "Content-Type": "application/json",
+            "X-Auth-Token": authToken,
+            "X-User-Id": userId,
+          },
+          method: "POST",
+        }
+      );
+
+      const result = await response.json();
+
+      if (result.success && result.message) {
+        const parsedMessage = JSON.parse(result.message);
+        return parsedMessage;
+      }
+      return null;
+    } catch (err) {
+      console.error(err);
+    }
+  }
+
   async sendTypingStatus(username: string, typing: boolean) {
     try {
       this.rcClient.methodCall(

--- a/packages/react/src/hooks/useFetchChatData.js
+++ b/packages/react/src/hooks/useFetchChatData.js
@@ -55,10 +55,10 @@ const useFetchChatData = (showRoles) => {
 
         if (showRoles) {
           const { roles } = await RCInstance.getChannelRoles(isChannelPrivate);
-          const fetchedAdmins = await RCInstance.getUsersInRole('admin');
-          const adminUsernames = fetchedAdmins?.users?.map(
-            (user) => user.username
-          );
+          const fetchedRoles = await RCInstance.getUserRoles();
+          const fetchedAdmins = fetchedRoles?.result;
+
+          const adminUsernames = fetchedAdmins?.map((user) => user.username);
           setAdmins(adminUsernames);
 
           const rolesObj =


### PR DESCRIPTION
# Brief Title

Fix: Ensure Admin role tag visibility for all users in channel messages

## Acceptance Criteria fulfillment

- [x]  Verify that the Admin role tag is visible to all users in a channel.
- [x] Test visibility across different user roles (e.g., Member, Moderator).
- [x] Create a new endpoint `getUserRoles` that fetches admins irrespective of permission boundaries

Fixes #783 

## Video/Screenshots


https://github.com/user-attachments/assets/12ed48da-6f35-4b16-8ef2-4c184fa438f4



## PR Test Details

**Note**: The PR will be ready for live testing at https://rocketchat.github.io/EmbeddedChat/pulls/pr-784 after approval. Contributors are requested to replace `<pr_number>` with the actual PR number.
