### PR TITLE
Fix: channel info issue after logout

### DIFF
--- a/packages/react/src/views/ChatHeader/ChatHeader.js
+++ b/packages/react/src/views/ChatHeader/ChatHeader.js
@@ -136,6 +136,7 @@ const ChatHeader = ({
     try {
       await RCInstance.logout();
       setMessages([]);
+      setChannelInfo({});
       setShowSidebar(false);
       setUserAvatarUrl(null);
       useMessageStore.setState({ isMessageLoaded: false });


### PR DESCRIPTION
# Brief Title
This PR resolves issues where channel information persists in the UI even after a user logs out.

## Acceptance Criteria fulfillment

- [ ] Reset the channel information to an empty state after logout.

Fixes #850 

## Video/Screenshots
[Screencast from 2025-01-09 19-37-19.webm](https://github.com/user-attachments/assets/aa5ffbb8-bacf-4018-8a56-5399eb0c9942)


## PR Test Details

**Note**: The PR will be ready for live testing at https://rocketchat.github.io/EmbeddedChat/pulls/pr-851 after approval. Contributors are requested to replace `<pr_number>` with the actual PR number.
