### PR TITLE
fix: multiple max-height causing multiple instances of scrollbars on attachment modal

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -16,3 +16,5 @@ node_modules
 .vscode
 
 .gitpod.yml
+
+/**/storybook-static/

--- a/packages/react/src/views/AttachmentPreview/AttachmentPreview.styles.js
+++ b/packages/react/src/views/AttachmentPreview/AttachmentPreview.styles.js
@@ -17,7 +17,7 @@ const getAttachmentPreviewStyles = () => {
     modalContent: css`
       overflow-y: auto;
       overflow-x: hidden;
-      max-height: 350px;
+      
     `,
 
     fileDescription: css`

--- a/packages/react/src/views/AttachmentPreview/AttachmentPreview.styles.js
+++ b/packages/react/src/views/AttachmentPreview/AttachmentPreview.styles.js
@@ -17,7 +17,6 @@ const getAttachmentPreviewStyles = () => {
     modalContent: css`
       overflow-y: auto;
       overflow-x: hidden;
-      
     `,
 
     fileDescription: css`


### PR DESCRIPTION
# Brief Title

Multiple `max-height` causing multiple instances of scrollbars on attachment modal.

## Video/Screenshots

Before

![image](https://github.com/user-attachments/assets/56bb8299-ec34-47e8-ab00-655321c752b0)

After

![image](https://github.com/user-attachments/assets/9eb0d683-f7b3-4e6b-ba22-bf22247a4900)


## PR Test Details

**Note**: The PR will be ready for live testing at https://rocketchat.github.io/EmbeddedChat/pulls/pr-994 after approval. Contributors are requested to replace `<pr_number>` with the actual PR number.
