### PR TITLE
Feat: Added 'Cancel Recording' and 'Finish Recording' tooltips for audio and video recording buttons.

### DIFF
--- a/packages/react/src/views/ChatInput/AudioMessageRecorder.js
+++ b/packages/react/src/views/ChatInput/AudioMessageRecorder.js
@@ -1,5 +1,11 @@
 import React, { useState, useEffect, useCallback, useRef } from 'react';
-import { Box, Icon, ActionButton, useTheme } from '@embeddedchat/ui-elements';
+import {
+  Box,
+  Icon,
+  ActionButton,
+  Tooltip,
+  useTheme,
+} from '@embeddedchat/ui-elements';
 import { useMediaRecorder } from '../../hooks/useMediaRecorder';
 import useMessageStore from '../../store/messageStore';
 import { getCommonRecorderStyles } from './ChatInput.styles';
@@ -131,14 +137,16 @@ const AudioMessageRecorder = ({ disabled }) => {
 
   if (state === 'idle') {
     return (
-      <ActionButton
-        ghost
-        square
-        disabled={disabled}
-        onClick={handleRecordButtonClick}
-      >
-        <Icon size="1.25rem" name="mic" />
-      </ActionButton>
+      <Tooltip text="Audio Message" position="top">
+        <ActionButton
+          ghost
+          square
+          disabled={disabled}
+          onClick={handleRecordButtonClick}
+        >
+          <Icon size="1.25rem" name="mic" />
+        </ActionButton>
+      </Tooltip>
     );
   }
 
@@ -146,18 +154,22 @@ const AudioMessageRecorder = ({ disabled }) => {
     <Box css={styles.controller}>
       {state === 'recording' && (
         <>
-          <ActionButton ghost onClick={handleCancelRecordButton}>
-            <Icon size="1.25rem" name="circle-cross" />
-          </ActionButton>
+          <Tooltip text="Cancel Recording" position="top">
+            <ActionButton ghost onClick={handleCancelRecordButton}>
+              <Icon size="1.25rem" name="circle-cross" />
+            </ActionButton>
+          </Tooltip>
           <Box css={styles.record}>
             <Box is="span" css={styles.dot} />
             <Box is="span" css={styles.timer}>
               {time}
             </Box>
           </Box>
-          <ActionButton ghost onClick={handleStopRecordButton}>
-            <Icon name="circle-check" size="1.25rem" />
-          </ActionButton>
+          <Tooltip text="Finish Recording" position="top">
+            <ActionButton ghost onClick={handleStopRecordButton}>
+              <Icon name="circle-check" size="1.25rem" />
+            </ActionButton>
+          </Tooltip>
         </>
       )}
     </Box>

--- a/packages/react/src/views/ChatInput/ChatInputFormattingToolbar.js
+++ b/packages/react/src/views/ChatInput/ChatInputFormattingToolbar.js
@@ -88,16 +88,8 @@ const ChatInputFormattingToolbar = ({
         </ActionButton>
       </Tooltip>
     ),
-    audio: (
-      <Tooltip text="Audio Message" position="top" key="audio">
-        <AudioMessageRecorder disabled={isRecordingMessage} />
-      </Tooltip>
-    ),
-    video: (
-      <Tooltip text="Video Message" position="top" key="video">
-        <VideoMessageRecorder disabled={isRecordingMessage} />
-      </Tooltip>
-    ),
+    audio: <AudioMessageRecorder disabled={isRecordingMessage} key="audio" />,
+    video: <VideoMessageRecorder disabled={isRecordingMessage} key="video" />,
     file: (
       <Tooltip text="Upload File" position="top" key="file">
         <ActionButton

--- a/packages/react/src/views/ChatInput/VideoMessageRecoder.js
+++ b/packages/react/src/views/ChatInput/VideoMessageRecoder.js
@@ -4,6 +4,7 @@ import {
   Box,
   Icon,
   ActionButton,
+  Tooltip,
   Modal,
   useTheme,
 } from '@embeddedchat/ui-elements';
@@ -146,14 +147,16 @@ const VideoMessageRecorder = ({ disabled }) => {
   return (
     <>
       {state === 'idle' && (
-        <ActionButton
-          ghost
-          square
-          disabled={disabled}
-          onClick={handleRecordButtonClick}
-        >
-          <Icon size="1.25rem" name="video-recorder" />
-        </ActionButton>
+        <Tooltip text="Video Message" position="top">
+          <ActionButton
+            ghost
+            square
+            disabled={disabled}
+            onClick={handleRecordButtonClick}
+          >
+            <Icon size="1.25rem" name="video-recorder" />
+          </ActionButton>
+        </Tooltip>
       )}
 
       {state === 'recording' && (
@@ -179,16 +182,20 @@ const VideoMessageRecorder = ({ disabled }) => {
               `}
             />
             <Box css={styles.controller}>
-              <ActionButton ghost onClick={handleCancelRecordButton}>
-                <Icon size="1.25rem" name="circle-cross" />
-              </ActionButton>
+              <Tooltip text="Cancel Recording" position="bottom">
+                <ActionButton ghost onClick={handleCancelRecordButton}>
+                  <Icon size="1.25rem" name="circle-cross" />
+                </ActionButton>
+              </Tooltip>
               <Box css={styles.record}>
                 <Box is="span" css={styles.dot} />
                 <Box css={styles.timer}>{time}</Box>
               </Box>
-              <ActionButton ghost onClick={handleStopRecordButton}>
-                <Icon name="circle-check" size="1.25rem" />
-              </ActionButton>
+              <Tooltip text="Finish Recording" position="bottom">
+                <ActionButton ghost onClick={handleStopRecordButton}>
+                  <Icon name="circle-check" size="1.25rem" />
+                </ActionButton>
+              </Tooltip>
             </Box>
           </Modal>
         </>


### PR DESCRIPTION
# Brief Title
Feat: Add 'Cancel Recording' and 'Finish Recording' tooltips for audio and video recording buttons.

## Acceptance Criteria fulfillment

- [X] When the user hovers the mouse over the circle-cross button while recording audio or video, the text "Cancel Recording" should be displayed.
- [X] When the user hovers the mouse over the circle-check button while recording audio or video, the text "Finish Recording" should be displayed.

Fixes #811

## Video/Screenshots:


https://github.com/user-attachments/assets/a94248b9-3e36-47cc-b6a0-7f0c886208ff



## PR Test Details

**Note**: The PR will be ready for live testing at https://rocketchat.github.io/EmbeddedChat/pulls/pr-812 after approval. Contributors are requested to replace `<pr_number>` with the actual PR number.
