### PR TITLE
Fix: Alt + Arrow Key Shortcuts Not Functioning in Message Navigation

### DIFF
--- a/packages/react/src/views/ChatInput/ChatInput.js
+++ b/packages/react/src/views/ChatInput/ChatInput.js
@@ -454,15 +454,14 @@ const ChatInput = ({ scrollToBottom }) => {
         if (messageRef && messageRef.current) {
           const { value, selectionStart } = messageRef.current;
           let newPosition = selectionStart;
-          
-          // Find the start of the previous word
+
           while (newPosition > 0 && /\s/.test(value[newPosition - 1])) {
             newPosition--;
           }
           while (newPosition > 0 && !/\s/.test(value[newPosition - 1])) {
             newPosition--;
           }
-          
+
           messageRef.current.setSelectionRange(newPosition, newPosition);
           messageRef.current.focus();
         }
@@ -473,15 +472,14 @@ const ChatInput = ({ scrollToBottom }) => {
         if (messageRef && messageRef.current) {
           const { value, selectionEnd } = messageRef.current;
           let newPosition = selectionEnd;
-          
-          // Find the end of the next word
+
           while (newPosition < value.length && /\s/.test(value[newPosition])) {
             newPosition++;
           }
           while (newPosition < value.length && !/\s/.test(value[newPosition])) {
             newPosition++;
           }
-          
+
           messageRef.current.setSelectionRange(newPosition, newPosition);
           messageRef.current.focus();
         }

--- a/packages/react/src/views/ChatInput/ChatInput.js
+++ b/packages/react/src/views/ChatInput/ChatInput.js
@@ -449,21 +449,59 @@ const ChatInput = ({ scrollToBottom }) => {
           sendMessage();
         }
         break;
-      case e.altKey && (e.code === 'ArrowUp' || 'ArrowRight'): {
+      case (e.ctrlKey || e.altKey) && e.code === 'ArrowLeft': {
         e.preventDefault();
-        e.stopPropagation();
         if (messageRef && messageRef.current) {
+          const { value, selectionStart } = messageRef.current;
+          let newPosition = selectionStart;
+          
+          // Find the start of the previous word
+          while (newPosition > 0 && /\s/.test(value[newPosition - 1])) {
+            newPosition--;
+          }
+          while (newPosition > 0 && !/\s/.test(value[newPosition - 1])) {
+            newPosition--;
+          }
+          
+          messageRef.current.setSelectionRange(newPosition, newPosition);
+          messageRef.current.focus();
+        }
+        break;
+      }
+      case (e.ctrlKey || e.altKey) && e.code === 'ArrowRight': {
+        e.preventDefault();
+        if (messageRef && messageRef.current) {
+          const { value, selectionEnd } = messageRef.current;
+          let newPosition = selectionEnd;
+          
+          // Find the end of the next word
+          while (newPosition < value.length && /\s/.test(value[newPosition])) {
+            newPosition++;
+          }
+          while (newPosition < value.length && !/\s/.test(value[newPosition])) {
+            newPosition++;
+          }
+          
+          messageRef.current.setSelectionRange(newPosition, newPosition);
+          messageRef.current.focus();
+        }
+        break;
+      }
+      case (e.ctrlKey || e.altKey) && e.code === 'ArrowUp': {
+        e.preventDefault();
+        if (messageRef && messageRef.current) {
+          // Move cursor to the start of the text
           messageRef.current.setSelectionRange(0, 0);
           messageRef.current.focus();
         }
         break;
       }
-      case e.altKey && (e.code === 'ArrowDown' || 'ArrowLeft'): {
+      case (e.ctrlKey || e.altKey) && e.code === 'ArrowDown': {
         e.preventDefault();
-        e.stopPropagation();
         if (messageRef && messageRef.current) {
-          const endlength = messageRef.current.value.length;
-          messageRef.current.setSelectionRange(endlength, endlength);
+          // Move cursor to the end of the text
+          const length = messageRef.current.value.length;
+          messageRef.current.setSelectionRange(length, length);
           messageRef.current.focus();
         }
         break;

--- a/packages/react/src/views/ChatInput/ChatInput.js
+++ b/packages/react/src/views/ChatInput/ChatInput.js
@@ -456,10 +456,10 @@ const ChatInput = ({ scrollToBottom }) => {
           let newPosition = selectionStart;
 
           while (newPosition > 0 && /\s/.test(value[newPosition - 1])) {
-            newPosition--;
+            newPosition -= 1;
           }
           while (newPosition > 0 && !/\s/.test(value[newPosition - 1])) {
-            newPosition--;
+            newPosition -= 1;
           }
 
           messageRef.current.setSelectionRange(newPosition, newPosition);
@@ -474,10 +474,10 @@ const ChatInput = ({ scrollToBottom }) => {
           let newPosition = selectionEnd;
 
           while (newPosition < value.length && /\s/.test(value[newPosition])) {
-            newPosition++;
+            newPosition += 1;
           }
           while (newPosition < value.length && !/\s/.test(value[newPosition])) {
-            newPosition++;
+            newPosition += 1;
           }
 
           messageRef.current.setSelectionRange(newPosition, newPosition);
@@ -488,7 +488,6 @@ const ChatInput = ({ scrollToBottom }) => {
       case (e.ctrlKey || e.altKey) && e.code === 'ArrowUp': {
         e.preventDefault();
         if (messageRef && messageRef.current) {
-          // Move cursor to the start of the text
           messageRef.current.setSelectionRange(0, 0);
           messageRef.current.focus();
         }
@@ -497,8 +496,9 @@ const ChatInput = ({ scrollToBottom }) => {
       case (e.ctrlKey || e.altKey) && e.code === 'ArrowDown': {
         e.preventDefault();
         if (messageRef && messageRef.current) {
-          // Move cursor to the end of the text
-          const length = messageRef.current.value.length;
+          const { current } = messageRef;
+          const { value } = current;
+          const { length } = value;
           messageRef.current.setSelectionRange(length, length);
           messageRef.current.focus();
         }


### PR DESCRIPTION
# This PR addresses the issue where Alt + Left Arrow, Alt + Right Arrow, Alt + Up Arrow, and Alt + Down Arrow shortcuts were not functioning as expected for message navigation.

## Acceptance Criteria fulfillment

- [x] Ensured that the event listeners correctly capture Alt + Arrow Key inputs.
- [x] Tested across different browsers to confirm the fix.


Fixes  #989

## Video/Screenshots
[Screencast from 2025-02-15 19-43-29.webm](https://github.com/user-attachments/assets/5f08aabe-db28-4363-9e91-10ff293f9b78)



## PR Test Details

**Note**: The PR will be ready for live testing at https://rocketchat.github.io/EmbeddedChat/pulls/pr-<pr_number> after approval. Contributors are requested to replace `<pr_number>` with the actual PR number.
