### PR TITLE
feat: Clicking Image in files aggregator now opens image Gallery

### DIFF
--- a/packages/react/src/views/FileMessage/FileMessage.js
+++ b/packages/react/src/views/FileMessage/FileMessage.js
@@ -22,7 +22,6 @@ import { useMessageStore } from '../../store';
 import { fileDisplayStyles as styles } from './Files.styles';
 
 const FileMessage = ({ fileMessage }) => {
-  console.log('fileMessage', fileMessage);
   const { classNames, styleOverrides } = useComponentOverrides('FileMessage');
   const dispatchToastMessage = useToastBarDispatch();
   const { RCInstance } = useRCContext();


### PR DESCRIPTION
# Brief Title

## Acceptance Criteria fulfillment

- [ ] clicking image files opens image Gallery
- [ ] clicking on other types of file download the file

Fixes #823 

## Video/Screenshots
Before: 
Clicking does not do anything.
After:
[Screencast from 2025-01-07 00-44-23.webm](https://github.com/user-attachments/assets/23e33b59-6471-4898-85e6-974eaf29dc6e)

## PR Test Details

**Note**: The PR will be ready for live testing at https://rocketchat.github.io/EmbeddedChat/pulls/pr-<pr_number> after approval. Contributors are requested to replace `<pr_number>` with the actual PR number.
