### PR TITLE
Added progress bar to toast messages for better UI experience

### DIFF
--- a/packages/ui-elements/src/components/ToastBar/ProgressBar.js
+++ b/packages/ui-elements/src/components/ToastBar/ProgressBar.js
@@ -1,0 +1,35 @@
+import React, { useEffect, useState } from 'react';
+import { Box } from '../Box';
+import useTheme from '../../hooks/useTheme';
+import { getProgressBarStyles } from './ToastBar.styles';
+
+const ProgressBar = ({ color, time }) => {
+  const [progress, setProgress] = useState(0);
+  const { theme } = useTheme();
+  const { mode } = useTheme();
+  const styles = getProgressBarStyles(theme, mode, progress, color);
+
+  useEffect(() => {
+    const intervalTime = 10;
+
+    const interval = setInterval(() => {
+      setProgress((prev) => {
+        if (prev < 100) {
+          return prev + 1;
+        }
+        clearInterval(interval);
+        return prev;
+      });
+    }, intervalTime);
+
+    return () => clearInterval(interval);
+  }, [time]);
+
+  return (
+    <Box css={styles.progressBarContainer}>
+      <Box css={styles.progressbar} />
+    </Box>
+  );
+};
+
+export default ProgressBar;

--- a/packages/ui-elements/src/components/ToastBar/ToastBar.js
+++ b/packages/ui-elements/src/components/ToastBar/ToastBar.js
@@ -7,11 +7,14 @@ import { Icon } from '../Icon';
 import { ActionButton } from '../ActionButton';
 import { getToastbarStyles } from './ToastBar.styles';
 import useTheme from '../../hooks/useTheme';
+import ProgressBar from './ProgressBar';
+import { darken, lighten } from '../../lib';
 
 const ToastBar = ({ toast, onClose }) => {
   const { type, message, time = 2000 } = toast;
   const toastRef = useRef();
   const { theme } = useTheme();
+  const { mode } = useTheme();
 
   const { classNames, styleOverrides } = useComponentOverrides('ToastBar');
   const styles = getToastbarStyles(theme);
@@ -45,17 +48,27 @@ const ToastBar = ({ toast, onClose }) => {
     setTimeout(onClose, time);
   }, [onClose, time]);
 
+  let progressBarBgColor = darken(bgColor, 0.5);
+  if (mode === 'dark') {
+    progressBarBgColor = lighten(bgColor, 0.85);
+  }
+
   return (
-    <Box
-      ref={toastRef}
-      css={styles.toastbar(color, bgColor, time)}
-      className={appendClassNames('ec-toast-bar', classNames)}
-      style={styleOverrides}
-    >
-      <Icon size="1em" name={iconName} />
-      {message}
-      <ActionButton icon="cross" size="small" onClick={onClose} ghost />
-    </Box>
+    <>
+      <Box
+        ref={toastRef}
+        css={styles.toastbar(color, bgColor, time)}
+        className={appendClassNames('ec-toast-bar', classNames)}
+        style={styleOverrides}
+      >
+        <Icon size="1em" name={iconName} />
+        {message}
+        <ActionButton icon="cross" size="small" onClick={onClose} ghost />
+      </Box>
+      <Box>
+        <ProgressBar color={progressBarBgColor} time={time} />
+      </Box>
+    </>
   );
 };
 

--- a/packages/ui-elements/src/components/ToastBar/ToastBar.styles.js
+++ b/packages/ui-elements/src/components/ToastBar/ToastBar.styles.js
@@ -27,7 +27,7 @@ export const getToastbarStyles = (theme) => {
       max-width: 20rem;
       color: ${color};
       background-color: ${bgColor};
-      border-radius: ${theme.radius};
+      border-radius: ${theme.radius} ${theme.radius} 0 0;
       padding: 0.75em 1em;
       z-index: ${theme.zIndex?.toastbar || 1600};
       animation: ${animation} ${time}ms ease-in-out forwards;
@@ -37,13 +37,35 @@ export const getToastbarStyles = (theme) => {
   return styles;
 };
 
-export const getToastBarContainerStyles = (theme) => {
+export const getToastBarContainerStyles = (theme, mode) => {
   const styles = {
     container: css`
       position: absolute;
       z-index: ${theme.zIndex?.toastbar || 1600};
       border-radius: ${theme.radius};
       animation: ${animation} ${2000}ms ease-in-out forwards;
+      box-shadow: ${mode === 'light'
+        ? '0 4px 8px 0 rgba(0, 0, 0, 0.2), 0 6px 20px 0 rgba(0, 0, 0, 0.19)'
+        : null};
+    `,
+  };
+  return styles;
+};
+
+export const getProgressBarStyles = (theme, mode, progress, color) => {
+  const styles = {
+    progressBarContainer: css`
+      width: 100%;
+      height: 7px;
+      border-radius: 0 0 ${theme.radius} ${theme.radius};
+      background-color: ${mode === 'dark' ? theme.colors.foreground : null};
+    `,
+    progressbar: css`
+      width: ${progress}%;
+      height: 100%;
+      background-color: ${color};
+      border-radius: 0 0 ${theme.radius} ${theme.radius};
+      transition: width 0.02s linear;
     `,
   };
   return styles;

--- a/packages/ui-elements/src/components/ToastBar/ToastContainer.js
+++ b/packages/ui-elements/src/components/ToastBar/ToastContainer.js
@@ -7,7 +7,8 @@ import { getToastBarContainerStyles } from './ToastBar.styles';
 
 const ToastContainer = () => {
   const { theme } = useTheme();
-  const styles = getToastBarContainerStyles(theme);
+  const { mode } = useTheme();
+  const styles = getToastBarContainerStyles(theme, mode);
   const { position, toasts, setToasts } = useContext(ToastContext);
   const positionStyle = useMemo(() => {
     const positions = position.split(/\s+/);


### PR DESCRIPTION
# Brief Title
Added progress bar to toast messages for better UI experience

## Acceptance Criteria fulfillment

- [X] Combine progress bar with toast messages so that the progress bar duration matches the time the toast message stays on the screen.
- [X] Ensure the progress bar is dynamically adapted to both light and dark themes.
- [X] Implement border radius for the progress bar to match the toast message style.
- [X] The color of the progress bar should match the toast message's color palette:
- [X] For light theme, the progress bar will be a darker tone.
- [X] For dark theme, the progress bar will be a lighter tone.

Fixes #902

## Video/Screenshots


https://github.com/user-attachments/assets/d6672be5-2416-455b-952d-b972ad48d94d


and 



https://github.com/user-attachments/assets/cb57ad60-cf60-4ea3-b8d5-4d909e2d966a



## PR Test Details

**Note**: The PR will be ready for live testing at https://rocketchat.github.io/EmbeddedChat/pulls/pr-903 after approval. Contributors are requested to replace `<pr_number>` with the actual PR number.
