### PR TITLE
Fix: Highlight entire message body for 'Jump to Message' functionality

### DIFF
--- a/packages/react/src/views/MessageAggregators/common/MessageAggregator.js
+++ b/packages/react/src/views/MessageAggregators/common/MessageAggregator.js
@@ -7,6 +7,8 @@ import {
   useTheme,
   ActionButton,
   Icon,
+  lighten,
+  darken,
 } from '@embeddedchat/ui-elements';
 import { MessageDivider } from '../../Message/MessageDivider';
 import Message from '../../Message/Message';
@@ -32,6 +34,7 @@ export const MessageAggregator = ({
   viewType = 'Sidebar',
 }) => {
   const { theme } = useTheme();
+  const { mode } = useTheme();
   const styles = getMessageAggregatorStyles(theme);
   const setExclusiveState = useSetExclusiveState();
   const { ECOptions } = useRCContext();
@@ -49,16 +52,24 @@ export const MessageAggregator = ({
   );
 
   const setShowSidebar = useSidebarStore((state) => state.setShowSidebar);
+
   const setJumpToMessage = (msgId) => {
     if (msgId) {
-      const element = document.getElementById(`ec-message-body-${msgId}`);
+      const childElement = document.getElementById(`ec-message-body-${msgId}`);
+      const element = childElement.closest('.ec-message');
+
       if (element) {
         setShowSidebar(false);
         element.scrollIntoView({ behavior: 'smooth', block: 'nearest' });
-        element.style.backgroundColor = theme.colors.warning;
+
+        element.style.backgroundColor =
+          mode === 'light'
+            ? darken(theme.colors.warning, 0.03)
+            : lighten(theme.colors.warningForeground, 0.03);
+
         setTimeout(() => {
           element.style.backgroundColor = '';
-        }, 1000);
+        }, 2000);
       }
     }
   };


### PR DESCRIPTION
# Brief Title
Fix: Highlight entire message body for 'Jump to Message' functionality


## Acceptance Criteria fulfillment

- [X] The entire message body is highlighted when using the 'Jump to Message' functionality.
- [X] The highlight color is clearly visible in both light and dark themes.

Fixes #821

## Video/Screenshots

Light theme: 


https://github.com/user-attachments/assets/b8e8110d-fc05-46de-9728-5dcabcec7b3f




Dark theme:



https://github.com/user-attachments/assets/6353c022-4a75-4e9a-ae0c-a93ab89b3ef7



## PR Test Details

**Note**: The PR will be ready for live testing at https://rocketchat.github.io/EmbeddedChat/pulls/pr-822 after approval. Contributors are requested to replace `<pr_number>` with the actual PR number.
