### PR TITLE
Fix: Tooltips names for Formatting toolbar is not correct and not align with rocket.chat

### DIFF
--- a/packages/react/src/lib/textFormat.js
+++ b/packages/react/src/lib/textFormat.js
@@ -1,7 +1,11 @@
 export const formatter = [
-  { name: 'bold', pattern: '*{{text}}*' },
-  { name: 'italic', pattern: '_{{text}}_' },
-  { name: 'strike', pattern: '~{{text}}~' },
-  { name: 'code', pattern: '`{{text}}`' },
-  { name: 'multiline', pattern: '```\n{{text}}\n``` ' },
+  { name: 'bold', pattern: '*{{text}}*', tooltip: 'Bold' },
+  { name: 'italic', pattern: '_{{text}}_', tooltip: 'Italic' },
+  { name: 'strike', pattern: '~{{text}}~', tooltip: 'Strikethrough' },
+  { name: 'code', pattern: '`{{text}}`', tooltip: 'Inline code' },
+  {
+    name: 'multiline',
+    pattern: '```\n{{text}}\n```',
+    tooltip: 'Multi-line code',
+  },
 ];

--- a/packages/react/src/views/ChatInput/ChatInputFormattingToolbar.js
+++ b/packages/react/src/views/ChatInput/ChatInputFormattingToolbar.js
@@ -130,7 +130,11 @@ const ChatInputFormattingToolbar = ({
     formatter: formatters
       .map((name) => formatter.find((item) => item.name === name))
       .map((item) => (
-        <Tooltip text={item.name} position="top" key={`formatter-${item.name}`}>
+        <Tooltip
+          text={item.tooltip || item.name}
+          position="top"
+          key={`formatter-${item.name}`}
+        >
           <ActionButton
             square
             disabled={isRecordingMessage}


### PR DESCRIPTION
# Brief Title

Update Tooltip Names for Formatting Options in ChatInputFormattingToolbar for clarity and to Align with Rocket.Chat.

## Acceptance Criteria fulfillment

- [ ] Verify tooltip for `Strikethrough` displays as "Strikethrough."
- [ ] Verify tooltip for `Inline code` displays as "Inline Code."
- [ ] Verify tooltip for `multiline code` displays as "Multi-line Code."

Fixes #878 

## Video/Screenshots


https://github.com/user-attachments/assets/6fa5a9e5-bf0e-4df5-b829-88472713d066



## PR Test Details

**Note**: The PR will be ready for live testing at https://rocketchat.github.io/EmbeddedChat/pulls/pr-<pr_number> after approval. Contributors are requested to replace `<pr_number>` with the actual PR number.
