### PR TITLE
docs: add Node.js >=18 requirement and nvm instructions for docs/ fol…

### DIFF
--- a/packages/docs/README.md
+++ b/packages/docs/README.md
@@ -1,17 +1,29 @@
 # EmbeddedChat Documentation
 
-This is the official documentation website of EmbeddedChat
+This is the official documentation website of EmbeddedChat.
+
+> **Node.js Version Requirement**
+>
+> The `docs/` folder requires **Node.js v18 or higher** to run correctly.
+> If you’re using a lower version (e.g., v16.19.0 from other parts of the monorepo), you may encounter errors.
+>
+> Use [NVM](https://github.com/nvm-sh/nvm) to install and switch to the correct version:
+>
+> ```bash
+> nvm install 18
+> nvm use 18
+> ```
 
 ### Installation
 
 ```
-$ yarn install
+ yarn install
 ```
 
 ### Local Development
 
 ```
-$ yarn dev
+ yarn dev
 ```
 
 This command starts a local development server and opens up a browser window. Most changes are reflected live without having to restart the server.
@@ -19,7 +31,7 @@ This command starts a local development server and opens up a browser window. Mo
 ### Build
 
 ```
-$ yarn build
+ yarn build
 ```
 
 This command generates static content into the `build` directory and can be served using any static contents hosting service.


### PR DESCRIPTION
# Clarify Node.js Version Requirement in `docs/` Folder and Improve README Commands

## Acceptance Criteria fulfillment

- [x] Added clear note in docs/README.md specifying that the `docs/` folder requires Node.js version 18 or higher.
- [x] Included instructions to install and switch Node.js versions using nvm for easier environment setup.
- [x] Removed leading `$` from shell command examples to make copy-pasting commands easier and prevent errors.

Fixes #1006 

## PR Test Details

**Note**: The PR will be ready for live testing at https://rocketchat.github.io/EmbeddedChat/pulls/pr-<pr_number> after approval. Contributors are requested to replace `<pr_number>` with the actual PR number.
