### PR TITLE
Added Divider in cahtinputformatingToolbar .

### DIFF
--- a/packages/react/src/views/ChatInput/ChatInput.styles.js
+++ b/packages/react/src/views/ChatInput/ChatInput.styles.js
@@ -85,6 +85,11 @@ export const getChatInputFormattingToolbarStyles = ({ theme, mode }) => {
         grid-template-columns: repeat(5, 0.2fr);
       }
     `,
+    dividerStyle: css`
+      width: 1px;
+      height: 1.5rem;
+      background: ${theme.colors.border};
+    `,
   };
   return styles;
 };

--- a/packages/react/src/views/ChatInput/ChatInputFormattingToolbar.js
+++ b/packages/react/src/views/ChatInput/ChatInputFormattingToolbar.js
@@ -156,7 +156,15 @@ const ChatInputFormattingToolbar = ({
       className={`ec-chat-input-formatting-toolbar ${classNames}`}
       style={styleOverrides}
     >
-      {surfaceItems.map((key) => chatToolMap[key])}
+      {surfaceItems.map((key, index) => (
+        <React.Fragment key={key}>
+          {chatToolMap[key]}
+          {((key === 'emoji' && index < surfaceItems.length - 1) ||
+            (key === 'link' && surfaceItems[index + 1] === 'audio')) && (
+            <Box css={styles.dividerStyle} />
+          )}
+        </React.Fragment>
+      ))}
 
       {isEmojiOpen && (
         <EmojiPicker


### PR DESCRIPTION
# Brief Title

Enhance the ChatInputFormattingToolbar component by adding vertical dividers between the following elements for improved UI clarity:

- Emoji and Bold
- Link and Audio Message

## Acceptance Criteria fulfillment

- [ ] Vertical dividers are added and visually separate Emoji and Bold, as well as Link and Audio Message.
- [ ]  Ensure the feature works seamlessly in both light and dark modes.
- [ ] Ensure the separators use theme.colors.border fetched dynamically using useTheme.


Fixes #876 

## Video/Screenshots

![image](https://github.com/user-attachments/assets/5d7aa1e5-b024-42c0-9f60-e0c8aadfdb41)


## PR Test Details

**Note**: The PR will be ready for live testing at https://rocketchat.github.io/EmbeddedChat/pulls/pr-<pr_number> after approval. Contributors are requested to replace `<pr_number>` with the actual PR number.
