### PR TITLE
Fix: Tool Tips positioned above for Message Toolbox

### DIFF
--- a/packages/react/src/views/Message/MessageToolbox.js
+++ b/packages/react/src/views/Message/MessageToolbox.js
@@ -229,9 +229,6 @@ export const MessageToolbox = ({
           style={styleOverrides}
           {...props}
         >
-          {surfaceOptions?.length > 0 && (
-            <SurfaceMenu options={surfaceOptions} size="small" />
-          )}
           {menuOptions?.length > 0 && (
             <Menu
               size="small"
@@ -239,6 +236,15 @@ export const MessageToolbox = ({
               tooltip={{ isToolTip: true, position: 'top', text: 'More' }}
               useWrapper={false}
               style={{ top: 'auto', bottom: `calc(100% + 2px)` }}
+            />
+          )}
+          {surfaceOptions?.length > 0 && (
+            <SurfaceMenu
+              options={surfaceOptions.map(option => ({
+                ...option,
+                tooltipPosition: 'top'
+              }))}
+              size="small"
             />
           )}
 

--- a/packages/react/src/views/SurfaceMenu/SurfaceItem.js
+++ b/packages/react/src/views/SurfaceMenu/SurfaceItem.js
@@ -2,7 +2,7 @@ import React from 'react';
 import { Tooltip, ActionButton } from '@embeddedchat/ui-elements';
 
 const SurfaceItem = ({ item, size }) => (
-  <Tooltip text={item.label} position="bottom" key={item.id}>
+  <Tooltip text={item.label} position={item.tooltipPosition || 'bottom'} key={item.id}>
     <ActionButton
       square
       ghost


### PR DESCRIPTION
# Tool-Tips positioned above Message Toolbox


## Acceptance Criteria fulfillment

- [ ] The tooltip should be fully visible and display the complete text without being truncated.

Fixes #900 

## Video/Screenshots

[Screencast from 2025-01-15 15-20-10.webm](https://github.com/user-attachments/assets/a6c85ec3-a3fd-431e-a3c8-704419b4adea)

**Note**: The PR will be ready for live testing at https://rocketchat.github.io/EmbeddedChat/pulls/pr- after approval. 
