### PR TITLE
Fixed slash commands entered in threads displayed in main chat

### DIFF
--- a/packages/api/src/EmbeddedChatApi.ts
+++ b/packages/api/src/EmbeddedChatApi.ts
@@ -1191,7 +1191,7 @@ export default class EmbeddedChatApi {
     return data;
   }
 
-  async execCommand({ command, params }: { command: string; params: string }) {
+  async execCommand({ command, params, tmid }: { command: string; params: string, tmid?: string }) {
     const { userId, authToken } = (await this.auth.getCurrentUser()) || {};
     const response = await fetch(`${this.host}/api/v1/commands.run`, {
       headers: {
@@ -1203,6 +1203,7 @@ export default class EmbeddedChatApi {
       body: JSON.stringify({
         command,
         params,
+        tmid,
         roomId: this.rid,
         triggerId: Math.random().toString(32).slice(2, 20),
       }),

--- a/packages/api/src/EmbeddedChatApi.ts
+++ b/packages/api/src/EmbeddedChatApi.ts
@@ -1191,7 +1191,15 @@ export default class EmbeddedChatApi {
     return data;
   }
 
-  async execCommand({ command, params, tmid }: { command: string; params: string, tmid?: string }) {
+  async execCommand({
+    command,
+    params,
+    tmid,
+  }: {
+    command: string;
+    params: string;
+    tmid?: string;
+  }) {
     const { userId, authToken } = (await this.auth.getCurrentUser()) || {};
     const response = await fetch(`${this.host}/api/v1/commands.run`, {
       headers: {

--- a/packages/react/src/views/ChatInput/ChatInput.js
+++ b/packages/react/src/views/ChatInput/ChatInput.js
@@ -354,7 +354,7 @@ const ChatInput = ({ scrollToBottom }) => {
 
   const handleCommandExecution = async (message) => {
     const execCommand = async (command, params) => {
-      await RCInstance.execCommand({ command, params });
+      await RCInstance.execCommand({ command, params, tmid: threadId });
       setFilteredCommands([]);
     };
 


### PR DESCRIPTION
# Brief Title

## Acceptance Criteria fulfillment

- [ ] Preserve and forward the tmid (thread message ID) when sending slash command requests
- [ ] Ensure the Rocket.Chat server response is rendered inside the originating thread
- [ ] Prevent slash command responses from leaking into the main channel context

Fixes #1041 

## Video/Screenshots
<img width="1708" height="596" alt="image" src="https://github.com/user-attachments/assets/390e3287-06a6-4a7f-9646-567819b27be8" />


## PR Test Details

**Note**: The PR will be ready for live testing at https://rocketchat.github.io/EmbeddedChat/pulls/pr-1042 after approval. Contributors are requested to replace `<pr_number>` with the actual PR number.
