### PR TITLE
fix: auto-detect OS/browser color theme on initial load

### DIFF
--- a/packages/docs/docusaurus.config.js
+++ b/packages/docs/docusaurus.config.js
@@ -123,6 +123,11 @@ const config = {
           },
         ],
       },
+    colorMode: {
+     defaultMode: 'light',
+     disableSwitch: false,
+     respectPrefersColorScheme: true, 
+    },
       prism: {
         theme: prismThemes.github,
         darkTheme: prismThemes.dracula,

--- a/packages/docs/src/css/custom.css
+++ b/packages/docs/src/css/custom.css
@@ -5,7 +5,7 @@
  */
 
 /* You can override the default Infima variables here. */
-:root {
+[data-theme='light']:root {
   --ifm-color-primary: #1f3e05;
   --ifm-color-primary-dark: #29784c;
   --ifm-color-primary-darker: #277148;


### PR DESCRIPTION
# Auto-detect and apply browser/OS theme preference on initial load

## Acceptance Criteria fulfillment

- [x] Detect user’s browser or OS dark/light theme preference automatically on first page load
- [x] Apply the detected theme without requiring manual toggle by user
- [x] Update theme correctly on reloads and respect user preference
- [x] Ensure theme toggle switch remains functional for manual overrides

Fixes #1004 

## Video/Screenshots

## PR Test Details

**Note**: The PR will be ready for live testing at https://rocketchat.github.io/EmbeddedChat/pulls/pr-<pr_number> after approval. Contributors are requested to replace `<pr_number>` with the actual PR number.
