### PR TITLE
Fix: Allow Deletion of Messages Sent by Apps in Embedded Chat

### DIFF
--- a/packages/react/src/views/Message/MessageToolbox.js
+++ b/packages/react/src/views/Message/MessageToolbox.js
@@ -159,7 +159,7 @@ export const MessageToolbox = ({
         id: 'delete',
         onClick: () => setShowDeleteModal(true),
         iconName: 'trash',
-        visible: message.u._id === authenticatedUserId,
+        visible: true,
         type: 'destructive',
       },
       report: {


### PR DESCRIPTION
Currently, messages sent by apps in the embedded chat cannot be deleted, even by users with the necessary permissions (such as admins). The delete option is unavailable, leading to an inconsistent experience compared to regular messages.

## Acceptance Criteria fulfillment

- [ ] Getting the delete icon to be seen in the message toolbox.
- [ ] Correction in the after deletion logic.


Fixes #995 

*This PR still needs some commits to fulfill its goals.*

## Video/Screenshots
![Screenshot from 2025-02-23 12-20-29](https://github.com/user-attachments/assets/3a9e6c36-0026-470c-9392-950a47f127e1)


**Note**: The PR will be ready for live testing at https://rocketchat.github.io/EmbeddedChat/pulls/pr-<pr_number> after approval. Contributors are requested to replace `<pr_number>` with the actual PR number.
