### PR TITLE
fix: bot name not appearing in message header

### DIFF
--- a/packages/react/src/views/Message/MessageHeader.js
+++ b/packages/react/src/views/Message/MessageHeader.js
@@ -116,7 +116,9 @@ const MessageHeader = ({
               : null
           }
         >
-          {message.u?.name}
+          {message.u?._id === 'rocket.cat'
+            ? message.u.username
+            : message.u.name}
         </Box>
       )}
       {showDisplayName && showUsername && (


### PR DESCRIPTION
# Brief Title
bot name not appearing in message header

## Acceptance Criteria fulfillment

- [ ] Ensure rocket.cat bot name is displayed when it sends messages

Fixes #963 

## Video/Screenshots


https://github.com/user-attachments/assets/159b426d-db19-4f95-81c2-41a77d3a8a56


## PR Test Details

**Note**: The PR will be ready for live testing at https://rocketchat.github.io/EmbeddedChat/pulls/pr-964 after approval. Contributors are requested to replace `<pr_number>` with the actual PR number.
