### PR TITLE
Fix Display user roles in MessageAggregator when showRoles is true

### DIFF
--- a/packages/react/src/views/MessageAggregators/common/MessageAggregator.js
+++ b/packages/react/src/views/MessageAggregators/common/MessageAggregator.js
@@ -17,6 +17,7 @@ import LoadingIndicator from './LoadingIndicator';
 import NoMessagesIndicator from './NoMessageIndicator';
 import FileDisplay from '../../FileMessage/FileMessage';
 import useSetExclusiveState from '../../../hooks/useSetExclusiveState';
+import { useRCContext } from '../../../context/RCInstance';
 
 export const MessageAggregator = ({
   title,
@@ -33,6 +34,8 @@ export const MessageAggregator = ({
   const { theme } = useTheme();
   const styles = getMessageAggregatorStyles(theme);
   const setExclusiveState = useSetExclusiveState();
+  const { ECOptions } = useRCContext();
+  const showRoles = ECOptions?.showRoles;
   const messages = useMessageStore((state) => state.messages);
   const threadMessages = useMessageStore((state) => state.threadMessages) || [];
   const allMessages = useMemo(
@@ -126,7 +129,7 @@ export const MessageAggregator = ({
                       type="default"
                       showAvatar
                       showToolbox={false}
-                      showRoles={false}
+                      showRoles={showRoles}
                       isInSidebar
                       style={{
                         flex: 1,


### PR DESCRIPTION
# Brief Title
Fix Display user roles in MessageAggregator when showRoles is true

## Acceptance Criteria fulfillment

- [X]  Ensure the showRoles setting displays user roles next to the user's name in MessageAggregator when set to true.
- [X] Verify that the showRoles setting does not display user roles in MessageAggregator when set to false.

Fixes #789

## Video/Screenshots


https://github.com/user-attachments/assets/f5cc80cb-2f32-4372-aa0d-e7429522c9e1



## PR Test Details

**Note**: The PR will be ready for live testing at https://rocketchat.github.io/EmbeddedChat/pulls/pr-790 after approval. Contributors are requested to replace `<pr_number>` with the actual PR number.
