### PR TITLE
fix: UI Jumps When Hovering Over Last Message's MessageToolbox Options

### DIFF
--- a/packages/react/src/views/SurfaceMenu/SurfaceItem.js
+++ b/packages/react/src/views/SurfaceMenu/SurfaceItem.js
@@ -2,7 +2,7 @@ import React from 'react';
 import { Tooltip, ActionButton } from '@embeddedchat/ui-elements';
 
 const SurfaceItem = ({ item, size }) => (
-  <Tooltip text={item.label} position="bottom" key={item.id}>
+  <Tooltip text={item.label} position="top" key={item.id}>
     <ActionButton
       square
       ghost


### PR DESCRIPTION
Fixes #970 By moving `MessageToolbox`'s button's tooltips to top instead of bottom. This is consistent with the Main Rocket Chat's tooltips.

## Video/Screenshots
New:
![Screenshot from 2025-02-09 16-16-11](https://github.com/user-attachments/assets/00b0a0bd-7371-433e-9d8a-b44ae19deeb8)
Tooltips in main Rocket Chat are also at the top:
![image](https://github.com/user-attachments/assets/8b5a1169-dc1b-4f4d-bf95-15ffd5790db8)


## PR Test Details

**Note**: The PR will be ready for live testing at https://rocketchat.github.io/EmbeddedChat/pulls/pr-971 after approval.
