### PR TITLE
fix: user info sidebar re-render

### DIFF
--- a/packages/react/src/views/UserInformation/UserInformation.js
+++ b/packages/react/src/views/UserInformation/UserInformation.js
@@ -58,7 +58,7 @@ const UserInformation = () => {
     };
 
     getCurrentUserInfo();
-  }, [RCInstance, setCurrentUserInfo]);
+  }, [RCInstance, currentUser]);
 
   const ViewComponent = viewType === 'Popup' ? Popup : Sidebar;
 


### PR DESCRIPTION
# Brief Title
If the user info sidebar is already open and I click on another avatar, the sidebar doesn’t update even though the user state is being updated. This happened because the useEffect dependency array didn’t include the user info change.

## Video/Screenshots ( Fixed )
https://github.com/user-attachments/assets/209dc72b-fc27-4ce3-9b61-d3de7cb9ef45

## PR Test Details

**Note**: The PR will be ready for live testing at https://rocketchat.github.io/EmbeddedChat/pulls/pr-1014 after approval. Contributors are requested to replace `1014` with the actual PR number.

Related Issue: #1017 
