### PR TITLE
Fix: Capitalize the First Letter of User Roles in User Information Except 'user' Role

### DIFF
--- a/packages/react/src/views/UserInformation/UserInformation.js
+++ b/packages/react/src/views/UserInformation/UserInformation.js
@@ -132,7 +132,11 @@ const UserInformation = () => {
                         css={styles.userRole}
                         className={appendClassNames('ec-message-user-role')}
                       >
-                        {role === 'admin' ? 'admin' : role}
+                        {role === 'admin'
+                          ? 'Admin'
+                          : role === 'user'
+                          ? 'user'
+                          : role.charAt(0).toUpperCase() + role.slice(1)}
                       </Box>
                     ))}
                   </Box>


### PR DESCRIPTION
# Brief Title
Fix: Capitalize the First Letter of User Roles in User Information Except 'user' Role

## Acceptance Criteria fulfillment

- [ ] The first letter of each user role (admin, moderator, leader, owner) is capitalized.
- [ ] The 'user' role should be in all lowercase.


Fixes #814

## Video/Screenshots:

![image](https://github.com/user-attachments/assets/09cc54bd-e74d-404d-a2ea-295eec2241c7)

and 

![image](https://github.com/user-attachments/assets/231004ae-54a7-4356-ac3e-2bd95b26df8c)


## PR Test Details

**Note**: The PR will be ready for live testing at https://rocketchat.github.io/EmbeddedChat/pulls/pr-815 after approval. Contributors are requested to replace `<pr_number>` with the actual PR number.
