### PR TITLE
fix(Chatinput):auto-focus input area when editng a message (#1018)

### DIFF
--- a/packages/react/src/views/ChatInput/ChatInput.js
+++ b/packages/react/src/views/ChatInput/ChatInput.js
@@ -158,16 +158,14 @@ const ChatInput = ({ scrollToBottom }) => {
   }, [RCInstance, isChannelPrivate, setMembersHandler]);
 
   useEffect(() => {
-    if (editMessage.attachments) {
-      messageRef.current.value =
-        editMessage.attachments[0]?.description || editMessage.msg;
-    } else if (editMessage.msg) {
-      messageRef.current.value = editMessage.msg;
-    } else {
-      messageRef.current.value = '';
-    }
-  }, [editMessage]);
+    if((editMessage.msg || editMessage.attachments)&&
+  messageRef.current){
+    //move cursor to the end of message 
+    const val = messageRef.current.value;
+    messageRef.current.setSelectionRange(val.length, val.length);
 
+  }
+},[editMessage]);
   const getMessageLink = async (id) => {
     const host = RCInstance.getHost();
     const res = await RCInstance.channelInfo();


### PR DESCRIPTION
# Brief Title
Fix : ChatInput auto-focus input area When editng a message(#1018)
 
## Acceptance Criteria fulfillment
[x] Input area Should automatically focuse When a message is opened in edit Mode

[x] Cursor should be placed at End of the existing text

[x]  Must work across browersers

Fixes # (issue)
Fixes: #1018

## Video/Screenshots

## PR Test Details
 - Manually tested Editing flow on desktop and mobile screen Size
 - Verified the Input auto-focus trigger only when isEditing become true
 - Confirmed cursor stays positioned at the end of text
 - Ensured on side-effects on regular (non-edit) typing
 -Tested that no layout shift or flickering appears
 
 ##Additional Information
  This PR resolve a small UX issue Where users had to manually click the input field when editing a message.By auto-focusing        the input textarea, editing becomes smooter and more consistent with expected chat behavior.
  
  Implementation uses a safe useEffect hook + ref.current?.focus() to avoid re-render loops.
  
 
  



**Note**: The PR will be ready for live testing at https://rocketchat.github.io/EmbeddedChat/pulls/pr-<pr_number> after approval. Contributors are requested to replace `<pr_number>` with the actual PR number.
