### PR TITLE
feat: Add timeStamps in attached text

### DIFF
--- a/packages/react/src/views/AttachmentHandler/TextAttachment.js
+++ b/packages/react/src/views/AttachmentHandler/TextAttachment.js
@@ -4,6 +4,8 @@ import PropTypes from 'prop-types';
 import { Box, Avatar, useTheme } from '@embeddedchat/ui-elements';
 import RCContext from '../../context/RCInstance';
 import { Markdown } from '../Markdown';
+import { format } from 'date-fns';
+import { useMemo } from 'react';
 
 const TextAttachment = ({ attachment, type, variantStyles = {} }) => {
   const { RCInstance } = useContext(RCContext);
@@ -14,6 +16,17 @@ const TextAttachment = ({ attachment, type, variantStyles = {} }) => {
   };
 
   const { theme } = useTheme();
+
+  const formattedTimestamp = useMemo(() => {
+    let timestamp;
+    if (typeof attachment.ts === 'object') {
+      timestamp = attachment.ts.$date;
+    } else if (typeof attachment.ts === 'string') {
+      timestamp = new Date(attachment.ts).getTime();
+    }
+    const formattedTime = format(new Date(timestamp), 'h:mm a');
+    return formattedTime;
+  }, [attachment.ts]);
 
   return (
     <Box
@@ -53,7 +66,24 @@ const TextAttachment = ({ attachment, type, variantStyles = {} }) => {
               alt="avatar"
               size="1.2em"
             />
-            <Box>@{attachment?.author_name}</Box>
+            <Box>{attachment?.author_name}</Box>
+            <Box
+              is="span"
+              css={css`
+                color: ${theme.colors.accentForeground};
+                overflow: hidden;
+                text-overflow: ellipsis;
+                white-space: nowrap;
+                letter-spacing: 0rem;
+                font-size: 0.7rem;
+                font-weight: 400;
+                line-height: 1rem;
+                flex-shrink: 0;
+                margin-left: 0.25rem;
+              `}
+            >
+              {formattedTimestamp}
+            </Box>
           </>
         )}
       </Box>
@@ -124,7 +154,7 @@ const TextAttachment = ({ attachment, type, variantStyles = {} }) => {
                       alt="avatar"
                       size="1.2em"
                     />
-                    <Box>@{nestedAttachment?.author_name}</Box>
+                    <Box>{nestedAttachment?.author_name}</Box>
                   </>
                 )}
               </Box>

--- a/packages/react/src/views/AttachmentHandler/TextAttachment.js
+++ b/packages/react/src/views/AttachmentHandler/TextAttachment.js
@@ -1,11 +1,10 @@
-import React, { useContext } from 'react';
+import React, { useContext, useMemo } from 'react';
 import { css } from '@emotion/react';
 import PropTypes from 'prop-types';
 import { Box, Avatar, useTheme } from '@embeddedchat/ui-elements';
 import RCContext from '../../context/RCInstance';
 import { Markdown } from '../Markdown';
 import { format } from 'date-fns';
-import { useMemo } from 'react';
 
 const TextAttachment = ({ attachment, type, variantStyles = {} }) => {
   const { RCInstance } = useContext(RCContext);
@@ -155,6 +154,23 @@ const TextAttachment = ({ attachment, type, variantStyles = {} }) => {
                       size="1.2em"
                     />
                     <Box>{nestedAttachment?.author_name}</Box>
+                    <Box
+                      is="span"
+                      css={css`
+                        color: ${theme.colors.accentForeground};
+                        overflow: hidden;
+                        text-overflow: ellipsis;
+                        white-space: nowrap;
+                        letter-spacing: 0rem;
+                        font-size: 0.7rem;
+                        font-weight: 400;
+                        line-height: 1rem;
+                        flex-shrink: 0;
+                        margin-left: 0.25rem;
+                      `}
+                    >
+                      {formattedTimestamp}
+                    </Box>
                   </>
                 )}
               </Box>

--- a/packages/react/src/views/Message/Message.js
+++ b/packages/react/src/views/Message/Message.js
@@ -10,6 +10,7 @@ import {
   lighten,
   darken,
 } from '@embeddedchat/ui-elements';
+import { css } from '@emotion/react';
 import { Attachments } from '../AttachmentHandler';
 import { Markdown } from '../Markdown';
 import MessageHeader from './MessageHeader';
@@ -255,16 +256,22 @@ const Message = ({
               >
                 {message.attachments && message.attachments.length > 0 ? (
                   <>
-                    <Markdown
-                      body={message}
-                      md={message.md}
-                      isReaction={false}
-                    />
                     <Attachments
                       attachments={message.attachments}
                       variantStyles={variantStyles}
                       msg={message}
                     />
+                    <div
+                      css={css`
+                        margin-top: 0.3rem;
+                      `}
+                    >
+                      <Markdown
+                        body={message}
+                        md={message.md}
+                        isReaction={false}
+                      />
+                    </div>
                   </>
                 ) : (
                   <Markdown body={message} md={message.md} isReaction={false} />

--- a/packages/react/src/views/QuoteMessage/QuoteMessage.js
+++ b/packages/react/src/views/QuoteMessage/QuoteMessage.js
@@ -13,6 +13,7 @@ import { useMessageStore } from '../../store';
 import getQuoteMessageStyles from './QuoteMessage.styles';
 import Attachment from '../AttachmentHandler/Attachment';
 import { Markdown } from '../Markdown';
+import { css } from '@emotion/react';
 
 const QuoteMessage = ({ className = '', style = {}, message }) => {
   const { RCInstance } = useContext(RCContext);
@@ -51,7 +52,23 @@ const QuoteMessage = ({ className = '', style = {}, message }) => {
           size="1.5em"
         />
         <Box>{message?.u.username}</Box>
-        <Box>{format(new Date(message.ts), 'h:mm a')}</Box>
+        <Box
+          is="span"
+          css={css`
+            color: ${theme.colors.accentForeground};
+            overflow: hidden;
+            text-overflow: ellipsis;
+            white-space: nowrap;
+            letter-spacing: 0rem;
+            font-size: 0.7rem;
+            font-weight: 400;
+            line-height: 1rem;
+            flex-shrink: 0;
+            margin-left: 0.25rem;
+          `}
+        >
+          {format(new Date(message.ts), 'h:mm a')}
+        </Box>
       </Box>
       <Box css={styles.message}>
         {message.file ? (


### PR DESCRIPTION
# Brief Title
Now text attachments also include timeStamps beside username just like RC
## Acceptance Criteria fulfillment

- [ ] Reverse the order of showing message before attachment, since RC follow attachment before message so that I reverse the order
- [ ] Include timeStams in both simple and nested-attachment
- [ ] Remove @ sign from attachment because RC also doesn't include it.

Fixes #873 

## Video/Screenshots
Before:
![image](https://github.com/user-attachments/assets/c64a0dce-9bca-4feb-bf52-43fe0ee1fb99)
After this PR it will look like this.
![Screenshot from 2025-01-12 23-23-49](https://github.com/user-attachments/assets/a1fb9db6-e659-426b-bd1a-7a4e0daf72e2)

## PR Test Details

**Note**: The PR will be ready for live testing at https://rocketchat.github.io/EmbeddedChat/pulls/pr-<pr_number> after approval. Contributors are requested to replace `<pr_number>` with the actual PR number.
