### PR TITLE
fix: auto focus input when editing a message

### DIFF
--- a/packages/react/src/views/ChatInput/ChatInput.js
+++ b/packages/react/src/views/ChatInput/ChatInput.js
@@ -161,8 +161,10 @@ const ChatInput = ({ scrollToBottom }) => {
     if (editMessage.attachments) {
       messageRef.current.value =
         editMessage.attachments[0]?.description || editMessage.msg;
+      messageRef.current.focus();
     } else if (editMessage.msg) {
       messageRef.current.value = editMessage.msg;
+      messageRef.current.focus();
     } else {
       messageRef.current.value = '';
     }


### PR DESCRIPTION
# Brief Title

When editing a message, clicking the edit icon did not automatically focus the input area. This caused users to manually click inside the input field before typing, which disrupted the editing flow.

## Video/Screenshots ( Fixed )

https://github.com/user-attachments/assets/7825660a-aecd-40b3-82cf-551ae7e6c646

## PR Test Details

**Note**: The PR will be ready for live testing at https://rocketchat.github.io/EmbeddedChat/pulls/pr-1019 after approval. Contributors are requested to replace `1019` with the actual PR number.

Related Issue: #1018 
