### PR TITLE
Fix: Made Emoji Picker responsive for Mobile Screens

### DIFF
--- a/packages/react/src/views/ChatInput/ChatInputFormattingToolbar.js
+++ b/packages/react/src/views/ChatInput/ChatInputFormattingToolbar.js
@@ -344,7 +344,11 @@ const ChatInputFormattingToolbar = ({
           positionStyles={css`
             position: absolute;
             bottom: 7rem;
-            left: 0.7rem;
+            left: 2rem;
+            @media (max-width: 499px) {
+              bottom: 0rem;
+              left: 0.7rem;
+            }
           `}
         />
       )}


### PR DESCRIPTION
# Brief Title
Fix: Made Emoji Picker responsive for Mobile Screens

## Acceptance Criteria fulfillment

- [X] Adjusted the positioning of the EmojiPicker for mobile screens.
- [X]  Ensured the EmojiPicker appears closer to the bottom on mobile devices.
- [X]  Verified that the EmojiPicker maintains its proper position on larger screens.

Fixes #960


## Video/Screenshots

Mobile Devices:



https://github.com/user-attachments/assets/d946ac3f-ddc2-4d17-a2f8-0358081accf8


Larger Displays: 

![image](https://github.com/user-attachments/assets/abb3b18e-ad09-4d07-9449-f0ee034f7e88)


## PR Test Details

**Note**: The PR will be ready for live testing at https://rocketchat.github.io/EmbeddedChat/pulls/pr-961 after approval. Contributors are requested to replace `<pr_number>` with the actual PR number.
