### PR TITLE
Fix: Include pinned messages from threads in the main chat interface

### DIFF
--- a/packages/react/src/hooks/useFetchChatData.js
+++ b/packages/react/src/hooks/useFetchChatData.js
@@ -6,6 +6,7 @@ import {
   useMemberStore,
   useMessageStore,
   useStarredMessageStore,
+  usePinnedMessageStore,
 } from '../store';
 
 const useFetchChatData = (showRoles) => {
@@ -16,6 +17,9 @@ const useFetchChatData = (showRoles) => {
   const setAdmins = useMemberStore((state) => state.setAdmins);
   const setStarredMessages = useStarredMessageStore(
     (state) => state.setStarredMessages
+  );
+  const setPinnedMessages = usePinnedMessageStore(
+    (state) => state.setPinnedMessages
   );
   const isUserAuthenticated = useUserStore(
     (state) => state.isUserAuthenticated
@@ -107,7 +111,24 @@ const useFetchChatData = (showRoles) => {
     [isUserAuthenticated, RCInstance, setStarredMessages]
   );
 
-  return { getMessagesAndRoles, getStarredMessages };
+  const getPinnedMessages = useCallback(
+    async (anonymousMode) => {
+      if (isUserAuthenticated) {
+        try {
+          if (!isUserAuthenticated && !anonymousMode) {
+            return;
+          }
+          const { messages } = await RCInstance.getPinnedMessages();
+          setPinnedMessages(messages);
+        } catch (e) {
+          console.error(e);
+        }
+      }
+    },
+    [isUserAuthenticated, RCInstance, setPinnedMessages]
+  );
+
+  return { getMessagesAndRoles, getStarredMessages, getPinnedMessages };
 };
 
 export default useFetchChatData;

--- a/packages/react/src/store/pinnedMessageStore.js
+++ b/packages/react/src/store/pinnedMessageStore.js
@@ -3,6 +3,8 @@ import { create } from 'zustand';
 const usePinnedMessageStore = create((set) => ({
   showPinned: false,
   setShowPinned: (showPinned) => set(() => ({ showPinned })),
+  PinnedMessage: [],
+  setPinnedMessages: (PinnedMessage) => set(() => ({ PinnedMessage })),
 }));
 
 export default usePinnedMessageStore;

--- a/packages/react/src/views/ChatLayout/ChatLayout.js
+++ b/packages/react/src/views/ChatLayout/ChatLayout.js
@@ -42,6 +42,9 @@ const ChatLayout = () => {
   const setStarredMessages = useStarredMessageStore(
     (state) => state.setStarredMessages
   );
+  const setPinnedMessages = usePinnedMessageStore(
+    (state) => state.setPinnedMessages
+  );
   const starredMessages = useStarredMessageStore(
     (state) => state.starredMessages
   );
@@ -94,8 +97,22 @@ const ChatLayout = () => {
       }
     }
   }, [isUserAuthenticated, anonymousMode, RCInstance]);
+
+  const getPinnedMessages = useCallback(async () => {
+    if (isUserAuthenticated) {
+      try {
+        if (!isUserAuthenticated && !anonymousMode) {
+          return;
+        }
+        const { messages } = await RCInstance.getPinnedMessages();
+        setPinnedMessages(messages);
+      } catch (e) {
+        console.error(e);
+      }
+    }
+  }, [isUserAuthenticated, anonymousMode, RCInstance]);
   useEffect(() => {
-    getStarredMessages();
+    getStarredMessages(), getPinnedMessages();
   }, [showSidebar]);
   return (
     <Box

--- a/packages/react/src/views/Message/Message.js
+++ b/packages/react/src/views/Message/Message.js
@@ -66,7 +66,7 @@ const Message = ({
   );
   const addQuoteMessage = useMessageStore((state) => state.addQuoteMessage);
   const openThread = useMessageStore((state) => state.openThread);
-  const { getStarredMessages } = useFetchChatData();
+  const { getStarredMessages, getPinnedMessages } = useFetchChatData();
   const dispatchToastMessage = useToastBarDispatch();
   const { editMessage, setEditMessage } = useMessageStore((state) => ({
     editMessage: state.editMessage,
@@ -135,6 +135,7 @@ const Message = ({
         message: isPinned ? 'Message unpinned' : 'Message pinned',
       });
     }
+    getPinnedMessages();
   };
 
   const handleCopyMessage = async (msg) => {

--- a/packages/react/src/views/MessageAggregators/PinnedMessages.js
+++ b/packages/react/src/views/MessageAggregators/PinnedMessages.js
@@ -1,15 +1,18 @@
 import React from 'react';
 import { useComponentOverrides } from '@embeddedchat/ui-elements';
 import { MessageAggregator } from './common/MessageAggregator';
+import { usePinnedMessageStore } from '../../store';
 
 const PinnedMessages = () => {
   const { variantOverrides } = useComponentOverrides('PinnedMessages');
   const viewType = variantOverrides.viewType || 'Sidebar';
+  const pinnedMessages = usePinnedMessageStore((state) => state.PinnedMessage);
   return (
     <MessageAggregator
       title="Pinned Messages"
       iconName="pin"
       noMessageInfo="No Pinned Messages"
+      fetchedMessageList={pinnedMessages}
       shouldRender={(msg) => msg.pinned}
       viewType={viewType}
     />


### PR DESCRIPTION
# Brief Title
This pull request addresses the issue where pinned messages in threads do not appear in the main chat interface. The solution involves fetching pinned messages from both the main chat and threads and combining them to ensure they are all displayed in the main chat interface.


Fixes #853 

## Video/Screenshots

Uploading Screen Recording 2025-01-09 at 9.42.28 PM.mov…



## PR Test Details

**Note**: The PR will be ready for live testing at https://rocketchat.github.io/EmbeddedChat/pulls/pr-<pr_number> after approval. Contributors are requested to replace `<pr_number>` with the actual PR number.
