### PR TITLE
Added search instruction to Search Messages sidebar

### DIFF
--- a/packages/react/src/views/MessageAggregators/common/MessageAggregator.js
+++ b/packages/react/src/views/MessageAggregators/common/MessageAggregator.js
@@ -18,6 +18,8 @@ import NoMessagesIndicator from './NoMessageIndicator';
 import FileDisplay from '../../FileMessage/FileMessage';
 import useSetExclusiveState from '../../../hooks/useSetExclusiveState';
 import { useRCContext } from '../../../context/RCInstance';
+import searchNote from '../data/searchMessageNote';
+import { Markdown } from '../../Markdown';
 
 export const MessageAggregator = ({
   title,
@@ -33,7 +35,8 @@ export const MessageAggregator = ({
   viewType = 'Sidebar',
 }) => {
   const { theme } = useTheme();
-  const styles = getMessageAggregatorStyles(theme);
+  const { mode } = useTheme();
+  const styles = getMessageAggregatorStyles(theme, mode);
   const setExclusiveState = useSetExclusiveState();
   const { ECOptions } = useRCContext();
   const showRoles = ECOptions?.showRoles;
@@ -109,6 +112,8 @@ export const MessageAggregator = ({
   const noMessages = messageList?.length === 0 || !messageRendered;
   const ViewComponent = viewType === 'Popup' ? Popup : Sidebar;
 
+  const showSearchNote = title === 'Search Messages';
+
   return (
     <ViewComponent
       title={title}
@@ -127,6 +132,16 @@ export const MessageAggregator = ({
           }
         : {})}
     >
+      {showSearchNote && (
+        <Box css={styles.noteStyle}>
+          <Markdown
+            body={searchNote.msg}
+            md={searchNote.md}
+            isReaction={false}
+          />
+        </Box>
+      )}
+
       {fetching || loading ? (
         <LoadingIndicator />
       ) : (

--- a/packages/react/src/views/MessageAggregators/common/MessageAggregator.styles.js
+++ b/packages/react/src/views/MessageAggregators/common/MessageAggregator.styles.js
@@ -1,6 +1,7 @@
 import { css } from '@emotion/react';
+import { lighten, darken } from '@embeddedchat/ui-elements';
 
-const getMessageAggregatorStyles = () => {
+const getMessageAggregatorStyles = (theme, mode) => {
   const styles = {
     listContainerStyles: css`
       flex: 1;
@@ -20,6 +21,15 @@ const getMessageAggregatorStyles = () => {
       display: flex;
       flex-direction: column;
       align-items: center;
+    `,
+
+    noteStyle: css`
+      margin-left: 16px;
+      margin-right: 16px;
+      font-size: 0.875rem;
+      color: ${mode === 'light'
+        ? lighten(theme?.colors.foreground, 8)
+        : darken(theme?.colors.foreground, 0.3)};
     `,
   };
 

--- a/packages/react/src/views/MessageAggregators/data/searchMessageNote.js
+++ b/packages/react/src/views/MessageAggregators/data/searchMessageNote.js
@@ -1,0 +1,42 @@
+const searchNote = {
+  msg: 'You can search using [Regular Expression](https://en.wikipedia.org/wiki/Regular_expression). e.g. `/^text$/i`',
+  md: [
+    {
+      type: 'PARAGRAPH',
+      value: [
+        {
+          type: 'PLAIN_TEXT',
+          value: 'You can search using ',
+        },
+        {
+          type: 'LINK',
+          value: {
+            src: {
+              type: 'PLAIN_TEXT',
+              value: 'https://en.wikipedia.org/wiki/Regular_expression',
+            },
+            label: [
+              {
+                type: 'PLAIN_TEXT',
+                value: 'Regular Expression',
+              },
+            ],
+          },
+        },
+        {
+          type: 'PLAIN_TEXT',
+          value: '. e.g. ',
+        },
+        {
+          type: 'INLINE_CODE',
+          value: {
+            type: 'PLAIN_TEXT',
+            value: '/^text$/i',
+          },
+        },
+      ],
+    },
+  ],
+};
+
+export default searchNote;


### PR DESCRIPTION
# Brief Title
Added search instruction to Search Messages sidebar

## Acceptance Criteria fulfillment

- [X] Instruction Display: When the view type is "Search Messages", a section with a markdown formatted message appears at the top of the sidebar.
- [X] Styling: The instruction should have its own custom style handling dark and light themes.
- [X] Rendering Condition: The instruction should only be rendered when the title of the view is Search Messages.

Fixes #909

## Video/Screenshots

![image](https://github.com/user-attachments/assets/f5f230cf-6b96-4bc8-8ae4-e1a1216f7d11)


and 

![image](https://github.com/user-attachments/assets/441bd58a-480b-48dd-986a-21f226853e32)


## PR Test Details

**Note**: The PR will be ready for live testing at https://rocketchat.github.io/EmbeddedChat/pulls/pr-910 after approval. Contributors are requested to replace `<pr_number>` with the actual PR number.
