### PR TITLE
Feat: Add keyboard shortcuts for closing modal (Escape) and submitting (Enter) in File Upload Window

### DIFF
--- a/packages/react/src/views/AttachmentPreview/AttachmentPreview.js
+++ b/packages/react/src/views/AttachmentPreview/AttachmentPreview.js
@@ -65,6 +65,22 @@ const AttachmentPreview = () => {
       setIsPending(false);
     }
   };
+
+  const onKeyDown = (e) => {
+    switch (true) {
+      case e.code === 'Escape':
+        e.preventDefault();
+        toggle();
+        break;
+      case e.code === 'Enter':
+        e.preventDefault();
+        submit();
+        break;
+      default:
+        break;
+    }
+  };
+
   return (
     <Modal onClose={toggle}>
       <Modal.Header>
@@ -112,6 +128,7 @@ const AttachmentPreview = () => {
                 value={fileName}
                 css={styles.input}
                 placeholder="name"
+                onKeyDown={onKeyDown}
               />
               <TypingUsers />
             </Box>
@@ -150,6 +167,7 @@ const AttachmentPreview = () => {
                   css={styles.input}
                   placeholder="Description"
                   ref={messageRef}
+                  onKeyDown={onKeyDown}
                 />
               </Box>
             </Box>

--- a/packages/react/src/views/AttachmentPreview/AttachmentPreview.js
+++ b/packages/react/src/views/AttachmentPreview/AttachmentPreview.js
@@ -1,4 +1,4 @@
-import React, { useContext, useState, useRef } from 'react';
+import React, { useContext, useState, useRef, useEffect } from 'react';
 import { css } from '@emotion/react';
 import { Box, Icon, Button, Input, Modal } from '@embeddedchat/ui-elements';
 import useAttachmentWindowStore from '../../store/attachmentwindow';
@@ -24,6 +24,7 @@ const AttachmentPreview = () => {
   const [filteredMembers, setFilteredMembers] = useState([]);
   const [mentionIndex, setMentionIndex] = useState(-1);
   const [startReadMentionUser, setStartReadMentionUser] = useState(false);
+  const [keyPressed, setKeyPressed] = useState(null);
 
   const [fileName, setFileName] = useState(data?.name);
 
@@ -66,20 +67,26 @@ const AttachmentPreview = () => {
     }
   };
 
-  const onKeyDown = (e) => {
-    switch (true) {
-      case e.code === 'Escape':
+  useEffect(() => {
+    const keyHandler = (e) => {
+      if (e.key === 'Enter') {
         e.preventDefault();
-        toggle();
-        break;
-      case e.code === 'Enter':
-        e.preventDefault();
-        submit();
-        break;
-      default:
-        break;
+        setKeyPressed('Enter');
+      }
+    };
+
+    document.addEventListener('keydown', keyHandler);
+    return () => {
+      document.removeEventListener('keydown', keyHandler);
+    };
+  }, []);
+
+  useEffect(() => {
+    if (keyPressed === 'Enter') {
+      submit();
+      setKeyPressed(null);
     }
-  };
+  }, [keyPressed, submit]);
 
   return (
     <Modal onClose={toggle}>
@@ -128,7 +135,6 @@ const AttachmentPreview = () => {
                 value={fileName}
                 css={styles.input}
                 placeholder="name"
-                onKeyDown={onKeyDown}
               />
               <TypingUsers />
             </Box>
@@ -167,7 +173,6 @@ const AttachmentPreview = () => {
                   css={styles.input}
                   placeholder="Description"
                   ref={messageRef}
-                  onKeyDown={onKeyDown}
                 />
               </Box>
             </Box>


### PR DESCRIPTION
# Brief Title
Feat: Add keyboard shortcuts for closing modal (Escape) and submitting (Enter) in File Upload Window

## Acceptance Criteria fulfillment

- [X] Pressing the Enter key triggers the submission of the file and prevents the default behavior (such as adding a new line in the text area) when the user is inside the input fields for the filename or description.
- [X] Pressing the Escape key closes the window when the user is inside the input fields for the filename or description.

Fixes #801

## Video/Screenshots


https://github.com/user-attachments/assets/23900de0-3b56-43f1-b3d5-bd0253aa73dc



## PR Test Details

**Note**: The PR will be ready for live testing at https://rocketchat.github.io/EmbeddedChat/pulls/pr-802 after approval. Contributors are requested to replace `<pr_number>` with the actual PR number.
