### PR TITLE
feat: New Timestamp component on the MessageToolBar and Support for Displaying it

### DIFF
--- a/packages/markups/src/elements/InlineElements.js
+++ b/packages/markups/src/elements/InlineElements.js
@@ -10,6 +10,7 @@ import ChannelMention from '../mentions/ChannelMention';
 import ColorElement from './ColorElement';
 import LinkSpan from './LinkSpan';
 import UserMention from '../mentions/UserMention';
+import TimestampElement from './TimestampElement';
 
 const InlineElements = ({ contents }) =>
   contents.map((content, index) => {
@@ -53,6 +54,10 @@ const InlineElements = ({ contents }) =>
             }
           />
         );
+
+      case 'TIMESTAMP':
+        return <TimestampElement key={index} contents={content.value} />;
+
       default:
         return null;
     }

--- a/packages/markups/src/elements/TimestampElement.js
+++ b/packages/markups/src/elements/TimestampElement.js
@@ -1,0 +1,118 @@
+import React from 'react';
+import PropTypes from 'prop-types';
+import CodeElement from './CodeElement';
+
+function timeAgo(dateParam, locale) {
+  const int = new Intl.RelativeTimeFormat(locale, { style: 'long' });
+
+  const date = new Date(dateParam).getTime();
+  const today = new Date().getTime();
+  const seconds = Math.round((date - today) / 1000);
+  const minutes = Math.round(seconds / 60);
+  const hours = Math.round(minutes / 60);
+  const days = Math.round(hours / 24);
+  const weeks = Math.round(days / 7);
+  const months = new Date(date).getMonth() - new Date().getMonth();
+  const years = new Date(date).getFullYear() - new Date().getFullYear();
+
+  if (Math.abs(seconds) < 60) {
+    return int.format(seconds, 'seconds');
+  }
+  if (Math.abs(minutes) < 60) {
+    return int.format(minutes, 'minutes');
+  }
+  if (Math.abs(hours) < 24) {
+    return int.format(hours, 'hours');
+  }
+  if (Math.abs(days) < 7) {
+    return int.format(days, 'days');
+  }
+  if (Math.abs(weeks) < 4) {
+    return int.format(weeks, 'weeks');
+  }
+  if (Math.abs(months) < 12) {
+    return int.format(months, 'months');
+  }
+  return int.format(years, 'years');
+}
+
+const formatTimestamp = (timestamp, format) => {
+  const date = new Date(timestamp * 1000);
+
+  const getOrdinalDate = (day) => {
+    const suffix = ['th', 'st', 'nd', 'rd'];
+    const val = day % 100;
+    return day + (suffix[(val - 20) % 10] || suffix[val] || suffix[0]);
+  };
+
+  const timeZoneOffset = date.getTimezoneOffset();
+  const sign = timeZoneOffset > 0 ? '-' : '+';
+  const hours = Math.floor(Math.abs(timeZoneOffset) / 60);
+  const minutes = Math.abs(timeZoneOffset) % 60;
+  const timeZone = `GMT${sign}${String(hours).padStart(2, '0')}:${String(
+    minutes
+  ).padStart(2, '0')}`;
+
+  const month = date.toLocaleString('en-US', { month: 'long' });
+  const day = getOrdinalDate(date.getDate());
+  const year = date.getFullYear();
+  const time = date.toLocaleString([], {
+    hour: '2-digit',
+    minute: '2-digit',
+    second: '2-digit',
+  });
+
+  const shortDate = date.toLocaleDateString('en-US');
+  const shortTime = date.toLocaleTimeString([], {
+    hour: '2-digit',
+    minute: '2-digit',
+  });
+
+  switch (format) {
+    case 't': {
+      return shortTime;
+    }
+    case 'T': {
+      return time;
+    }
+    case 'd': {
+      return shortDate;
+    }
+    case 'D': {
+      return `${shortDate}, ${shortTime}`;
+    }
+    case 'f': {
+      return `${month} ${day}, ${year} at ${time} ${timeZone}`;
+    }
+    case 'F': {
+      const weekday = date.toLocaleString('en-US', { weekday: 'long' });
+      return `${weekday}, ${month} ${day} ${year} at ${time} ${timeZone}`;
+    }
+    case 'R': {
+      return timeAgo(timestamp * 1000, 'en');
+    }
+    default: {
+      return date.toLocaleString();
+    }
+  }
+};
+
+const TimestampElement = ({ contents }) => {
+  if (typeof contents === 'object' && contents.timestamp && contents.format) {
+    const { timestamp, format } = contents;
+
+    const formattedTimestamp = formatTimestamp(parseInt(timestamp, 10), format);
+    return <CodeElement contents={{ value: formattedTimestamp }} />;
+  }
+
+  return null;
+};
+
+export default TimestampElement;
+
+TimestampElement.propTypes = {
+  contents: PropTypes.shape({
+    timestamp: PropTypes.string.isRequired,
+    format: PropTypes.string.isRequired,
+  }).isRequired,
+};

--- a/packages/react/src/views/ChatInput/ChatInput.styles.js
+++ b/packages/react/src/views/ChatInput/ChatInput.styles.js
@@ -172,3 +172,137 @@ export const getInsertLinkModalStyles = (theme) => {
 
   return styles;
 };
+
+export const getTimestampStyles = (theme, mode) => {
+  const styles = {
+    timestampModal: css`
+      position: fixed;
+      inset: 0;
+      display: flex;
+      align-items: center;
+      justify-content: center;
+      z-index: 1300;
+
+      // Not hardcoding the color; this value will be the same for all themes.
+      background-color: rgba(0, 0, 0, 0.2);
+    `,
+    timestampModalContent: css`
+      background-color: ${theme.colors.card};
+      color: ${theme.colors.cardForeground};
+      border-radius: 10px;
+      padding: 20px;
+      max-width: 400px;
+      width: 100%;
+      max-height: 80vh;
+      overflow-y: auto;
+      box-shadow: 0px 4px 8px rgba(0, 0, 0, 0.1);
+    `,
+    modalHeader: css`
+      display: flex;
+      justify-content: space-between;
+      align-items: center;
+      margin-bottom: 10px;
+      border-bottom: 1px solid ${theme.colors.border};
+      padding-bottom: 10px;
+    `,
+    timestampPreview: css`
+      margin-bottom: 20px;
+      padding: 10px;
+      background-color: ${mode === 'light'
+        ? theme.commonColors.white
+        : theme.commonColors.black};
+      border: 1px solid ${theme.colors.border};
+      border-radius: 5px;
+    `,
+    previewText: css`
+      font-weight: bold;
+    `,
+    previewCode: css`
+      font-family: monospace;
+      color: ${theme.colors.info};
+      word-wrap: break-word;
+    `,
+    timestampInputs: css`
+      display: flex;
+      justify-content: space-between;
+      margin-bottom: 20px;
+    `,
+    dateInput: css`
+      width: 48%;
+    `,
+    timeInput: css`
+      width: 48%;
+    `,
+    inputLabel: css`
+      display: block;
+      margin-bottom: 5px;
+      font-size: 14px;
+      font-weight: bold;
+      color: ${theme.colors.foreground};
+    `,
+    inputField: css`
+      width: 100%;
+      padding: 8px;
+      border-radius: 5px;
+      border: 1px solid ${theme.colors.input};
+      font-size: 14px;
+      background-color: ${lighten(theme.colors.background, 1)};
+      color: ${theme.colors.foreground};
+    `,
+    formatSelection: css`
+      margin-bottom: 20px;
+    `,
+    formatOptions: css`
+      max-height: 200px;
+      overflow-y: auto;
+      display: flex;
+      flex-wrap: wrap;
+      gap: 10px;
+    `,
+    formatOption: css`
+      width: calc(50% - 5px);
+      display: flex;
+      align-items: flex-start;
+      padding: 10px;
+      border: 1px solid ${theme.colors.border};
+      border-radius: 5px;
+      margin-bottom: 10px;
+      cursor: pointer;
+
+      &:nth-last-child(-n + 3) {
+        width: 100%;
+      }
+    `,
+    formatOptionSelected: css`
+      background-color: ${theme.colors.accent};
+      border-color: ${theme.colors.primary};
+    `,
+    formatRadio: css`
+      margin-right: 10px;
+    `,
+    formatDetails: css`
+      flex: 1;
+      cursor: pointer;
+    `,
+    formatLabel: css`
+      font-size: 17px;
+      font-weight: bold;
+      color: ${theme.colors.foreground};
+    `,
+    formatDescription: css`
+      font-size: 14px;
+      color: ${theme.colors.mutedForeground};
+    `,
+    formatExample: css`
+      font-size: 12px;
+      color: ${theme.colors.accentForeground};
+    `,
+    modalFooter: css`
+      display: flex;
+      justify-content: space-between;
+      margin-top: 20px;
+    `,
+  };
+
+  return styles;
+};

--- a/packages/react/src/views/ChatInput/ChatInputFormattingToolbar.js
+++ b/packages/react/src/views/ChatInput/ChatInputFormattingToolbar.js
@@ -23,9 +23,17 @@ const ChatInputFormattingToolbar = ({
   inputRef,
   triggerButton,
   optionConfig = {
-    surfaceItems: ['emoji', 'formatter', 'link', 'audio', 'video', 'file'],
+    surfaceItems: [
+      'emoji',
+      'formatter',
+      'link',
+      'audio',
+      'video',
+      'file',
+      'timestamp',
+    ],
     formatters: ['bold', 'italic', 'strike', 'code', 'multiline'],
-    smallScreenSurfaceItems: ['emoji', 'video', 'audio', 'file'],
+    smallScreenSurfaceItems: ['emoji', 'video', 'audio', 'file', 'timestamp'],
     popOverItems: ['formatter', 'link'],
   },
 }) => {
@@ -47,6 +55,7 @@ const ChatInputFormattingToolbar = ({
     (state) => state.isRecordingMessage
   );
 
+  const [isTimestampSelectorOpen, setIsTimestampSelectorOpen] = useState(false);
   const [isEmojiOpen, setEmojiOpen] = useState(false);
   const [isInsertLinkOpen, setInsertLinkOpen] = useState(false);
   const [isPopoverOpen, setPopoverOpen] = useState(false);
@@ -141,6 +150,7 @@ const ChatInputFormattingToolbar = ({
         popOverItemStyles={styles.popOverItemStyles}
       />
     ),
+
     video: (
       <VideoMessageRecorder
         displayName={
@@ -150,6 +160,7 @@ const ChatInputFormattingToolbar = ({
         disabled={isRecordingMessage}
       />
     ),
+
     file:
       isPopoverOpen && popOverItems.includes('file') ? (
         <Box
@@ -179,6 +190,7 @@ const ChatInputFormattingToolbar = ({
           </ActionButton>
         </Tooltip>
       ),
+
     link:
       isPopoverOpen && popOverItems.includes('link') ? (
         <Box
@@ -208,6 +220,23 @@ const ChatInputFormattingToolbar = ({
           </ActionButton>
         </Tooltip>
       ),
+
+    timestamp: (
+      <Tooltip text="Insert timestamp" position="top" key="timestamp">
+        <ActionButton
+          square
+          ghost
+          disabled={isRecordingMessage}
+          onClick={() => {
+            if (isRecordingMessage) return;
+            setIsTimestampSelectorOpen(!isTimestampSelectorOpen);
+          }}
+        >
+          <Icon name="clock" size="1.25rem" />
+        </ActionButton>
+      </Tooltip>
+    ),
+
     formatter: formatters
       .map((name) => formatter.find((item) => item.name === name))
       .map((item) =>
@@ -375,7 +404,13 @@ const ChatInputFormattingToolbar = ({
         />
       )}
 
-      <TimestampSelector onSelect={handleTimestampSelect} />
+      {isTimestampSelectorOpen && (
+        <TimestampSelector
+          onSelect={handleTimestampSelect}
+          isTimestampSelectorOpen={isTimestampSelectorOpen}
+          onClose={() => setIsTimestampSelectorOpen(false)}
+        />
+      )}
     </Box>
   );
 };

--- a/packages/react/src/views/ChatInput/ChatInputFormattingToolbar.js
+++ b/packages/react/src/views/ChatInput/ChatInputFormattingToolbar.js
@@ -16,6 +16,7 @@ import VideoMessageRecorder from './VideoMessageRecoder';
 import { getChatInputFormattingToolbarStyles } from './ChatInput.styles';
 import formatSelection from '../../lib/formatSelection';
 import InsertLinkToolBox from './InsertLinkToolBox';
+import { TimestampSelector } from './TimestampSelector';
 
 const ChatInputFormattingToolbar = ({
   messageRef,
@@ -81,6 +82,23 @@ const ChatInputFormattingToolbar = ({
 
     triggerButton?.(null, message);
     setInsertLinkOpen(false);
+  };
+
+  const handleTimestampSelect = (timestamp) => {
+    const messageInput = messageRef.current;
+
+    const start = messageInput.selectionStart;
+    const end = messageInput.selectionEnd;
+    const msg = messageInput.value;
+
+    const updatedMessage = msg.slice(0, start) + timestamp + msg.slice(end);
+    messageInput.value = updatedMessage;
+
+    const newCursorPosition = start + timestamp.length;
+    messageInput.selectionStart = newCursorPosition;
+    messageInput.selectionEnd = newCursorPosition;
+
+    triggerButton?.(null, updatedMessage);
   };
 
   const chatToolMap = {
@@ -356,6 +374,8 @@ const ChatInputFormattingToolbar = ({
           onClose={() => setInsertLinkOpen(false)}
         />
       )}
+
+      <TimestampSelector onSelect={handleTimestampSelect} />
     </Box>
   );
 };

--- a/packages/react/src/views/ChatInput/TimestampSelector.js
+++ b/packages/react/src/views/ChatInput/TimestampSelector.js
@@ -55,12 +55,12 @@ const formatOptions = [
   },
 ];
 
-export function TimestampSelector({ onSelect }) {
+export function TimestampSelector({ onSelect, isTimestampSelectorOpen }) {
   const { theme } = useTheme();
   const { mode } = useTheme();
   const styles = getTimestampStyles(theme, mode);
 
-  const [isOpen, setIsOpen] = useState(false);
+  const [isOpen, setIsOpen] = useState(isTimestampSelectorOpen);
   const [selectedDate, setSelectedDate] = useState(new Date());
   const [selectedFormat, setSelectedFormat] = useState('f');
   const [previewTimestamp, setPreviewTimestamp] = useState('');
@@ -90,103 +90,95 @@ export function TimestampSelector({ onSelect }) {
   };
 
   return (
-    <Box>
-      <Tooltip text="Insert timestamp" position="top">
-        <ActionButton square ghost onClick={() => setIsOpen(!isOpen)}>
-          <Icon name="clock" />
-        </ActionButton>
-      </Tooltip>
+    isOpen && (
+      <Box css={styles.timestampModal}>
+        <Box css={styles.timestampModalContent}>
+          <Box css={styles.modalHeader}>
+            <h3>Insert Timestamp</h3>
+            <ActionButton square ghost onClick={() => setIsOpen(false)}>
+              <Icon name="cross" />
+            </ActionButton>
+          </Box>
 
-      {isOpen && (
-        <Box css={styles.timestampModal}>
-          <Box css={styles.timestampModalContent}>
-            <Box css={styles.modalHeader}>
-              <h3>Insert Timestamp</h3>
-              <ActionButton square ghost onClick={() => setIsOpen(false)}>
-                <Icon name="cross" />
-              </ActionButton>
+          <Box css={styles.timestampPreview}>
+            <Box css={styles.previewText}>Preview:</Box>
+            <code css={styles.previewCode}>{previewTimestamp}</code>
+          </Box>
+
+          <Box css={styles.timestampInputs}>
+            <Box css={styles.dateInput}>
+              <Box css={styles.inputLabel}>Date</Box>
+              <Input
+                type="date"
+                value={selectedDate.toISOString().split('T')[0]}
+                onChange={handleDateChange}
+                css={styles.inputField}
+              />
             </Box>
 
-            <Box css={styles.timestampPreview}>
-              <Box css={styles.previewText}>Preview:</Box>
-              <code css={styles.previewCode}>{previewTimestamp}</code>
+            <Box css={styles.timeInput}>
+              <Box css={styles.inputLabel}>Time</Box>
+              <Input
+                type="time"
+                value={selectedDate.toTimeString().slice(0, 5)}
+                onChange={handleTimeChange}
+                css={styles.inputField}
+              />
             </Box>
+          </Box>
 
-            <Box css={styles.timestampInputs}>
-              <Box css={styles.dateInput}>
-                <Box css={styles.inputLabel}>Date</Box>
-                <Input
-                  type="date"
-                  value={selectedDate.toISOString().split('T')[0]}
-                  onChange={handleDateChange}
-                  css={styles.inputField}
-                />
-              </Box>
-
-              <Box css={styles.timeInput}>
-                <Box css={styles.inputLabel}>Time</Box>
-                <Input
-                  type="time"
-                  value={selectedDate.toTimeString().slice(0, 5)}
-                  onChange={handleTimeChange}
-                  css={styles.inputField}
-                />
-              </Box>
-            </Box>
-
-            <Box css={styles.formatSelection}>
-              <Box css={styles.inputLabel}>Format</Box>
-              <Box css={styles.formatOptions}>
-                {formatOptions.map((format) => (
-                  <Box
-                    key={format.value}
+          <Box css={styles.formatSelection}>
+            <Box css={styles.inputLabel}>Format</Box>
+            <Box css={styles.formatOptions}>
+              {formatOptions.map((format) => (
+                <Box
+                  key={format.value}
+                  css={[
+                    styles.formatOption,
+                    selectedFormat === format.value &&
+                      styles.formatOptionSelected,
+                  ]}
+                >
+                  <input
+                    type="radio"
+                    id={`format-${format.value}`}
+                    name="format"
+                    value={format.value}
+                    checked={selectedFormat === format.value}
+                    onChange={() => setSelectedFormat(format.value)}
+                    css={styles.formatRadio}
+                  />
+                  <label
+                    htmlFor={`format-${format.value}`}
                     css={[
-                      styles.formatOption,
+                      styles.formatLabel,
                       selectedFormat === format.value &&
                         styles.formatOptionSelected,
                     ]}
                   >
-                    <input
-                      type="radio"
-                      id={`format-${format.value}`}
-                      name="format"
-                      value={format.value}
-                      checked={selectedFormat === format.value}
-                      onChange={() => setSelectedFormat(format.value)}
-                      css={styles.formatRadio}
-                    />
-                    <label
-                      htmlFor={`format-${format.value}`}
-                      css={[
-                        styles.formatLabel,
-                        selectedFormat === format.value &&
-                          styles.formatOptionSelected,
-                      ]}
-                    >
-                      <Box css={styles.formatDetails}>
-                        <Box css={styles.formatLabel}>{format.label}</Box>
-                        <Box css={styles.formatDescription}>
-                          {format.description}
-                        </Box>
-                        <Box css={styles.formatExample}>
-                          e.g. {format.example}
-                        </Box>
+                    <Box css={styles.formatDetails}>
+                      <Box css={styles.formatLabel}>{format.label}</Box>
+                      <Box css={styles.formatDescription}>
+                        {format.description}
                       </Box>
-                    </label>
-                  </Box>
-                ))}
-              </Box>
-            </Box>
-
-            <Box css={styles.modalFooter}>
-              <Button type="secondary" onClick={() => setIsOpen(false)}>
-                Cancel
-              </Button>
-              <Button onClick={handleInsert}>Insert</Button>
+                      <Box css={styles.formatExample}>
+                        e.g. {format.example}
+                      </Box>
+                    </Box>
+                  </label>
+                </Box>
+              ))}
             </Box>
           </Box>
+
+          <Box css={styles.modalFooter}>
+            <Button type="secondary" onClick={() => setIsOpen(false)}>
+              Cancel
+            </Button>
+            <Button onClick={handleInsert}>Insert</Button>
+          </Box>
         </Box>
-      )}
-    </Box>
+      </Box>
+    )
   );
 }

--- a/packages/react/src/views/ChatInput/TimestampSelector.js
+++ b/packages/react/src/views/ChatInput/TimestampSelector.js
@@ -1,0 +1,192 @@
+import React, { useState, useEffect } from 'react';
+import {
+  ActionButton,
+  Box,
+  Button,
+  Input,
+  Icon,
+  Tooltip,
+  useTheme,
+} from '@embeddedchat/ui-elements';
+import { getTimestampStyles } from './ChatInput.styles';
+
+const formatOptions = [
+  {
+    value: 'R',
+    label: 'Relative',
+    description: 'Shows relative time',
+    example: '2 hours ago',
+  },
+  {
+    value: 't',
+    label: 'Short Time',
+    description: 'Shows only time',
+    example: '12:00 AM',
+  },
+  {
+    value: 'T',
+    label: 'Long Time',
+    description: 'Shows detailed time',
+    example: '12:00:00 AM',
+  },
+  {
+    value: 'd',
+    label: 'Short Date',
+    description: 'Shows date briefly',
+    example: '12/31/2020',
+  },
+  {
+    value: 'D',
+    label: 'Long Date',
+    description: 'Shows full date',
+    example: 'Thursday, December 31, 2020',
+  },
+  {
+    value: 'f',
+    label: 'Full DateTime',
+    description: 'Shows date and time',
+    example: 'December 31, 2020 12:00 AM',
+  },
+  {
+    value: 'F',
+    label: 'Long DateTime',
+    description: 'Shows detailed date and time',
+    example: 'Thursday, December 31, 2020 12:00:00 AM',
+  },
+];
+
+export function TimestampSelector({ onSelect }) {
+  const { theme } = useTheme();
+  const { mode } = useTheme();
+  const styles = getTimestampStyles(theme, mode);
+
+  const [isOpen, setIsOpen] = useState(false);
+  const [selectedDate, setSelectedDate] = useState(new Date());
+  const [selectedFormat, setSelectedFormat] = useState('f');
+  const [previewTimestamp, setPreviewTimestamp] = useState('');
+
+  useEffect(() => {
+    if (isOpen) {
+      const timestamp = Math.floor(selectedDate.getTime() / 1000);
+      const formatted = `<t:${timestamp}:${selectedFormat}>`;
+      setPreviewTimestamp(formatted);
+    }
+  }, [selectedDate, selectedFormat, isOpen]);
+
+  const handleDateChange = (e) => {
+    setSelectedDate(new Date(e.target.value));
+  };
+
+  const handleTimeChange = (e) => {
+    const [hours, minutes] = e.target.value.split(':');
+    const newDate = new Date(selectedDate);
+    newDate.setHours(parseInt(hours, 10), parseInt(minutes, 10));
+    setSelectedDate(newDate);
+  };
+
+  const handleInsert = () => {
+    onSelect(previewTimestamp);
+    setIsOpen(false);
+  };
+
+  return (
+    <Box>
+      <Tooltip text="Insert timestamp" position="top">
+        <ActionButton square ghost onClick={() => setIsOpen(!isOpen)}>
+          <Icon name="clock" />
+        </ActionButton>
+      </Tooltip>
+
+      {isOpen && (
+        <Box css={styles.timestampModal}>
+          <Box css={styles.timestampModalContent}>
+            <Box css={styles.modalHeader}>
+              <h3>Insert Timestamp</h3>
+              <ActionButton square ghost onClick={() => setIsOpen(false)}>
+                <Icon name="cross" />
+              </ActionButton>
+            </Box>
+
+            <Box css={styles.timestampPreview}>
+              <Box css={styles.previewText}>Preview:</Box>
+              <code css={styles.previewCode}>{previewTimestamp}</code>
+            </Box>
+
+            <Box css={styles.timestampInputs}>
+              <Box css={styles.dateInput}>
+                <Box css={styles.inputLabel}>Date</Box>
+                <Input
+                  type="date"
+                  value={selectedDate.toISOString().split('T')[0]}
+                  onChange={handleDateChange}
+                  css={styles.inputField}
+                />
+              </Box>
+
+              <Box css={styles.timeInput}>
+                <Box css={styles.inputLabel}>Time</Box>
+                <Input
+                  type="time"
+                  value={selectedDate.toTimeString().slice(0, 5)}
+                  onChange={handleTimeChange}
+                  css={styles.inputField}
+                />
+              </Box>
+            </Box>
+
+            <Box css={styles.formatSelection}>
+              <Box css={styles.inputLabel}>Format</Box>
+              <Box css={styles.formatOptions}>
+                {formatOptions.map((format) => (
+                  <Box
+                    key={format.value}
+                    css={[
+                      styles.formatOption,
+                      selectedFormat === format.value &&
+                        styles.formatOptionSelected,
+                    ]}
+                  >
+                    <input
+                      type="radio"
+                      id={`format-${format.value}`}
+                      name="format"
+                      value={format.value}
+                      checked={selectedFormat === format.value}
+                      onChange={() => setSelectedFormat(format.value)}
+                      css={styles.formatRadio}
+                    />
+                    <label
+                      htmlFor={`format-${format.value}`}
+                      css={[
+                        styles.formatLabel,
+                        selectedFormat === format.value &&
+                          styles.formatOptionSelected,
+                      ]}
+                    >
+                      <Box css={styles.formatDetails}>
+                        <Box css={styles.formatLabel}>{format.label}</Box>
+                        <Box css={styles.formatDescription}>
+                          {format.description}
+                        </Box>
+                        <Box css={styles.formatExample}>
+                          e.g. {format.example}
+                        </Box>
+                      </Box>
+                    </label>
+                  </Box>
+                ))}
+              </Box>
+            </Box>
+
+            <Box css={styles.modalFooter}>
+              <Button type="secondary" onClick={() => setIsOpen(false)}>
+                Cancel
+              </Button>
+              <Button onClick={handleInsert}>Insert</Button>
+            </Box>
+          </Box>
+        </Box>
+      )}
+    </Box>
+  );
+}


### PR DESCRIPTION
# Brief Title
Add New Timestamp component on the MessageToolBar and Support for Displaying it

## Acceptance Criteria fulfillment

- [X] Create a new chat input component that will create these timestamps in the required format
- [X] Added support for rendering timestamps in various formats like relative time ("5 minutes ago") or full date and time.
- [X] Implemented flexible timestamp formatting options (e.g., short time, full date, long-form date with time).
- [X] Ensured the TimestampElement correctly handles and displays timestamps based on the provided format.

Fixes #987

## Video:


https://github.com/user-attachments/assets/9eb82359-7b1d-4e7b-abbf-117515f9ec14




## PR Test Details

**Note**: The PR will be ready for live testing at https://rocketchat.github.io/EmbeddedChat/pulls/pr-988 after approval. Contributors are requested to replace `<pr_number>` with the actual PR number.
