### PR TITLE
Feat: Enhanced 'Email' and 'Created At' Fields of User Info

### DIFF
--- a/packages/react/src/lib/formatTimestampGetDate.js
+++ b/packages/react/src/lib/formatTimestampGetDate.js
@@ -1,0 +1,10 @@
+const formatTimestampGetDate = (timestamp) => {
+  const date = new Date(timestamp);
+  return date.toLocaleDateString('en-US', {
+    year: 'numeric',
+    month: 'long',
+    day: 'numeric',
+  });
+};
+
+export default formatTimestampGetDate;

--- a/packages/react/src/views/UserInformation/UserInformation.js
+++ b/packages/react/src/views/UserInformation/UserInformation.js
@@ -61,8 +61,6 @@ const UserInformation = () => {
 
   const ViewComponent = viewType === 'Popup' ? Popup : Sidebar;
 
-  console.log('currentUserInfo: ' + JSON.stringify(currentUserInfo));
-
   return (
     <ViewComponent
       title="User Info"

--- a/packages/react/src/views/UserInformation/UserInformation.js
+++ b/packages/react/src/views/UserInformation/UserInformation.js
@@ -25,6 +25,7 @@ const UserInformation = () => {
   const setExclusiveState = useSetExclusiveState();
   const { RCInstance } = useContext(RCContext);
   const { theme } = useTheme();
+  const { mode } = useTheme();
   const styles = getUserInformationStyles(theme);
   const [currentUserInfo, setCurrentUserInfo] = useState({});
   const [isUserInfoFetched, setIsUserInfoFetched] = useState(false);
@@ -183,7 +184,13 @@ const UserInformation = () => {
                 <Box key={index} css={styles.emailContainer}>
                   <a
                     href={`mailto:${email.address}`}
-                    style={{ textDecoration: 'underline', color: '#095AD2' }}
+                    style={{
+                      textDecoration: 'underline',
+                      color:
+                        mode === 'light'
+                          ? theme.colors.info
+                          : theme.colors.warningForeground,
+                    }}
                   >
                     {email.address}
                   </a>

--- a/packages/react/src/views/UserInformation/UserInformation.js
+++ b/packages/react/src/views/UserInformation/UserInformation.js
@@ -14,6 +14,7 @@ import {
 import RCContext from '../../context/RCInstance';
 import { useUserStore } from '../../store';
 import formatTimestamp from '../../lib/formatTimestamp';
+import formatTimestampGetDate from '../../lib/formatTimestampGetDate';
 import UserInfoField from './UserInfoField';
 import getUserInformationStyles from './UserInformation.styles';
 import useSetExclusiveState from '../../hooks/useSetExclusiveState';
@@ -59,6 +60,8 @@ const UserInformation = () => {
   }, [RCInstance, setCurrentUserInfo]);
 
   const ViewComponent = viewType === 'Popup' ? Popup : Sidebar;
+
+  console.log('currentUserInfo: ' + JSON.stringify(currentUserInfo));
 
   return (
     <ViewComponent
@@ -182,7 +185,7 @@ const UserInformation = () => {
                 <Box key={index} css={styles.emailContainer}>
                   <a
                     href={`mailto:${email.address}`}
-                    style={{ textDecoration: 'none', color: 'inherit' }}
+                    style={{ textDecoration: 'underline', color: '#095AD2' }}
                   >
                     {email.address}
                   </a>
@@ -197,7 +200,7 @@ const UserInformation = () => {
             />
             <UserInfoField
               label="Created at"
-              value={formatTimestamp(currentUserInfo.createdAt)}
+              value={formatTimestampGetDate(currentUserInfo.createdAt)}
               isAdmin={isAllowedToViewFullInfo}
               authenticatedUserId={authenticatedUserId}
               currentUserInfo={currentUserInfo}


### PR DESCRIPTION
# Brief Title
Feat: Enhanced 'Email' and 'Created At' Fields of User Info

## Acceptance Criteria fulfillment

- [X] Enhance the 'Email' Field UI: The 'Email' field should be formatted for better readability and visual appeal.
- [X] Modify 'Created At' Field: The 'Created At' field should display the full date in the format: "Month Day, Year" (e.g., "December 16, 2024"), instead of the current timestamp.

Fixes #785

## Video/Screenshots


https://github.com/user-attachments/assets/1f673d58-e099-40de-87ff-6de07840d93d





## PR Test Details

**Note**: The PR will be ready for live testing at https://rocketchat.github.io/EmbeddedChat/pulls/pr-786 after approval. Contributors are requested to replace `<pr_number>` with the actual PR number.
