### PR TITLE
fix: Added css to quote text properly

### DIFF
--- a/packages/markups/src/blocks/QuoteBlock.js
+++ b/packages/markups/src/blocks/QuoteBlock.js
@@ -1,14 +1,25 @@
 import React from 'react';
 import PropTypes from 'prop-types';
 import ParagraphBlock from './ParagraphBlock';
+import { css } from '@emotion/react';
+import { useTheme } from '@embeddedchat/ui-elements';
 
-const QuoteBlock = ({ contents }) => (
-  <blockquote>
-    {contents.map((paragraph, index) => (
-      <ParagraphBlock key={index} contents={paragraph.value} />
-    ))}
-  </blockquote>
-);
+const QuoteBlock = ({ contents }) => {
+  const { theme } = useTheme();
+  return (
+    <blockquote
+      css={css`
+        background-color: ${theme.colors.secondary};
+        border-left: 1.5px solid ${theme.colors.primary};
+        padding-left: 0.5rem;
+      `}
+    >
+      {contents.map((paragraph, index) => (
+        <ParagraphBlock key={index} contents={paragraph.value} />
+      ))}
+    </blockquote>
+  );
+};
 
 export default QuoteBlock;
 

--- a/packages/react/src/views/AttachmentHandler/TextAttachment.js
+++ b/packages/react/src/views/AttachmentHandler/TextAttachment.js
@@ -3,6 +3,7 @@ import { css } from '@emotion/react';
 import PropTypes from 'prop-types';
 import { Box, Avatar, useTheme } from '@embeddedchat/ui-elements';
 import RCContext from '../../context/RCInstance';
+import { Markdown } from '../Markdown';
 
 const TextAttachment = ({ attachment, type, variantStyles = {} }) => {
   const { RCInstance } = useContext(RCContext);
@@ -62,11 +63,19 @@ const TextAttachment = ({ attachment, type, variantStyles = {} }) => {
           white-space: pre-line;
         `}
       >
-        {attachment?.text
-          ? attachment.text[0] === '['
-            ? attachment.text.match(/\n(.*)/)?.[1] || ''
-            : attachment.text
-          : ''}
+        {attachment?.text ? (
+          attachment.text[0] === '[' ? (
+            attachment.text.match(/\n(.*)/)?.[1] || ''
+          ) : (
+            <Markdown
+              body={attachment.text}
+              md={attachment.md}
+              isReaction={false}
+            />
+          )
+        ) : (
+          ''
+        )}
         {attachment?.attachments &&
           attachment.attachments.map((nestedAttachment, index) => (
             <Box

--- a/packages/react/src/views/ChatInput/ChatInput.js
+++ b/packages/react/src/views/ChatInput/ChatInput.js
@@ -34,7 +34,6 @@ import useShowCommands from '../../hooks/useShowCommands';
 import useSearchMentionUser from '../../hooks/useSearchMentionUser';
 import formatSelection from '../../lib/formatSelection';
 import { parseEmoji } from '../../lib/emoji';
-import { Markdown } from '../Markdown';
 
 const ChatInput = ({ scrollToBottom }) => {
   const { styleOverrides, classNames } = useComponentOverrides('ChatInput');

--- a/packages/react/src/views/Message/MessageToolbox.js
+++ b/packages/react/src/views/Message/MessageToolbox.js
@@ -275,7 +275,7 @@ export const MessageToolbox = ({
               padding: '0 0.5rem 0.5rem',
             }}
           >
-            <Markdown body={message} isReaction={false} />
+            <Markdown body={message} md={message.md} isReaction={false} />
           </Modal.Content>
           <Modal.Footer>
             <Button type="secondary" onClick={handleOnClose}>

--- a/packages/react/src/views/QuoteMessage/QuoteMessage.js
+++ b/packages/react/src/views/QuoteMessage/QuoteMessage.js
@@ -85,7 +85,7 @@ const QuoteMessage = ({ className = '', style = {}, message }) => {
           ) : (
             <Box css={styles.message}>
               {message.msg ? (
-                <Markdown body={message} isReaction={false} />
+                <Markdown body={message} md={message.md} isReaction={false} />
               ) : (
                 `${message.file?.name} (${
                   message.file?.size ? (message.file.size / 1024).toFixed(2) : 0
@@ -96,7 +96,7 @@ const QuoteMessage = ({ className = '', style = {}, message }) => {
         ) : message?.msg[0] === '[' ? (
           message?.msg.match(/\n(.*)/)[1]
         ) : (
-          <Markdown body={message} isReaction={false} />
+          <Markdown body={message} md={message.md} isReaction={false} />
         )}
         {message.attachments &&
           message.attachments.length > 0 &&


### PR DESCRIPTION
# Brief Title

now using > before any text will show separate quote I use theme for bg color to maintain the coding standard.

- [ ] Add css to quote text propely

Fixes #840 

## Video/Screenshots
![Screenshot from 2025-01-09 01-50-38](https://github.com/user-attachments/assets/2d3ac5db-3d33-4502-9e23-8f4d5e4b51be)
## PR Test Details

**Note**: The PR will be ready for live testing at https://rocketchat.github.io/EmbeddedChat/pulls/pr-<pr_number> after approval. Contributors are requested to replace `<pr_number>` with the actual PR number.
