### PR TITLE
feat: Maintain Scroll Position When Closing a Thread

### DIFF
--- a/packages/react/src/views/ChatBody/ChatBody.js
+++ b/packages/react/src/views/ChatBody/ChatBody.js
@@ -268,10 +268,14 @@ const ChatBody = ({
   };
 
   useEffect(() => {
-    if (messageListRef.current) {
-      messageListRef.current.scrollTop = messageListRef.current.scrollHeight;
+    const lastMessage = messages[0];
+    if (
+      lastMessage &&
+      lastMessage.t !== "message_pinned"
+    ) {
+      scrollToBottom();
     }
-  }, [messages]);
+  }, [messages.length]);
 
   useEffect(() => {
     checkOverflow();

--- a/packages/react/src/views/ChatBody/ChatBody.js
+++ b/packages/react/src/views/ChatBody/ChatBody.js
@@ -269,10 +269,7 @@ const ChatBody = ({
 
   useEffect(() => {
     const lastMessage = messages[0];
-    if (
-      lastMessage &&
-      lastMessage.t !== "message_pinned"
-    ) {
+    if (lastMessage && lastMessage.t !== 'message_pinned') {
       scrollToBottom();
     }
   }, [messages.length]);

--- a/packages/react/src/views/ChatHeader/ChatHeader.js
+++ b/packages/react/src/views/ChatHeader/ChatHeader.js
@@ -105,6 +105,20 @@ const ChatHeader = ({
 
   const closeThread = useMessageStore((state) => state.closeThread);
 
+  const handleCloseThread = useCallback(() => {
+    const threadMessageId = threadMainMessage?._id;
+    closeThread();
+    setTimeout(() => {
+      const element = document.getElementById(`ec-message-body-${threadMessageId}`);
+      if (element) {
+        element.scrollIntoView({
+          behavior: 'instant',
+          block: 'start',
+        });
+      }
+    }, 300);
+  }, [closeThread, threadMainMessage]);
+
   const setShowMembers = useMemberStore((state) => state.setShowMembers);
   const setShowSearch = useSearchMessageStore((state) => state.setShowSearch);
   const setShowPinned = usePinnedMessageStore((state) => state.setShowPinned);
@@ -430,7 +444,7 @@ const ChatHeader = ({
       {isThreadOpen && (
         <DynamicHeader
           title={threadMainMessage}
-          handleClose={closeThread}
+          handleClose={handleCloseThread}
           iconName="arrow-back"
         />
       )}

--- a/packages/react/src/views/ChatHeader/ChatHeader.js
+++ b/packages/react/src/views/ChatHeader/ChatHeader.js
@@ -109,7 +109,9 @@ const ChatHeader = ({
     const threadMessageId = threadMainMessage?._id;
     closeThread();
     setTimeout(() => {
-      const element = document.getElementById(`ec-message-body-${threadMessageId}`);
+      const element = document.getElementById(
+        `ec-message-body-${threadMessageId}`
+      );
       if (element) {
         element.scrollIntoView({
           behavior: 'instant',


### PR DESCRIPTION
# Brief Title

## Acceptance Criteria fulfillment

- [x] When a thread is closed, the scroll position should remain at the `ThreadMainMessage`.

Fixes #972 

## Video/Screenshots
[Screencast from 2025-02-10 01-22-36.webm](https://github.com/user-attachments/assets/13a59d56-eacb-4b1b-bca7-76093037346a)

## Details
`setJumpToMessage` also uses `document.getElementById`, `element.scrollIntoView` and a small `setTimeout` to delay closing the thread, to scroll to a message (in `MessageAggregator.js`). I have used the same procedure.


## PR Test Details
**Note**: The PR will be ready for live testing at https://rocketchat.github.io/EmbeddedChat/pulls/pr-973 after approval.
