### PR TITLE
chore: Upgrade actions/cache from v2 to v3 to address deprecation

### DIFF
--- a/.github/workflows/build-and-lint.yml
+++ b/.github/workflows/build-and-lint.yml
@@ -23,10 +23,10 @@ jobs:
         uses: actions/setup-node@v3
         with:
           node-version: 16.19.0
-          cache: 'yarn'
+          cache: "yarn"
 
       - name: Cache dependencies
-        uses: actions/cache@v2
+        uses: actions/cache@v3
         with:
           path: ~/.yarn
           key: ${{ runner.os }}-yarn-${{ hashFiles('**/yarn.lock') }}


### PR DESCRIPTION
# Brief Title
Upgrade actions/cache from v2 to v3 to address deprecation

- [ ] Upgrade actions/cache from v2 to v3.

Fixes #959 

## Video/Screenshots

## PR Test Details

**Note**: The PR will be ready for live testing at https://rocketchat.github.io/EmbeddedChat/pulls/pr-<pr_number> after approval. Contributors are requested to replace `<pr_number>` with the actual PR number.
