### PR TITLE
Fix: Add labels above input fields in Add Link window

### DIFF
--- a/packages/react/src/views/ChatInput/InsertLinkToolBox.js
+++ b/packages/react/src/views/ChatInput/InsertLinkToolBox.js
@@ -9,7 +9,7 @@ const InsertLinkToolBox = ({
 }) => {
   const { theme } = useTheme();
   const styles = getInsertLinkModalStyles(theme);
-  const [linkText, setLinkText] = useState(selectedText || 'Text');
+  const [linkText, setLinkText] = useState(selectedText);
   const [linkUrl, setLinkUrl] = useState(null);
 
   const handleLinkTextOnChange = (e) => {
@@ -26,16 +26,23 @@ const InsertLinkToolBox = ({
         <Modal.Close onClick={onClose} />
       </Modal.Header>
       <Modal.Content css={styles.modalContent}>
+        <p htmlFor="linkText" style={{ marginLeft: '1rem' }}>
+          Text
+        </p>
         <Input
+          id="linkText"
           type="text"
           onChange={handleLinkTextOnChange}
           value={linkText}
           css={styles.inputWithFormattingBox}
         />
+        <p htmlFor="linkUrl" style={{ marginLeft: '1rem' }}>
+          URL
+        </p>
         <Input
+          id="linkUrl"
           type="text"
           onChange={handleLinkUrlOnChange}
-          placeholder="URL"
           css={styles.inputWithFormattingBox}
         />
       </Modal.Content>


### PR DESCRIPTION
# Brief Title
Add labels above input fields in Add Link window

## Acceptance Criteria fulfillment

- [X]  Add a label above the URL input field in the Add Link window.
- [X]  Add a label above the Text input field in the Add Link window.
- [X]  Ensure the UI matches the expected design with proper labels, similar to RC.

Fixes #881

## Video/Screenshots

![image](https://github.com/user-attachments/assets/944f9465-277c-4f08-9c5b-0a057be3c4e2)


## PR Test Details

**Note**: The PR will be ready for live testing at https://rocketchat.github.io/EmbeddedChat/pulls/pr-882 after approval. Contributors are requested to replace `<pr_number>` with the actual PR number.
