### PR TITLE
fixing messages not being rendered inside threads

### DIFF
--- a/packages/api/src/EmbeddedChatApi.ts
+++ b/packages/api/src/EmbeddedChatApi.ts
@@ -632,7 +632,7 @@ export default class EmbeddedChatApi {
     try {
       const { userId, authToken } = (await this.auth.getCurrentUser()) || {};
       const messages = await fetch(
-        `${this.host}/api/v1/chat.getThreadMessages?roomId=$tmid=${tmid}`,
+        `${this.host}/api/v1/chat.getThreadMessages?tmid=${tmid}`,
         {
           headers: {
             "Content-Type": "application/json",

--- a/packages/api/src/EmbeddedChatApi.ts
+++ b/packages/api/src/EmbeddedChatApi.ts
@@ -632,7 +632,7 @@ export default class EmbeddedChatApi {
     try {
       const { userId, authToken } = (await this.auth.getCurrentUser()) || {};
       const messages = await fetch(
-        `${this.host}/api/v1/chat.getThreadMessages?roomId=${this.rid}&tmid=${tmid}`,
+        `${this.host}/api/v1/chat.getThreadMessages?roomId=$tmid=${tmid}`,
         {
           headers: {
             "Content-Type": "application/json",


### PR DESCRIPTION
# Brief Title

Fixing the unnecessary query parameters for the getThreadMessages endpoint which is used to fetch the messages of  respective threads.

Fixes #1032 

## Video/Screenshots
<img width="870" height="358" alt="image" src="https://github.com/user-attachments/assets/bdf05810-fd5f-40d6-8697-f4fcef6e1074" />

Note: The PR will be ready for live testing at https://rocketchat.github.io/EmbeddedChat/pulls/pr-1033 after approval. Contributors are requested to replace <pr_number> with the actual PR number.

