### PR TITLE
feat: Add Unpin and Unstar message functionality to the icons in Message Headers

### DIFF
--- a/packages/react/src/views/Message/Message.js
+++ b/packages/react/src/views/Message/Message.js
@@ -218,6 +218,8 @@ const Message = ({
               {...(variantStyles?.name?.includes('bubble') && {
                 showDisplayName: !isMe,
               })}
+              handlePinMessage={handlePinMessage}
+              handleStarMessage={handleStarMessage}
             />
           )}
           {!message.t ? (

--- a/packages/react/src/views/Message/MessageHeader.js
+++ b/packages/react/src/views/Message/MessageHeader.js
@@ -19,6 +19,8 @@ const MessageHeader = ({
   isTimeStamped = true,
   isRoles = false,
   showDisplayName = true,
+  handlePinMessage,
+  handleStarMessage
 }) => {
   const { styleOverrides, classNames, variantOverrides } =
     useComponentOverrides('MessageHeader');
@@ -181,6 +183,7 @@ const MessageHeader = ({
                 name="star-filled"
                 size="1em"
                 color={theme.colors.primary}
+                onClick={() => handleStarMessage(message)}
               />
             </Tooltip>
           ) : null}
@@ -191,6 +194,7 @@ const MessageHeader = ({
                 name="pin"
                 size="1em"
                 color={theme.colors.primary}
+                onClick={() => handlePinMessage(message)}
               />
             </Tooltip>
           ) : null}


### PR DESCRIPTION
# Brief Title

## Acceptance Criteria fulfillment

- [ ] Task 1 : Implement “unpin” from the pinned files list by clicking the pin icon.
- [ ] Task 2 : Implement “unstar” from the starred files list by clicking the star icon.
- [ ] Task 3 : Copy direct link to message and Extra menu toolbox is not implemented , (To keep UI minimal , because Embedded chat is often nested inside some other application).

Fixes #741 

In this PR, I’ve opted for a simpler approach: **users can unpin or unstar a file directly by clicking the existing icons. This preserves a clean interface within EmbeddedChat, which is often nested in other applications. Adding a separate “Copy Link” or extra menu might complicate the embedded experience.** 

## Video/Screenshots


https://github.com/user-attachments/assets/89046d99-f77d-402b-bf55-f8127f913358



## PR Test Details

**Note**: The PR will be ready for live testing at https://rocketchat.github.io/EmbeddedChat/pulls/pr-<pr_number> after approval. Contributors are requested to replace `<pr_number>` with the actual PR number.
