### PR TITLE
Feat: Enhanced the Display of Text, Image, Audio & Video Attachments

### DIFF
--- a/packages/react/src/views/AttachmentHandler/AudioAttachment.js
+++ b/packages/react/src/views/AttachmentHandler/AudioAttachment.js
@@ -1,7 +1,13 @@
 import React, { useState, useContext } from 'react';
 import PropTypes from 'prop-types';
 import { css } from '@emotion/react';
-import { Box, Avatar, useTheme } from '@embeddedchat/ui-elements';
+import {
+  Box,
+  Avatar,
+  useTheme,
+  lighten,
+  darken,
+} from '@embeddedchat/ui-elements';
 import AttachmentMetadata from './AttachmentMetadata';
 import RCContext from '../../context/RCInstance';
 
@@ -15,6 +21,7 @@ const AudioAttachment = ({
 }) => {
   const { RCInstance } = useContext(RCContext);
   const { theme } = useTheme();
+  const { mode } = useTheme();
   const getUserAvatarUrl = (icon) => {
     const instanceHost = RCInstance.getHost();
     const URL = `${instanceHost}${icon}`;
@@ -39,7 +46,12 @@ const AudioAttachment = ({
           (type ? variantStyles.pinnedContainer : '') ||
             css`
               ${type === 'file'
-                ? `border: 3px solid ${theme.colors.border};`
+                ? `border: 3px solid ${theme.colors.border}; 
+                background-color: ${
+                  mode === 'light'
+                    ? darken(theme.colors.background, 0.015)
+                    : lighten(theme.colors.background, 0.5)
+                };`
                 : ''}
             `,
         ]}

--- a/packages/react/src/views/AttachmentHandler/ImageAttachment.js
+++ b/packages/react/src/views/AttachmentHandler/ImageAttachment.js
@@ -1,7 +1,13 @@
 import React, { useState, useContext } from 'react';
 import { css } from '@emotion/react';
 import PropTypes from 'prop-types';
-import { Box, Avatar, useTheme } from '@embeddedchat/ui-elements';
+import {
+  Box,
+  Avatar,
+  useTheme,
+  lighten,
+  darken,
+} from '@embeddedchat/ui-elements';
 import AttachmentMetadata from './AttachmentMetadata';
 import ImageGallery from '../ImageGallery/ImageGallery';
 import RCContext from '../../context/RCInstance';
@@ -27,6 +33,7 @@ const ImageAttachment = ({
   };
 
   const { theme } = useTheme();
+  const { mode } = useTheme();
 
   const { authorIcon, authorName } = author;
 
@@ -48,7 +55,13 @@ const ImageAttachment = ({
           (type ? variantStyles.pinnedContainer : '') ||
             css`
               ${type === 'file'
-                ? `border: 2px solid ${theme.colors.border};`
+                ? `border: 2px solid ${
+                    theme.colors.border
+                  }; background-color: ${
+                    mode === 'light'
+                      ? darken(theme.colors.background, 0.015)
+                      : lighten(theme.colors.background, 0.5)
+                  };`
                 : ''}
             `,
         ]}

--- a/packages/react/src/views/AttachmentHandler/TextAttachment.js
+++ b/packages/react/src/views/AttachmentHandler/TextAttachment.js
@@ -1,7 +1,13 @@
 import React, { useContext } from 'react';
 import { css } from '@emotion/react';
 import PropTypes from 'prop-types';
-import { Box, Avatar, useTheme } from '@embeddedchat/ui-elements';
+import {
+  Box,
+  Avatar,
+  useTheme,
+  lighten,
+  darken,
+} from '@embeddedchat/ui-elements';
 import RCContext from '../../context/RCInstance';
 
 const TextAttachment = ({ attachment, type, variantStyles = {} }) => {
@@ -13,6 +19,7 @@ const TextAttachment = ({ attachment, type, variantStyles = {} }) => {
   };
 
   const { theme } = useTheme();
+  const { mode } = useTheme();
 
   return (
     <Box
@@ -30,7 +37,13 @@ const TextAttachment = ({ attachment, type, variantStyles = {} }) => {
         `,
         (type ? variantStyles.pinnedContainer : variantStyles.quoteContainer) ||
           css`
-            ${!type ? `border: 3px solid ${theme.colors.border};` : ''}
+            ${!type
+              ? `border: 3px solid ${theme.colors.border}; background-color: ${
+                  mode === 'light'
+                    ? darken(theme.colors.background, 0.015)
+                    : lighten(theme.colors.background, 0.5)
+                }; `
+              : ''}
           `,
       ]}
     >

--- a/packages/react/src/views/AttachmentHandler/VideoAttachment.js
+++ b/packages/react/src/views/AttachmentHandler/VideoAttachment.js
@@ -1,7 +1,13 @@
 import React, { useState, useContext } from 'react';
 import PropTypes from 'prop-types';
 import { css } from '@emotion/react';
-import { Box, Avatar, useTheme } from '@embeddedchat/ui-elements';
+import {
+  Box,
+  Avatar,
+  useTheme,
+  lighten,
+  darken,
+} from '@embeddedchat/ui-elements';
 import AttachmentMetadata from './AttachmentMetadata';
 import RCContext from '../../context/RCInstance';
 
@@ -25,6 +31,7 @@ const VideoAttachment = ({
 }) => {
   const { RCInstance } = useContext(RCContext);
   const { theme } = useTheme();
+  const { mode } = useTheme();
   const getUserAvatarUrl = (icon) => {
     const instanceHost = RCInstance.getHost();
     const URL = `${instanceHost}${icon}`;
@@ -49,7 +56,12 @@ const VideoAttachment = ({
           (type ? variantStyles.pinnedContainer : '') ||
             css`
               ${type === 'file'
-                ? `border: 3px solid ${theme.colors.border};`
+                ? `border: 3px solid ${theme.colors.border}; 
+                background-color: ${
+                  mode === 'light'
+                    ? darken(theme.colors.background, 0.015)
+                    : lighten(theme.colors.background, 0.5)
+                };`
                 : ''}
             `,
         ]}


### PR DESCRIPTION
# Brief Title
Feat: Enhanced the Display of Text, Image, Audio & Video Attachments

## Acceptance Criteria fulfillment

- [X] For Text, Image, Audio, and Video attachments, adjust the background to lighten or darken based on the light and dark themes.
- [X] For the Light theme, make the background darker.
- [X] For the Dark theme, make the background lighter.
- [X] Make sure the hover effect is still visible on these attachments 

Fixes #816

## Video/Screenshots:

Stormy Seas Dark Theme: 


https://github.com/user-attachments/assets/35e7eaab-7e04-44fe-8bb4-f69efe916abf



Default Light Theme: 




https://github.com/user-attachments/assets/21e9f2a9-4488-4ad8-b071-b6242e0338a9




Rose Amber Variant Light Theme: 



https://github.com/user-attachments/assets/d5602420-d49d-4b3e-ae44-78bed6881d3e




## PR Test Details

**Note**: The PR will be ready for live testing at https://rocketchat.github.io/EmbeddedChat/pulls/pr-817 after approval. Contributors are requested to replace `<pr_number>` with the actual PR number.
