### PR TITLE
Fix: Capitalize the First Letter of User Roles in the UI

### DIFF
--- a/packages/react/src/views/Message/MessageHeader.js
+++ b/packages/react/src/views/Message/MessageHeader.js
@@ -127,7 +127,7 @@ const MessageHeader = ({
               css={styles.userRole}
               className={appendClassNames('ec-message-user-role')}
             >
-              admin
+              Admin
             </Box>
           )}
 
@@ -138,7 +138,7 @@ const MessageHeader = ({
               css={styles.userRole}
               className={appendClassNames('ec-message-user-role')}
             >
-              {role}
+              {role.charAt(0).toUpperCase() + role.slice(1)}
             </Box>
           ))}
         </>


### PR DESCRIPTION
# Brief Title

## Acceptance Criteria fulfillment

- [X] The first letter of each user role (admin, moderator, leader, owner) is capitalized.
- [X] Verify that the changes are applied in all relevant areas (e.g., message headers, message aggregators)

Fixes #797

## Video/Screenshots

![image](https://github.com/user-attachments/assets/d5a32e4e-ce70-43aa-9db9-ec1bdb6541ea)


## PR Test Details

**Note**: The PR will be ready for live testing at https://rocketchat.github.io/EmbeddedChat/pulls/pr-798 after approval. Contributors are requested to replace `<pr_number>` with the actual PR number.
