### PR TITLE
Fix: Ensure deleted messages are removed from starred and pinned message sidebars

### DIFF
--- a/packages/react/src/views/ChatLayout/ChatLayout.js
+++ b/packages/react/src/views/ChatLayout/ChatLayout.js
@@ -12,6 +12,7 @@ import {
   useThreadsMessageStore,
   useMemberStore,
   useSidebarStore,
+  useMessageStore,
 } from '../../store';
 
 import RoomMembers from '../RoomMembers/RoomMember';
@@ -45,6 +46,7 @@ const ChatLayout = () => {
   const starredMessages = useStarredMessageStore(
     (state) => state.starredMessages
   );
+  const messages = useMessageStore((state) => state.messages);
   const showSidebar = useSidebarStore((state) => state.showSidebar);
   const showMentions = useMentionsStore((state) => state.showMentions);
   const showAllFiles = useFileStore((state) => state.showAllFiles);
@@ -96,7 +98,7 @@ const ChatLayout = () => {
   }, [isUserAuthenticated, anonymousMode, RCInstance]);
   useEffect(() => {
     getStarredMessages();
-  }, [showSidebar]);
+  }, [showSidebar, messages]);
   return (
     <Box
       css={styles.layout}


### PR DESCRIPTION
# Brief Title
This pull request addresses the issue where messages deleted from the main chat interface do not get removed from the starred messages sidebar modal and the pinned messages sidebar modal. The solution involves updating the state for starred and pinned messages in real-time when a message is deleted from the main chat interface.


Fixes #861 

## Video/Screenshots

https://github.com/user-attachments/assets/93071f1d-fa71-4c50-b325-2a73c175bb6c



## PR Test Details

**Note**: The PR will be ready for live testing at https://rocketchat.github.io/EmbeddedChat/pulls/pr-<pr_number> after approval. Contributors are requested to replace `<pr_number>` with the actual PR number.
