### PR TITLE
Fix: Prevent Quoting the Same Message Multiple Times

### DIFF
--- a/packages/react/src/store/messageStore.js
+++ b/packages/react/src/store/messageStore.js
@@ -83,9 +83,7 @@ const useMessageStore = create((set, get) => ({
     }),
   removeQuoteMessage: (quoteMessage) =>
     set((state) => ({
-      quoteMessage: state.quoteMessage.filter(
-        (msg) => msg._id !== quoteMessage._id
-      ),
+      quoteMessage: state.quoteMessage.filter((i) => i !== quoteMessage),
     })),
 
   clearQuoteMessages: () => set({ quoteMessage: [] }),

--- a/packages/react/src/store/messageStore.js
+++ b/packages/react/src/store/messageStore.js
@@ -75,11 +75,19 @@ const useMessageStore = create((set, get) => ({
   setEditMessagePermissions: (editMessagePermissions) =>
     set((state) => ({ ...state, editMessagePermissions })),
   addQuoteMessage: (quoteMessage) =>
-    set((state) => ({ quoteMessage: [...state.quoteMessage, quoteMessage] })),
+    set((state) => {
+      const updatedQuoteMessages = state.quoteMessage.filter(
+        (msg) => msg._id !== quoteMessage._id
+      );
+      return { quoteMessage: [...updatedQuoteMessages, quoteMessage] };
+    }),
   removeQuoteMessage: (quoteMessage) =>
     set((state) => ({
-      quoteMessage: state.quoteMessage.filter((i) => i !== quoteMessage),
+      quoteMessage: state.quoteMessage.filter(
+        (msg) => msg._id !== quoteMessage._id
+      ),
     })),
+
   clearQuoteMessages: () => set({ quoteMessage: [] }),
   setMessageToReport: (messageId) =>
     set(() => ({ messageToReport: messageId })),


### PR DESCRIPTION
# Brief Title
Prevent Quoting the Same Message Multiple Times

## Acceptance Criteria fulfillment

- [x]  Ensure the same message cannot be quoted multiple times by checking for the message _id before adding it to the quoteMessage state.

Fixes #799 

## Video/Screenshots

[fix.webm](https://github.com/user-attachments/assets/c9df2a12-1f69-414e-a0e2-ed7d510cc033)


## PR Test Details

**Note**: The PR will be ready for live testing at https://rocketchat.github.io/EmbeddedChat/pulls/pr-800 after approval. Contributors are requested to replace `<pr_number>` with the actual PR number.
