### PR TITLE
fix: ensure messageBox and Toolbox are not visible to unauthorized users in read-only room

### DIFF
--- a/packages/react/src/views/ChatHeader/ChatHeader.js
+++ b/packages/react/src/views/ChatHeader/ChatHeader.js
@@ -154,19 +154,20 @@ const ChatHeader = ({
     };
 
     const setMessageAllowed = async () => {
-      const permissionRes = await RCInstance.permissionInfo();
       const channelRolesRes = await RCInstance.getChannelRoles(
         isChannelPrivate
       );
 
-      if (permissionRes.success && channelRolesRes.success) {
-        const postMsgRoles = permissionRes.update[140]?.roles || [];
+      if (channelRolesRes.success) {
         const channelLevelRoles = channelRolesRes.roles
           .filter((chRole) => chRole.u?._id === authenticatedUserId)
           .flatMap((chRole) => chRole.roles);
 
         const allRoles = [...channelLevelRoles, ...workspaceLevelRoles];
-        const canSendMsg = postMsgRoles.some((role) => allRoles.includes(role));
+        const canSendMsg =
+          allRoles.includes('admin') ||
+          allRoles.includes('moderator') ||
+          allRoles.includes('owner');
 
         setCanSendMsg(canSendMsg);
       }

--- a/packages/react/src/views/ChatInput/ChatInput.js
+++ b/packages/react/src/views/ChatInput/ChatInput.js
@@ -465,7 +465,7 @@ const ChatInput = ({ scrollToBottom }) => {
             status={
               editMessage.msg || editMessage.attachments
                 ? 'Editing Message'
-                : isChannelReadOnly
+                : isChannelReadOnly && canSendMsg && isUserAuthenticated
                 ? 'This room is read only'
                 : undefined
             }
@@ -529,7 +529,10 @@ const ChatInput = ({ scrollToBottom }) => {
                 ? 'This room is read only'
                 : 'Sign in to chat'
             }
-            css={styles.textInput}
+            css={css`
+              ${styles.textInput}
+              ${!canSendMsg && isUserAuthenticated && `text-align: center;`}
+            `}
             onChange={onTextChange}
             onBlur={() => {
               sendTypingStop();
@@ -547,14 +550,16 @@ const ChatInput = ({ scrollToBottom }) => {
             `}
           >
             {isUserAuthenticated ? (
-              <ActionButton
-                ghost
-                size="large"
-                onClick={() => sendMessage()}
-                type="primary"
-                disabled={disableButton || isRecordingMessage}
-                icon="send"
-              />
+              canSendMsg ? (
+                <ActionButton
+                  ghost
+                  size="large"
+                  onClick={() => sendMessage()}
+                  type="primary"
+                  disabled={disableButton || isRecordingMessage}
+                  icon="send"
+                />
+              ) : null
             ) : (
               <Button onClick={onJoin} type="primary" disabled={isLoginIn}>
                 {isLoginIn ? <Throbber /> : 'JOIN'}
@@ -562,7 +567,7 @@ const ChatInput = ({ scrollToBottom }) => {
             )}
           </Box>
         </Box>
-        {isUserAuthenticated && (
+        {isUserAuthenticated && canSendMsg && (
           <ChatInputFormattingToolbar
             messageRef={messageRef}
             inputRef={inputRef}


### PR DESCRIPTION
# Brief Title

Unauthorized Users in Read-Only Channels Can Access Message Toolbox and React with Emojis

## Acceptance Criteria fulfillment

- [ ] Revise the canSendMsg global state
- [ ]  Ensure that users in read-only channels cannot access the message toolbox.

Fixes #868 

## Video/Screenshots


https://github.com/user-attachments/assets/5c3709ff-f0bb-4d17-81fc-e0dfdc0e5782


## PR Test Details

**Note**: The PR will be ready for live testing at https://rocketchat.github.io/EmbeddedChat/pulls/pr-<pr_number> after approval. Contributors are requested to replace `<pr_number>` with the actual PR number.
