### PR TITLE
Fix: attachment and avatar size in messages

### DIFF
--- a/packages/react/src/views/AttachmentHandler/AudioAttachment.js
+++ b/packages/react/src/views/AttachmentHandler/AudioAttachment.js
@@ -76,7 +76,11 @@ const AudioAttachment = ({
           isExpanded={isExpanded}
         />
         {isExpanded && (
-          <audio src={host + attachment.audio_url} width="100%" controls />
+          <audio
+            src={host + attachment.audio_url}
+            style={{ maxHeight: '100%', maxWidth: '100%' }}
+            controls
+          />
         )}
 
         {attachment.attachments &&

--- a/packages/react/src/views/AttachmentHandler/VideoAttachment.js
+++ b/packages/react/src/views/AttachmentHandler/VideoAttachment.js
@@ -87,11 +87,12 @@ const VideoAttachment = ({
         />
         {isExpanded && (
           <video
-            width={300}
             controls
             style={{
               borderBottomLeftRadius: 'inherit',
               borderBottomRightRadius: 'inherit',
+              maxWidth: '100%',
+              maxHeight: '200px',
             }}
           >
             <source

--- a/packages/react/src/views/Message/Message.styles.js
+++ b/packages/react/src/views/Message/Message.styles.js
@@ -11,6 +11,9 @@ export const getMessageStyles = ({ theme }) => {
       padding-left: 2.25rem;
       padding-right: 2.25rem;
       color: ${theme.colors.foreground};
+      @media (max-width: 768px) {
+        padding-left: 0.8rem;
+      }
     `,
     messageEditing: css`
       background-color: ${theme.colors.secondary};

--- a/packages/react/src/views/Message/MessageAvatarContainer.js
+++ b/packages/react/src/views/Message/MessageAvatarContainer.js
@@ -43,7 +43,15 @@ const MessageAvatarContainer = ({
         <Avatar
           url={getUserAvatarUrl(message.u.username)}
           alt="avatar"
-          size={message.t ? '1.2em' : '2.25em'}
+          size={
+            window.matchMedia('(max-width: 768px)').matches
+              ? message.t
+                ? '1.2em'
+                : '1.5em'
+              : message.t
+              ? '1.5em'
+              : '2.25em'
+          }
           onClick={handleAvatarClick}
         />
       ) : null}


### PR DESCRIPTION
# Brief Title
Fixed responsiveness for attachments and avatar sizes in messages.

## Acceptance Criteria fulfillment

- [x] Adjusted avatar size using `window.matchMedia` for responsive behavior.
- [x] Added responsive padding in the message styles for smaller screen widths
- [x] Updated attachment display styles to ensure consistent responsiveness and prevent overflowing for smaller screens.

Fixes #908 

## Video/Screenshots
[Screencast from 2025-01-19 01-16-00.webm](https://github.com/user-attachments/assets/2799e04f-680f-4b28-a223-83bc8b73dd11)

## PR Test Details

**Note**: The PR will be ready for live testing at https://rocketchat.github.io/EmbeddedChat/pulls/pr-922 after approval. Contributors are requested to replace `<pr_number>` with the actual PR number.
