### PR TITLE
fix: implement validation URL to block XSS and invalid links

### DIFF
--- a/package.json
+++ b/package.json
@@ -25,6 +25,7 @@
     "typescript": "^5.1.3"
   },
   "dependencies": {
-    "dompurify": "^3.1.6"
+    "dompurify": "^3.1.6",
+    "validator": "^13.15.15"
   }
 }

--- a/packages/react/src/views/ChatInput/InsertLinkToolBox.js
+++ b/packages/react/src/views/ChatInput/InsertLinkToolBox.js
@@ -1,5 +1,6 @@
-import React, { useState } from 'react';
+import React, { useState, useEffect } from 'react';
 import { Modal, Input, Button, useTheme } from '@embeddedchat/ui-elements';
+import validator from 'validator';
 import { getInsertLinkModalStyles } from './ChatInput.styles';
 
 const InsertLinkToolBox = ({
@@ -9,14 +10,35 @@ const InsertLinkToolBox = ({
 }) => {
   const { theme } = useTheme();
   const styles = getInsertLinkModalStyles(theme);
-  const [linkText, setLinkText] = useState(selectedText || 'Text');
-  const [linkUrl, setLinkUrl] = useState(null);
+  const [linkText, setLinkText] = useState(selectedText || '');
+  const [linkUrl, setLinkUrl] = useState('');
+  const [isUrlValid, setIsUrlValid] = useState(false);
+
+  const validateUrl = (url) =>
+    validator.isURL(url, {
+      protocols: ['http', 'https'],
+      require_protocol: true,
+      require_valid_protocol: true,
+      disallow_auth: true,
+    });
+
+  useEffect(() => {
+    const isValid = validateUrl(linkUrl);
+    setIsUrlValid(isValid);
+  }, [linkUrl]);
 
   const handleLinkTextOnChange = (e) => {
     setLinkText(e.target.value);
   };
   const handleLinkUrlOnChange = (e) => {
-    setLinkUrl(e.target.value);
+    const url = e.target.value.trim();
+    setLinkUrl(url);
+    setIsUrlValid(url ? validateUrl(url) : false);
+  };
+
+  const handleAdd = () => {
+    if (!isUrlValid) return;
+    handleAddLink(linkText, linkUrl);
   };
 
   return (
@@ -30,11 +52,13 @@ const InsertLinkToolBox = ({
           type="text"
           onChange={handleLinkTextOnChange}
           value={linkText}
+          placeholder="Text"
           css={styles.inputWithFormattingBox}
         />
         <Input
           type="text"
           onChange={handleLinkUrlOnChange}
+          value={linkUrl}
           placeholder="URL"
           css={styles.inputWithFormattingBox}
         />
@@ -43,7 +67,12 @@ const InsertLinkToolBox = ({
         <Button type="secondary" onClick={onClose}>
           Cancel
         </Button>
-        <Button type="primary" onClick={() => handleAddLink(linkText, linkUrl)}>
+        <Button
+          type="primary"
+          onClick={handleAdd}
+          disabled={!isUrlValid || !linkText.trim()}
+          title={!isUrlValid ? 'Please enter a valid URL' : ''}
+        >
           Add
         </Button>
       </Modal.Footer>

--- a/yarn.lock
+++ b/yarn.lock
@@ -15209,6 +15209,7 @@ __metadata:
     husky: ^9.0.11
     lerna: ^6.6.2
     typescript: ^5.1.3
+    validator: ^13.15.15
   languageName: unknown
   linkType: soft
 
@@ -31650,6 +31651,13 @@ __metadata:
   dependencies:
     builtins: ^5.0.0
   checksum: 5342a994986199b3c28e53a8452a14b2bb5085727691ea7aa0d284a6606b127c371e0925ae99b3f1ef7cc7d2c9de75f52eb61a3d1cc45e39bca1e3a9444cbb4e
+  languageName: node
+  linkType: hard
+
+"validator@npm:^13.15.15":
+  version: 13.15.15
+  resolution: "validator@npm:13.15.15"
+  checksum: 10c1b9215a25c31497c481cf4a3ee3e17dcf0b8a219445788e7167ed1b93b8597bbf657bd5c8ca22199b699c3ab41df902c23526cc514075c4b71bd19a13d02c
   languageName: node
   linkType: hard
 


### PR DESCRIPTION
# Security Fix: URL Validation in InsertLinkToolBox

## Acceptance Criteria fulfillment
- [x] Added URL validation using `isUrl` 
- [x] Blocked dangerous schemes (javascript:, data:, etc.)
- [x] Added visual feedback for invalid URLs

Fixes #1010  
#1011 

## Video/Screenshots
Given video in issue #1010

## Technical Changes
1. Added `validator`  lib and use `isUrl` function that checks whether the URL is valid or not.
2. Modified InsertLinkToolBox to:
  - Disable "Add" button for invalid URLs
  - Show error message for bad inputs
  - Maintain existing edit functionality
        
## PR Test Details
Test with:
  - Valid URLs (https://rocket.chat)
  - Invalid URLs (`javascript:alert(1)`, `hello world`)

**Note**: The PR will be ready for live testing at https://rocketchat.github.io/EmbeddedChat/pulls/pr-<pr_number> after approval. Contributors are requested to replace `<pr_number>` with the actual PR number.
