### PR TITLE
 Fix arrow redirection for thread messages in starred message modal

### DIFF
--- a/packages/react/src/views/MessageAggregators/common/MessageAggregator.js
+++ b/packages/react/src/views/MessageAggregators/common/MessageAggregator.js
@@ -1,5 +1,5 @@
 import React, { useState, useMemo } from 'react';
-import { isSameDay, format } from 'date-fns';
+import { isSameDay, format, set } from 'date-fns';
 import {
   Box,
   Sidebar,
@@ -49,17 +49,37 @@ export const MessageAggregator = ({
   );
 
   const setShowSidebar = useSidebarStore((state) => state.setShowSidebar);
-  const setJumpToMessage = (msgId) => {
+  const openThread = useMessageStore((state) => state.openThread);
+  const closeThread = useMessageStore((state) => state.closeThread);
+
+  const setJumpToMessage = (msg) => {
+    if (!msg || !msg._id) {
+      console.error('Invalid message object:', msg);
+      return;
+    }
+    const { _id: msgId, tmid: threadId } = msg;
     if (msgId) {
-      const element = document.getElementById(`ec-message-body-${msgId}`);
-      if (element) {
-        setShowSidebar(false);
-        element.scrollIntoView({ behavior: 'smooth', block: 'nearest' });
-        element.style.backgroundColor = theme.colors.warning;
-        setTimeout(() => {
-          element.style.backgroundColor = '';
-        }, 1000);
+      let element;
+      if (threadId) {
+        const parentMessage = messages.find((m) => m._id === threadId);
+        if (parentMessage) {
+          openThread(parentMessage);
+          setShowSidebar(false);
+        }
+      } else {
+        closeThread();
       }
+      setTimeout(() => {
+        element = document.getElementById(`ec-message-body-${msgId}`);
+        if (element) {
+          setShowSidebar(false);
+          element.scrollIntoView({ behavior: 'smooth', block: 'nearest' });
+          element.style.backgroundColor = theme.colors.warning;
+          setTimeout(() => {
+            element.style.backgroundColor = '';
+          }, 1000);
+        }
+      }, 300);
     }
   };
 
@@ -146,7 +166,7 @@ export const MessageAggregator = ({
                     <ActionButton
                       square
                       ghost
-                      onClick={() => setJumpToMessage(msg._id)}
+                      onClick={() => setJumpToMessage(msg)}
                       css={{
                         position: 'relative',
                         zIndex: 10,


### PR DESCRIPTION
# Brief Title
This pull request addresses the issue where the arrow redirection in the starred message modal does not correctly open the thread view and scroll to the specific message. The setJumpToMessage function has been updated to handle both regular messages and thread messages, ensuring that the correct interface is opened and the message is scrolled into view.
## Acceptance Criteria fulfillment

-Updated the setJumpToMessage function to correctly handle thread messages by finding the parent message and passing it to the openThread function.
- [Ensured that the correct interface is opened and the message is scrolled into view.


Fixes #832 

## Video/Screenshots

https://github.com/user-attachments/assets/0396a3a6-5a70-4cd9-aea0-633c0b933740



## PR Test Details

**Note**: The PR will be ready for live testing at https://rocketchat.github.io/EmbeddedChat/pulls/pr-<pr_number> after approval. Contributors are requested to replace `<pr_number>` with the actual PR number.
