### PR TITLE
fix:Notification Bugs for Avatar, Room Conversion, and Room Name Change Events.

### DIFF
--- a/packages/react/src/views/Message/MessageHeader.js
+++ b/packages/react/src/views/Message/MessageHeader.js
@@ -68,18 +68,32 @@ const MessageHeader = ({
         return 'unarchived room';
       case 'room-allowed-reacting':
         return 'allowed reactions';
+      case 'room_changed_avatar':
+        return `changed room avatar`;
       case 'room_changed_announcement':
-        return `changed announcement to: ${
+        return `changed room announcement to: ${
           message?.msg && message.msg.length > 0 ? message.msg : '(none)'
         }`;
       case 'room_changed_description':
-        return `changed description to: ${
+        return `changed room description to: ${
           message?.msg && message.msg.length > 0 ? message.msg : '(none)'
         }`;
       case 'room_changed_topic':
-        return `changed topic to: ${
+        return `changed room topic to: ${
           message?.msg && message.msg.length > 0 ? message.msg : '(none)'
         }`;
+      case 'r':
+        return `changed room name to ${
+          message?.msg && message.msg.length > 0 ? message.msg : '(none)'
+        }`;
+      case 'user-converted-to-team':
+        return `converted #${
+          message?.msg && message.msg.length > 0 ? message.msg : '(none)'
+        } to team`;
+      case 'user-converted-to-channel':
+        return `converted #${
+          message?.msg && message.msg.length > 0 ? message.msg : '(none)'
+        } to channel`;
       default:
         return '';
     }


### PR DESCRIPTION

# Brief Title

Fix Notification Bugs for Avatar, Room Conversion, and Room Name Change Events.


## Acceptance Criteria fulfillment

- [ ] Notification for room avatar changes displays correct wording (e.g., "changed room avatar").
- [ ] Notification for room-to-team and team-to-channel conversion displays appropriate messages (e.g., "converted #roomName to team" and "converted #roomName to channel").
- [ ] Notification for room name change events displays the correct message and is not empty.

Fixes #918 

## Video/Screenshots
![image](https://github.com/user-attachments/assets/f84e07fc-e69c-4d88-b3fe-f770c67e13b8)

![image](https://github.com/user-attachments/assets/d1fe360d-2ea2-45f7-aaca-69de1520c50e)


## PR Test Details

**Note**: The PR will be ready for live testing at https://rocketchat.github.io/EmbeddedChat/pulls/pr-<pr_number> after approval. Contributors are requested to replace `<pr_number>` with the actual PR number.
