### PR TITLE
Fix Loading of Older Thread Messages in Thread Message Modal

### DIFF
--- a/packages/api/src/EmbeddedChatApi.ts
+++ b/packages/api/src/EmbeddedChatApi.ts
@@ -556,7 +556,7 @@ export default class EmbeddedChatApi {
     try {
       const { userId, authToken } = (await this.auth.getCurrentUser()) || {};
       const messages = await fetch(
-        `${this.host}/api/v1/chat.getThreadMessages?roomId=${this.rid}&tmid=${tmid}`,
+        `${this.host}/api/v1/chat.getThreadMessages?roomId=${this.rid}`,
         {
           headers: {
             "Content-Type": "application/json",
@@ -567,6 +567,26 @@ export default class EmbeddedChatApi {
         }
       );
       return await messages.json();
+    } catch (err) {
+      console.log(err);
+    }
+  }
+
+  async getAllThreadMessages(type?: string, text?: string) {
+    try {
+      const { userId, authToken } = (await this.auth.getCurrentUser()) || {};
+      const allthreads = await fetch(
+        `${this.host}/api/v1/chat.getThreadsList?rid=${this.rid}&type=${type}&text=${text}`,
+        {
+          headers: {
+            "Content-Type": "application/json",
+            "X-Auth-Token": authToken,
+            "X-User-Id": userId,
+          },
+          method: "GET",
+        }
+      );
+      return await allthreads.json();
     } catch (err) {
       console.log(err);
     }

--- a/packages/api/src/EmbeddedChatApi.ts
+++ b/packages/api/src/EmbeddedChatApi.ts
@@ -556,7 +556,7 @@ export default class EmbeddedChatApi {
     try {
       const { userId, authToken } = (await this.auth.getCurrentUser()) || {};
       const messages = await fetch(
-        `${this.host}/api/v1/chat.getThreadMessages?roomId=${this.rid}`,
+        `${this.host}/api/v1/chat.getThreadMessages?roomId=${this.rid}&tmid=${tmid}`,
         {
           headers: {
             "Content-Type": "application/json",

--- a/packages/docs/blog/EmbeddedChat-2023.md
+++ b/packages/docs/blog/EmbeddedChat-2023.md
@@ -132,6 +132,7 @@ class EmbeddedChatApi {
         field?: object | undefined;
     }): Promise<any>;
     getThreadMessages(tmid: string): Promise<any>;
+    getAllThreadMessages( type?: string, text?: string): Promise<any>;
     getChannelRoles(): Promise<any>;
     sendTypingStatus(username: string, typing: boolean): Promise<void>;
     sendMessage(message: any, threadId: string): Promise<any>;

--- a/packages/react/src/hooks/useFetchChatData.js
+++ b/packages/react/src/hooks/useFetchChatData.js
@@ -23,6 +23,10 @@ const useFetchChatData = (showRoles) => {
   const setViewUserInfoPermissions = useUserStore(
     (state) => state.setViewUserInfoPermissions
   );
+  const AllThreadMessages = useMessageStore((state) => state.allThreadMessages);
+  const setAllThreadMessages = useMessageStore(
+    (state) => state.setAllThreadMessages
+  );
 
   const getMessagesAndRoles = useCallback(
     async (anonymousMode) => {
@@ -90,6 +94,24 @@ const useFetchChatData = (showRoles) => {
     ]
   );
 
+  const getAllThreadMessages = useCallback(
+    async (anonymousMode) => {
+      if (isUserAuthenticated) {
+        try {
+          if (!isUserAuthenticated && !anonymousMode) {
+            return;
+          }
+          const { threads: allThreadMessages } =
+            await RCInstance.getAllThreadMessages();
+          setAllThreadMessages(allThreadMessages);
+        } catch (e) {
+          console.log(e);
+        }
+      }
+    },
+    [isUserAuthenticated, RCInstance, setAllThreadMessages]
+  );
+
   const getStarredMessages = useCallback(
     async (anonymousMode) => {
       if (isUserAuthenticated) {
@@ -107,7 +129,7 @@ const useFetchChatData = (showRoles) => {
     [isUserAuthenticated, RCInstance, setStarredMessages]
   );
 
-  return { getMessagesAndRoles, getStarredMessages };
+  return { getMessagesAndRoles, getStarredMessages, getAllThreadMessages };
 };
 
 export default useFetchChatData;

--- a/packages/react/src/store/messageStore.js
+++ b/packages/react/src/store/messageStore.js
@@ -6,6 +6,7 @@ const useMessageStore = create((set, get) => ({
   messages: [],
   isMessageLoaded: false,
   threadMessages: [],
+  allThreadMessages: [],
   filtered: false,
   editMessage: {},
   quoteMessage: [],
@@ -113,6 +114,8 @@ const useMessageStore = create((set, get) => ({
   },
   setThreadMessages: (messages) => set(() => ({ threadMessages: messages })),
   setHeaderTitle: (title) => set(() => ({ headerTitle: title })),
+  setAllThreadMessages: (messages) =>
+    set(() => ({ allThreadMessages: messages })),
 }));
 
 export default useMessageStore;

--- a/packages/react/src/views/ChatBody/ChatBody.js
+++ b/packages/react/src/views/ChatBody/ChatBody.js
@@ -59,6 +59,10 @@ const ChatBody = ({
   const isChannelPrivate = useChannelStore((state) => state.isChannelPrivate);
   const channelInfo = useChannelStore((state) => state.channelInfo);
   const isLoginIn = useLoginStore((state) => state.isLoginIn);
+  const setAllThreadMessages = useMessageStore(
+    (state) => state.setAllThreadMessages
+  );
+  const { getAllThreadMessages } = useFetchChatData();
 
   const [isThreadOpen, threadMainMessage] = useMessageStore((state) => [
     state.isThreadOpen,
@@ -92,6 +96,8 @@ const ChatBody = ({
           isChannelPrivate
         );
         setThreadMessages(messages.reverse());
+
+        getAllThreadMessages();
       } catch (e) {
         console.error(e);
       }

--- a/packages/react/src/views/ChatLayout/ChatLayout.js
+++ b/packages/react/src/views/ChatLayout/ChatLayout.js
@@ -12,6 +12,7 @@ import {
   useThreadsMessageStore,
   useMemberStore,
   useSidebarStore,
+  useMessageStore,
 } from '../../store';
 
 import RoomMembers from '../RoomMembers/RoomMember';
@@ -44,6 +45,9 @@ const ChatLayout = () => {
   );
   const starredMessages = useStarredMessageStore(
     (state) => state.starredMessages
+  );
+  const setAllThreadMessages = useMessageStore(
+    (state) => state.setAllThreadMessages
   );
   const showSidebar = useSidebarStore((state) => state.showSidebar);
   const showMentions = useMentionsStore((state) => state.showMentions);
@@ -96,6 +100,24 @@ const ChatLayout = () => {
   }, [isUserAuthenticated, anonymousMode, RCInstance]);
   useEffect(() => {
     getStarredMessages();
+  }, [showSidebar]);
+
+  const getAllThreads = useCallback(async () => {
+    if (isUserAuthenticated) {
+      try {
+        if (!isUserAuthenticated && !anonymousMode) {
+          return;
+        }
+        const { threads: allThreadMessages } =
+          await RCInstance.getAllThreadMessages();
+        setAllThreadMessages(allThreadMessages);
+      } catch (e) {
+        console.log(e);
+      }
+    }
+  }, [isUserAuthenticated, RCInstance, setAllThreadMessages]);
+  useEffect(() => {
+    getAllThreads();
   }, [showSidebar]);
   return (
     <Box

--- a/packages/react/src/views/MessageAggregators/ThreadedMessages.js
+++ b/packages/react/src/views/MessageAggregators/ThreadedMessages.js
@@ -10,7 +10,7 @@ const ThreadedMessages = () => {
   const { variantOverrides } = useComponentOverrides('ThreadedMessages');
   const viewType = variantOverrides.viewType || 'Sidebar';
   const [text, setText] = useState('');
-
+  const allThreadMessages = useMessageStore((state) => state.allThreadMessages);
   const handleInputChange = (e) => {
     setText(e.target.value);
   };
@@ -26,6 +26,7 @@ const ThreadedMessages = () => {
   return (
     <MessageAggregator
       title="Threads"
+      fetchedMessageList={allThreadMessages}
       iconName="thread"
       noMessageInfo="No threads found"
       searchProps={{


### PR DESCRIPTION
# Brief Title
This pull request addresses the issue where older thread messages are not being loaded in the thread message modal. 
## Acceptance Criteria fulfillment

- Updated the getAllThreadMessages function in EmbeddedChatApi.ts to correctly fetch older thread messages.
-Updated the ChatBody component to correctly use the getAllThreadMessages function from the useFetchChatData hook and update the state.


Fixes #895 

## Video/Screenshots


https://github.com/user-attachments/assets/f2912771-dd29-4320-b59f-e5f13a347169



## PR Test Details

**Note**: The PR will be ready for live testing at https://rocketchat.github.io/EmbeddedChat/pulls/pr-<pr_number> after approval. Contributors are requested to replace `<pr_number>` with the actual PR number.
