### PR TITLE
FIX: Pin action system message does not render markdown or message content #1022

### DIFF
--- a/packages/react/src/views/AttachmentHandler/TextAttachment.js
+++ b/packages/react/src/views/AttachmentHandler/TextAttachment.js
@@ -15,7 +15,6 @@ const FileAttachment = ({
   variantStyles = {},
   msg,
 }) => {
-
   const { RCInstance } = useContext(RCContext);
   const { theme } = useTheme();
   const [isExpanded, setIsExpanded] = useState(true);
@@ -116,7 +115,7 @@ const FileAttachment = ({
               ) : (
                 <Markdown
                   body={attachment.text}
-                  md={parse(attachment?.text)} 
+                  md={parse(attachment?.text)}
                   isReaction={false}
                 />
               )

--- a/packages/react/src/views/AttachmentHandler/TextAttachment.js
+++ b/packages/react/src/views/AttachmentHandler/TextAttachment.js
@@ -5,6 +5,7 @@ import { Box, Avatar, useTheme, Icon } from '@embeddedchat/ui-elements';
 import AttachmentMetadata from './AttachmentMetadata';
 import RCContext from '../../context/RCInstance';
 import { Markdown } from '../Markdown';
+import { parse } from '@rocket.chat/message-parser';
 
 const FileAttachment = ({
   attachment,
@@ -14,6 +15,8 @@ const FileAttachment = ({
   variantStyles = {},
   msg,
 }) => {
+  console.log("Text Attachment file log")
+  console.log(attachment)
   const { RCInstance } = useContext(RCContext);
   const { theme } = useTheme();
   const [isExpanded, setIsExpanded] = useState(true);
@@ -113,8 +116,8 @@ const FileAttachment = ({
                 attachment.text.match(/\n(.*)/)?.[1] || ''
               ) : (
                 <Markdown
-                  body={attachment.text}
-                  md={attachment.md}
+                  body={attachment?.text}
+                  md={parse(attachment?.text)} 
                   isReaction={false}
                 />
               )

--- a/packages/react/src/views/AttachmentHandler/TextAttachment.js
+++ b/packages/react/src/views/AttachmentHandler/TextAttachment.js
@@ -2,10 +2,10 @@ import React, { useState, useContext } from 'react';
 import { css } from '@emotion/react';
 import PropTypes from 'prop-types';
 import { Box, Avatar, useTheme, Icon } from '@embeddedchat/ui-elements';
+import { parse } from '@rocket.chat/message-parser';
 import AttachmentMetadata from './AttachmentMetadata';
 import RCContext from '../../context/RCInstance';
 import { Markdown } from '../Markdown';
-import { parse } from '@rocket.chat/message-parser';
 
 const FileAttachment = ({
   attachment,

--- a/packages/react/src/views/AttachmentHandler/TextAttachment.js
+++ b/packages/react/src/views/AttachmentHandler/TextAttachment.js
@@ -15,8 +15,7 @@ const FileAttachment = ({
   variantStyles = {},
   msg,
 }) => {
-  console.log("Text Attachment file log")
-  console.log(attachment)
+
   const { RCInstance } = useContext(RCContext);
   const { theme } = useTheme();
   const [isExpanded, setIsExpanded] = useState(true);
@@ -116,7 +115,7 @@ const FileAttachment = ({
                 attachment.text.match(/\n(.*)/)?.[1] || ''
               ) : (
                 <Markdown
-                  body={attachment?.text}
+                  body={attachment.text}
                   md={parse(attachment?.text)} 
                   isReaction={false}
                 />


### PR DESCRIPTION
# Brief Title

When you pin a message the system message which is sent for the pin action does not render the pinned message components.


Fixes #1022 

## Video/Screenshots
<img width="1691" height="716" alt="image" src="https://github.com/user-attachments/assets/a4cc8f84-83cf-4506-9836-eff589e03143" />


## PR Test Details

**Note**: The PR will be ready for live testing at https://rocketchat.github.io/EmbeddedChat/pulls/pr-<pr_number> after approval. Contributors are requested to replace `<pr_number>` with the actual PR number.

Related Issue: #1022
