### PR TITLE
Fix: deletion of message get simultaneously deleted from the starred modal.

### DIFF
--- a/packages/react/src/views/Message/Message.js
+++ b/packages/react/src/views/Message/Message.js
@@ -194,6 +194,7 @@ const Message = ({
         message: 'Error in deleting message',
       });
     }
+    getStarredMessages();
   };
 
   const handleEmojiClick = async (e, msg, canReact) => {


### PR DESCRIPTION
# Brief Title

deletion of the starred message from the main chat interface gets deleted from the starred modal.



Fixes #965

## Video/Screenshots

https://github.com/user-attachments/assets/3bd4eb9d-a82a-4673-8f40-605d59e3cec1


## PR Test Details

**Note**: The PR will be ready for live testing at https://rocketchat.github.io/EmbeddedChat/pulls/pr-<pr_number> after approval. Contributors are requested to replace `<pr_number>` with the actual PR number.
