### PR TITLE
Feat: Show 'Edit Message' Button for all message types

### DIFF
--- a/packages/react/src/views/Message/MessageToolbox.js
+++ b/packages/react/src/views/Message/MessageToolbox.js
@@ -82,9 +82,7 @@ export const MessageToolbox = ({
     ? true
     : message.u._id === authenticatedUserId;
 
-  const isVisibleForMessageType =
-    message.files?.[0].type !== 'audio/mpeg' &&
-    message.files?.[0].type !== 'video/mp4';
+  const isVisibleForMessage = message.attachments?.[0].description !== '';
 
   const options = useMemo(
     () => ({
@@ -136,7 +134,7 @@ export const MessageToolbox = ({
         id: 'edit',
         onClick: () => handleEditMessage(message),
         iconName: 'edit',
-        visible: isAllowedToEditMessage && isVisibleForMessageType,
+        visible: isAllowedToEditMessage && isVisibleForMessage,
         color: isEditing ? 'secondary' : 'default',
         ghost: !isEditing,
       },

--- a/packages/react/src/views/Message/MessageToolbox.js
+++ b/packages/react/src/views/Message/MessageToolbox.js
@@ -82,8 +82,6 @@ export const MessageToolbox = ({
     ? true
     : message.u._id === authenticatedUserId;
 
-  const isVisibleForMessage = message.attachments?.[0].description !== '';
-
   const options = useMemo(
     () => ({
       reply: {
@@ -134,7 +132,7 @@ export const MessageToolbox = ({
         id: 'edit',
         onClick: () => handleEditMessage(message),
         iconName: 'edit',
-        visible: isAllowedToEditMessage && isVisibleForMessage,
+        visible: isAllowedToEditMessage,
         color: isEditing ? 'secondary' : 'default',
         ghost: !isEditing,
       },


### PR DESCRIPTION
# Brief Title
Feat: Show 'Edit Message' Button for all message types 

## Acceptance Criteria fulfillment

- [X] If an attachment message contains a description, the user should be able to edit it.
- [X] If an attachment message does not contain a description, the user should be able to add one.

By 'attachment,' I’m referring to: audio, video, files, and images.

Fixes #825

## Video/Screenshots


https://github.com/user-attachments/assets/4887a85f-8743-44bc-8437-91213da4d37c



## PR Test Details

**Note**: The PR will be ready for live testing at https://rocketchat.github.io/EmbeddedChat/pulls/pr-826 after approval. Contributors are requested to replace `<pr_number>` with the actual PR number.
