### PR TITLE
feat: Enhance add link modal and disabling message items while typing

### DIFF
--- a/packages/react/src/views/ChatInput/AudioMessageRecorder.js
+++ b/packages/react/src/views/ChatInput/AudioMessageRecorder.js
@@ -5,7 +5,8 @@ import useMessageStore from '../../store/messageStore';
 import { getCommonRecorderStyles } from './ChatInput.styles';
 import useAttachmentWindowStore from '../../store/attachmentwindow';
 
-const AudioMessageRecorder = () => {
+const AudioMessageRecorder = (props) => {
+  const { disable } = props;
   const videoRef = useRef(null);
   const { theme } = useTheme();
   const styles = getCommonRecorderStyles(theme);
@@ -130,7 +131,12 @@ const AudioMessageRecorder = () => {
 
   if (state === 'idle') {
     return (
-      <ActionButton ghost square onClick={handleRecordButtonClick}>
+      <ActionButton
+        ghost
+        square
+        onClick={handleRecordButtonClick}
+        disabled={disable}
+      >
         <Icon size="1.25rem" name="mic" />
       </ActionButton>
     );

--- a/packages/react/src/views/ChatInput/ChatInput.styles.js
+++ b/packages/react/src/views/ChatInput/ChatInput.styles.js
@@ -122,7 +122,7 @@ export const getInsertLinkModalStyles = (theme) => {
     inputWithFormattingBox: css`
       border: 1px solid ${theme.colors.border};
       border-radius: ${theme.radius};
-      margin: 0.5rem 1rem;
+      margin: 0rem 1rem 0.5rem 1rem;
       &.focused {
         border: ${`1.5px solid ${theme.colors.ring}`};
       }

--- a/packages/react/src/views/ChatInput/ChatInputFormattingToolbar.js
+++ b/packages/react/src/views/ChatInput/ChatInputFormattingToolbar.js
@@ -72,6 +72,8 @@ const ChatInputFormattingToolbar = ({
     setInsertLinkOpen(false);
   };
 
+  const isTyping = messageRef.current?.value.length > 0;
+  console.log(isTyping);
   const chatToolMap = {
     emoji: (
       <Tooltip text="Emoji" position="top" key="emoji-btn">
@@ -89,12 +91,12 @@ const ChatInputFormattingToolbar = ({
     ),
     audio: (
       <Tooltip text="Audio Message" position="top" key="audio">
-        <AudioMessageRecorder />
+        <AudioMessageRecorder disable={isTyping} />
       </Tooltip>
     ),
     video: (
       <Tooltip text="Video Message" position="top" key="video">
-        <VideoMessageRecorder />
+        <VideoMessageRecorder disable={isTyping} />
       </Tooltip>
     ),
     file: (
@@ -102,7 +104,7 @@ const ChatInputFormattingToolbar = ({
         <ActionButton
           square
           ghost
-          disabled={isRecordingMessage}
+          disabled={isRecordingMessage || isTyping}
           onClick={handleClickToOpenFiles}
         >
           <Icon name="attachment" size="1.25rem" />

--- a/packages/react/src/views/ChatInput/InsertLinkToolBox.js
+++ b/packages/react/src/views/ChatInput/InsertLinkToolBox.js
@@ -17,7 +17,7 @@ const InsertLinkToolBox = ({
 }) => {
   const { theme } = useTheme();
   const styles = getInsertLinkModalStyles(theme);
-  const [linkText, setLinkText] = useState(selectedText);
+  const [linkText, setLinkText] = useState(selectedText || 'Text');
   const [linkUrl, setLinkUrl] = useState(null);
 
   const handleLinkTextOnChange = (e) => {

--- a/packages/react/src/views/ChatInput/InsertLinkToolBox.js
+++ b/packages/react/src/views/ChatInput/InsertLinkToolBox.js
@@ -1,5 +1,13 @@
 import React, { useState } from 'react';
-import { Modal, Input, Button, useTheme } from '@embeddedchat/ui-elements';
+import {
+  Modal,
+  Input,
+  Button,
+  useTheme,
+  Icon,
+  Box,
+} from '@embeddedchat/ui-elements';
+import { css } from '@emotion/react';
 import { getInsertLinkModalStyles } from './ChatInput.styles';
 
 const InsertLinkToolBox = ({
@@ -9,7 +17,7 @@ const InsertLinkToolBox = ({
 }) => {
   const { theme } = useTheme();
   const styles = getInsertLinkModalStyles(theme);
-  const [linkText, setLinkText] = useState(selectedText || 'Text');
+  const [linkText, setLinkText] = useState(selectedText);
   const [linkUrl, setLinkUrl] = useState(null);
 
   const handleLinkTextOnChange = (e) => {
@@ -21,23 +29,52 @@ const InsertLinkToolBox = ({
 
   return (
     <Modal>
-      <Modal.Header css={styles.modalHeader}>
-        <Modal.Title>Add link</Modal.Title>
+      <Modal.Header>
+        <Icon
+          name="link"
+          size="1.5rem"
+          css={css`
+            margin-right: 0.25rem;
+            margin-top: 0.5rem;
+          `}
+        />{' '}
+        <Modal.Title>Add Link</Modal.Title>
         <Modal.Close onClick={onClose} />
       </Modal.Header>
-      <Modal.Content css={styles.modalContent}>
-        <Input
-          type="text"
-          onChange={handleLinkTextOnChange}
-          value={linkText}
-          css={styles.inputWithFormattingBox}
-        />
-        <Input
-          type="text"
-          onChange={handleLinkUrlOnChange}
-          placeholder="URL"
-          css={styles.inputWithFormattingBox}
-        />
+      <Modal.Content>
+        <Box css={styles.modalContent}>
+          <Box
+            is="span"
+            css={css`
+              font-weight: 550;
+              margin-left: 1rem;
+            `}
+          >
+            Link Text
+          </Box>
+          <Input
+            type="text"
+            onChange={handleLinkTextOnChange}
+            value={linkText}
+            placeholder="Text"
+            css={styles.inputWithFormattingBox}
+          />
+          <Box
+            is="span"
+            css={css`
+              font-weight: 550;
+              margin-left: 1rem;
+            `}
+          >
+            Link URL
+          </Box>
+          <Input
+            type="text"
+            onChange={handleLinkUrlOnChange}
+            placeholder="URL"
+            css={styles.inputWithFormattingBox}
+          />
+        </Box>
       </Modal.Content>
       <Modal.Footer css={styles.modalFooter}>
         <Button type="secondary" onClick={onClose}>

--- a/packages/react/src/views/ChatInput/VideoMessageRecoder.js
+++ b/packages/react/src/views/ChatInput/VideoMessageRecoder.js
@@ -12,7 +12,8 @@ import useMessageStore from '../../store/messageStore';
 import { getCommonRecorderStyles } from './ChatInput.styles';
 import useAttachmentWindowStore from '../../store/attachmentwindow';
 
-const VideoMessageRecorder = () => {
+const VideoMessageRecorder = (props) => {
+  const { disable } = props;
   const videoRef = useRef(null);
   const { theme } = useTheme();
   const styles = getCommonRecorderStyles(theme);
@@ -145,7 +146,12 @@ const VideoMessageRecorder = () => {
   return (
     <>
       {state === 'idle' && (
-        <ActionButton ghost square onClick={handleRecordButtonClick}>
+        <ActionButton
+          ghost
+          square
+          onClick={handleRecordButtonClick}
+          disabled={disable}
+        >
           <Icon size="1.25rem" name="video-recorder" />
         </ActionButton>
       )}

--- a/packages/react/src/views/SurfaceMenu/SurfaceItem.js
+++ b/packages/react/src/views/SurfaceMenu/SurfaceItem.js
@@ -2,7 +2,7 @@ import React from 'react';
 import { Tooltip, ActionButton } from '@embeddedchat/ui-elements';
 
 const SurfaceItem = ({ item, size }) => (
-  <Tooltip text={item.label} position="bottom" key={item.id}>
+  <Tooltip text={item.label} position="top" key={item.id}>
     <ActionButton
       square
       ghost


### PR DESCRIPTION
# Brief Title
Enhance add link modal and disabling message items while typing
## Acceptance Criteria fulfillment

- [ ] Improving Add Link Modal - adding link icon, giving label
- [ ] Disabling Audio/video/file messages on typing
- [ ] change position of tooltip of message toolbar facing above because for the bottom most messages the titles are being cut off.


Fixes #808 

## Video/Screenshots
[Screencast from 2025-01-06 02-08-58.webm](https://github.com/user-attachments/assets/b8c95d1d-4ee3-43b1-94fa-d38f554cf45e)

## PR Test Details

**Note**: The PR will be ready for live testing at https://rocketchat.github.io/EmbeddedChat/pulls/pr-<pr_number> after approval. Contributors are requested to replace `<pr_number>` with the actual PR number.
