### PR TITLE
Bug: Hide 'Report Message' option on user's own message and enhance Message Modal

### DIFF
--- a/packages/react/src/views/Message/MessageToolbox.js
+++ b/packages/react/src/views/Message/MessageToolbox.js
@@ -171,7 +171,7 @@ export const MessageToolbox = ({
         id: 'report',
         onClick: () => handlerReportMessage(message),
         iconName: 'report',
-        visible: true,
+        visible: message.u._id !== authenticatedUserId,
         type: 'destructive',
       },
     }),

--- a/packages/react/src/views/MessageList/MessageList.js
+++ b/packages/react/src/views/MessageList/MessageList.js
@@ -19,6 +19,12 @@ const MessageList = ({ messages }) => {
 
   const filteredMessages = messages.filter((msg) => !msg.tmid);
 
+  const foundMessage = messages.find(
+    (message) => message._id === messageToReport
+  );
+  // console.log("messageToReport: " + JSON.stringify(messageToReport));
+  // console.log("foundMessage: " + JSON.stringify(foundMessage));
+
   return (
     <>
       {filteredMessages.length === 0 ? (
@@ -60,7 +66,10 @@ const MessageList = ({ messages }) => {
             );
           })}
           {showReportMessage && (
-            <MessageReportWindow messageId={messageToReport} />
+            <MessageReportWindow
+              messageId={messageToReport}
+              reportedMessage={foundMessage}
+            />
           )}
         </>
       )}

--- a/packages/react/src/views/ReportMessage/MessageReportWindow.js
+++ b/packages/react/src/views/ReportMessage/MessageReportWindow.js
@@ -4,7 +4,7 @@ import { Box, Input } from '@embeddedchat/ui-elements';
 import ReportWindowButtons from './ReportWindowButtons';
 import styles from './ReportMessage.styles';
 
-const MessageReportWindow = ({ messageId }) => {
+const MessageReportWindow = ({ messageId, reportedMessage }) => {
   const [reportDescription, setDescription] = useState('');
   return (
     <ReportWindowButtons
@@ -14,6 +14,7 @@ const MessageReportWindow = ({ messageId }) => {
       cancelText="Cancel"
       reportDescription={reportDescription}
       messageId={messageId}
+      message={reportedMessage}
     >
       <Box css={styles.conatiner}>
         <Input

--- a/packages/react/src/views/ReportMessage/ReportWindowButtons.js
+++ b/packages/react/src/views/ReportMessage/ReportWindowButtons.js
@@ -9,13 +9,21 @@ import {
 } from '@embeddedchat/ui-elements';
 import { useMessageStore } from '../../store';
 import RCContext from '../../context/RCInstance';
+import { Markdown } from '../Markdown';
+import Attachment from '../AttachmentHandler/Attachment';
 
-const ReportWindowButtons = ({ children, reportDescription, messageId }) => {
+const ReportWindowButtons = ({
+  children,
+  reportDescription,
+  messageId,
+  message,
+}) => {
   const [toggleReportMessage, setMessageToReport] = useMessageStore((state) => [
     state.toggleShowReportMessage,
     state.setMessageToReport,
   ]);
   const { RCInstance } = useContext(RCContext);
+  const instanceHost = RCInstance.getHost();
   const dispatchToastMessage = useToastBarDispatch();
 
   const handleOnClose = () => {
@@ -56,6 +64,61 @@ const ReportWindowButtons = ({ children, reportDescription, messageId }) => {
         </Modal.Title>
         <Modal.Close onClick={handleOnClose} />
       </Modal.Header>
+      <Modal.Content
+        style={{
+          overflow: 'scroll',
+          whiteSpace: 'wrap',
+          padding: '1rem',
+          maxHeight: '50vh',
+        }}
+      >
+        {message.file ? (
+          message.file.type.startsWith('image/') ? (
+            <div>
+              <img
+                src={`${instanceHost}/file-upload/${message.file._id}/${message.file.name}`}
+                alt={message.file.name}
+                style={{ maxWidth: '100px', maxHeight: '100px' }}
+              />
+              <div>{`${message.file.name} (${(message.file.size / 1024).toFixed(
+                2
+              )} kB)`}</div>
+            </div>
+          ) : message.file.type.startsWith('video/') ? (
+            <video controls style={{ maxWidth: '100%', maxHeight: '200px' }}>
+              <source
+                src={`${instanceHost}/file-upload/${message.file._id}/${message.file.name}`}
+                type={message.file.type}
+              />
+              Your browser does not support the video tag.
+            </video>
+          ) : message.file.type.startsWith('audio/') ? (
+            <audio controls style={{ maxWidth: '100%' }}>
+              <source
+                src={`${instanceHost}/file-upload/${message.file._id}/${message.file.name}`}
+                type={message.file.type}
+              />
+              Your browser does not support the audio element.
+            </audio>
+          ) : (
+            <Markdown body={message} md={message.md} isReaction={false} />
+          )
+        ) : (
+          <Markdown body={message} md={message.md} isReaction={false} />
+        )}
+        {message.attachments &&
+          message.attachments.length > 0 &&
+          message.msg &&
+          message.msg[0] === '[' &&
+          message.attachments.map((attachment, index) => (
+            <Attachment
+              key={index}
+              attachment={attachment}
+              type={attachment.type}
+              host={instanceHost}
+            />
+          ))}
+      </Modal.Content>
       <Modal.Content>{children}</Modal.Content>
       <Modal.Footer>
         <Button type="secondary" onClick={handleOnClose}>


### PR DESCRIPTION
# Brief Title
Bug: Hide 'Report Message' option on user's own message and enhance Message Modal

## Acceptance Criteria fulfillment

- [X] Hide the 'Report Message' option when the user is viewing their own message.
- [X]  Include the message description in the Report Message Modal.
- [X]  Enhance the styling of the Report Message Modal.

Fixes #904

## Video/Screenshots



https://github.com/user-attachments/assets/f1ebdf55-e063-4e73-a73a-890812260771



## PR Test Details

**Note**: The PR will be ready for live testing at https://rocketchat.github.io/EmbeddedChat/pulls/pr-905 after approval. Contributors are requested to replace `<pr_number>` with the actual PR number.
