### PR TITLE
feat: add search term highlighting in search messages

### DIFF
--- a/packages/markups/src/elements/BoldSpan.js
+++ b/packages/markups/src/elements/BoldSpan.js
@@ -4,6 +4,7 @@ import PlainSpan from './PlainSpan';
 import ItalicSpan from './ItalicSpan';
 import StrikeSpan from './StrikeSpan';
 import LinkSpan from './LinkSpan';
+import HighlightSpan from './HighlightSpan';
 
 const BoldSpan = ({ contents }) => (
   <strong>
@@ -29,6 +30,9 @@ const BoldSpan = ({ contents }) => (
               }
             />
           );
+
+        case 'HIGHLIGHT_TEXT':
+          return <HighlightSpan key={index} contents={content.value} />;
 
         default:
           return null;

--- a/packages/markups/src/elements/CodeElement.js
+++ b/packages/markups/src/elements/CodeElement.js
@@ -1,15 +1,29 @@
 import React from 'react';
 import PropTypes from 'prop-types';
 import PlainSpan from './PlainSpan';
+import HighlightSpan from './HighlightSpan';
 import { InlineElementsStyles } from './elements.styles';
 
 const CodeElement = ({ contents }) => {
   const styles = InlineElementsStyles();
-  return (
-    <code css={styles.inlineElement}>
-      <PlainSpan contents={contents.value} />
-    </code>
-  );
+
+  // Handle highlighted content (array of tokens) or plain string
+  const renderContents = () => {
+    if (contents.hasHighlight && Array.isArray(contents.value)) {
+      return contents.value.map((token, index) => {
+        switch (token.type) {
+          case 'HIGHLIGHT_TEXT':
+            return <HighlightSpan key={index} contents={token.value} />;
+          case 'PLAIN_TEXT':
+          default:
+            return <PlainSpan key={index} contents={token.value} />;
+        }
+      });
+    }
+    return <PlainSpan contents={contents.value} />;
+  };
+
+  return <code css={styles.inlineElement}>{renderContents()}</code>;
 };
 
 export default CodeElement;

--- a/packages/markups/src/elements/HighlightSpan.js
+++ b/packages/markups/src/elements/HighlightSpan.js
@@ -1,0 +1,18 @@
+import React from 'react';
+import PropTypes from 'prop-types';
+import { css } from '@emotion/react';
+
+const highlightStyle = css`
+  background-color: yellow;
+  color: black;
+`;
+
+const HighlightSpan = ({ contents }) => (
+  <mark css={highlightStyle}>{contents}</mark>
+);
+
+export default HighlightSpan;
+
+HighlightSpan.propTypes = {
+  contents: PropTypes.string,
+};

--- a/packages/markups/src/elements/InlineElements.js
+++ b/packages/markups/src/elements/InlineElements.js
@@ -11,6 +11,7 @@ import ColorElement from './ColorElement';
 import LinkSpan from './LinkSpan';
 import UserMention from '../mentions/UserMention';
 import TimestampElement from './TimestampElement';
+import HighlightSpan from './HighlightSpan';
 
 const InlineElements = ({ contents }) =>
   contents.map((content, index) => {
@@ -57,6 +58,9 @@ const InlineElements = ({ contents }) =>
 
       case 'TIMESTAMP':
         return <TimestampElement key={index} contents={content.value} />;
+
+      case 'HIGHLIGHT_TEXT':
+        return <HighlightSpan key={index} contents={content.value} />;
 
       default:
         return null;

--- a/packages/markups/src/elements/ItalicSpan.js
+++ b/packages/markups/src/elements/ItalicSpan.js
@@ -3,6 +3,7 @@ import PropTypes from 'prop-types';
 import PlainSpan from './PlainSpan';
 import BoldSpan from './BoldSpan';
 import StrikeSpan from './StrikeSpan';
+import HighlightSpan from './HighlightSpan';
 
 const ItalicSpan = ({ contents }) => (
   <em>
@@ -16,6 +17,9 @@ const ItalicSpan = ({ contents }) => (
 
         case 'BOLD':
           return <BoldSpan key={index} contents={content.value} />;
+
+        case 'HIGHLIGHT_TEXT':
+          return <HighlightSpan key={index} contents={content.value} />;
 
         default:
           return null;

--- a/packages/markups/src/elements/LinkSpan.js
+++ b/packages/markups/src/elements/LinkSpan.js
@@ -5,6 +5,7 @@ import PlainSpan from './PlainSpan';
 import StrikeSpan from './StrikeSpan';
 import ItalicSpan from './ItalicSpan';
 import BoldSpan from './BoldSpan';
+import HighlightSpan from './HighlightSpan';
 
 const getBaseURI = () => {
   if (document.baseURI) {
@@ -47,6 +48,9 @@ const LinkSpan = ({ href, label }) => {
 
         case 'BOLD':
           return <BoldSpan key={index} contents={content.value} />;
+
+        case 'HIGHLIGHT_TEXT':
+          return <HighlightSpan key={index} contents={content.value} />;
 
         default:
           return null;

--- a/packages/markups/src/elements/StrikeSpan.js
+++ b/packages/markups/src/elements/StrikeSpan.js
@@ -3,6 +3,7 @@ import PropTypes from 'prop-types';
 import PlainSpan from './PlainSpan';
 import BoldSpan from './BoldSpan';
 import ItalicSpan from './ItalicSpan';
+import HighlightSpan from './HighlightSpan';
 
 const StrikeSpan = ({ contents }) => (
   <del>
@@ -16,6 +17,9 @@ const StrikeSpan = ({ contents }) => (
 
         case 'BOLD':
           return <BoldSpan key={index} contents={content.value} />;
+
+        case 'HIGHLIGHT_TEXT':
+          return <HighlightSpan key={index} contents={content.value} />;
 
         default:
           return null;

--- a/packages/react/src/lib/highlightUtils.js
+++ b/packages/react/src/lib/highlightUtils.js
@@ -1,0 +1,263 @@
+/**
+ * Utility functions for highlighting search terms in messages
+ */
+
+/**
+ * Escapes special regex characters in a string
+ * @param {string} str - The string to escape
+ * @returns {string} - The escaped string
+ */
+const escapeRegex = (str) => str.replace(/[.*+?^${}()|[\]\\]/g, '\\$&');
+
+/**
+ * Highlights occurrences of searchTerm within a plain text value,
+ * returning an array of PLAIN_TEXT and HIGHLIGHT_TEXT tokens.
+ * @param {string} text - The text to search within
+ * @param {string} searchTerm - The term to highlight
+ * @returns {{ tokens: Array, matchCount: number }}
+ */
+const highlightInText = (text, searchTerm) => {
+  if (!text || !searchTerm) {
+    return { tokens: [{ type: 'PLAIN_TEXT', value: text || '' }], matchCount: 0 };
+  }
+
+  const regex = new RegExp(`(${escapeRegex(searchTerm)})`, 'gi');
+  const parts = text.split(regex);
+  let matchCount = 0;
+  const tokens = [];
+
+  parts.forEach((part) => {
+    if (!part) return;
+    if (part.toLowerCase() === searchTerm.toLowerCase()) {
+      tokens.push({ type: 'HIGHLIGHT_TEXT', value: part });
+      matchCount += 1;
+    } else {
+      tokens.push({ type: 'PLAIN_TEXT', value: part });
+    }
+  });
+
+  return { tokens, matchCount };
+};
+
+/**
+ * Recursively processes tokens to inject HIGHLIGHT_TEXT tokens
+ * @param {Array} tokens - Array of markdown tokens
+ * @param {string} searchTerm - The term to highlight
+ * @returns {{ tokens: Array, matchCount: number }}
+ */
+const highlightInTokens = (tokens, searchTerm) => {
+  if (!Array.isArray(tokens)) {
+    return { tokens: [], matchCount: 0 };
+  }
+
+  let totalMatchCount = 0;
+  const processedTokens = [];
+
+  tokens.forEach((token) => {
+    if (!token) return;
+
+    switch (token.type) {
+      case 'PLAIN_TEXT': {
+        const { tokens: highlighted, matchCount } = highlightInText(
+          token.value,
+          searchTerm
+        );
+        processedTokens.push(...highlighted);
+        totalMatchCount += matchCount;
+        break;
+      }
+
+      case 'BOLD':
+      case 'ITALIC':
+      case 'STRIKE': {
+        if (Array.isArray(token.value)) {
+          const { tokens: innerTokens, matchCount } = highlightInTokens(
+            token.value,
+            searchTerm
+          );
+          processedTokens.push({ ...token, value: innerTokens });
+          totalMatchCount += matchCount;
+        } else if (typeof token.value === 'string') {
+          const { tokens: highlighted, matchCount } = highlightInText(
+            token.value,
+            searchTerm
+          );
+          processedTokens.push({ ...token, value: highlighted });
+          totalMatchCount += matchCount;
+        } else {
+          processedTokens.push(token);
+        }
+        break;
+      }
+
+      case 'LINK': {
+        if (token.value && Array.isArray(token.value.label)) {
+          const { tokens: labelTokens, matchCount } = highlightInTokens(
+            token.value.label,
+            searchTerm
+          );
+          processedTokens.push({
+            ...token,
+            value: { ...token.value, label: labelTokens },
+          });
+          totalMatchCount += matchCount;
+        } else {
+          processedTokens.push(token);
+        }
+        break;
+      }
+
+      case 'INLINE_CODE': {
+        const codeText = typeof token.value === 'string' ? token.value : '';
+        const { tokens: highlighted, matchCount } = highlightInText(
+          codeText,
+          searchTerm
+        );
+        if (matchCount > 0) {
+          processedTokens.push({ ...token, value: highlighted, hasHighlight: true });
+        } else {
+          processedTokens.push(token);
+        }
+        totalMatchCount += matchCount;
+        break;
+      }
+
+      default:
+        processedTokens.push(token);
+        break;
+    }
+  });
+
+  return { tokens: processedTokens, matchCount: totalMatchCount };
+};
+
+/**
+ * Processes block-level tokens (PARAGRAPH, HEADING, etc.) to inject highlighting
+ * @param {Array} md - Array of block-level tokens
+ * @param {string} searchTerm - The term to highlight
+ * @returns {{ md: Array, matchCount: number }}
+ */
+const highlightInMd = (md, searchTerm) => {
+  if (!Array.isArray(md)) {
+    return { md: [], matchCount: 0 };
+  }
+
+  let totalMatchCount = 0;
+  const processedMd = md.map((block) => {
+    if (!block) return block;
+
+    switch (block.type) {
+      case 'PARAGRAPH':
+      case 'HEADING': {
+        const { tokens, matchCount } = highlightInTokens(block.value, searchTerm);
+        totalMatchCount += matchCount;
+        return { ...block, value: tokens };
+      }
+
+      case 'UNORDERED_LIST':
+      case 'ORDERED_LIST': {
+        const processedItems = block.value.map((item) => {
+          const { tokens, matchCount } = highlightInTokens(item.value, searchTerm);
+          totalMatchCount += matchCount;
+          return { ...item, value: tokens };
+        });
+        return { ...block, value: processedItems };
+      }
+
+      case 'QUOTE': {
+        const { md: innerMd, matchCount } = highlightInMd(block.value, searchTerm);
+        totalMatchCount += matchCount;
+        return { ...block, value: innerMd };
+      }
+
+      case 'CODE': {
+        // For code blocks, check each line
+        if (Array.isArray(block.value)) {
+          let codeMatchCount = 0;
+          const processedLines = block.value.map((line) => {
+            if (typeof line.value === 'string') {
+              const { tokens, matchCount } = highlightInText(line.value, searchTerm);
+              codeMatchCount += matchCount;
+              if (matchCount > 0) {
+                return { ...line, value: tokens, hasHighlight: true };
+              }
+            }
+            return line;
+          });
+          totalMatchCount += codeMatchCount;
+          return { ...block, value: processedLines };
+        }
+        return block;
+      }
+
+      default:
+        return block;
+    }
+  });
+
+  return { md: processedMd, matchCount: totalMatchCount };
+};
+
+/**
+ * Applies search term highlighting to a message.
+ * If message has `md`, injects HIGHLIGHT_TEXT tokens.
+ * If message only has `msg`, creates basic PARAGRAPH tokens with highlighting.
+ * Returns a NEW message object (does not mutate original).
+ *
+ * @param {Object} message - The message object
+ * @param {string} searchTerm - The term to highlight
+ * @returns {{ message: Object, matchCount: number }}
+ */
+export const applyHighlightToMessage = (message, searchTerm) => {
+  if (!message || !searchTerm || !searchTerm.trim()) {
+    return { message, matchCount: 0 };
+  }
+
+  const term = searchTerm.trim();
+
+  // If message has md tokens, process them
+  if (message.md && Array.isArray(message.md)) {
+    const { md, matchCount } = highlightInMd(message.md, term);
+    return {
+      message: { ...message, md },
+      matchCount,
+    };
+  }
+
+  // If message only has msg (plain text), create basic md structure
+  if (message.msg && typeof message.msg === 'string') {
+    const { tokens, matchCount } = highlightInText(message.msg, term);
+    return {
+      message: {
+        ...message,
+        md: [{ type: 'PARAGRAPH', value: tokens }],
+      },
+      matchCount,
+    };
+  }
+
+  return { message, matchCount: 0 };
+};
+
+/**
+ * Applies highlighting to an array of messages.
+ * Returns NEW array with NEW message objects (does not mutate originals).
+ *
+ * @param {Array} messages - Array of message objects
+ * @param {string} searchTerm - The term to highlight
+ * @returns {{ messages: Array, totalMatchCount: number }}
+ */
+export const applyHighlightToMessages = (messages, searchTerm) => {
+  if (!Array.isArray(messages) || !searchTerm || !searchTerm.trim()) {
+    return { messages: messages || [], totalMatchCount: 0 };
+  }
+
+  let totalMatchCount = 0;
+  const highlightedMessages = messages.map((msg) => {
+    const { message, matchCount } = applyHighlightToMessage(msg, searchTerm);
+    totalMatchCount += matchCount;
+    return message;
+  });
+
+  return { messages: highlightedMessages, totalMatchCount };
+};

--- a/packages/react/src/views/MessageAggregators/SearchMessages.js
+++ b/packages/react/src/views/MessageAggregators/SearchMessages.js
@@ -49,6 +49,7 @@ const SearchMessages = () => {
         isSearch: true,
         handleInputChange,
         placeholder: 'Search Messages',
+        searchedText: text,
       }}
       searchFiltered={messageList}
       shouldRender={(msg) => !!msg}

--- a/packages/react/src/views/MessageAggregators/common/MessageAggregator.js
+++ b/packages/react/src/views/MessageAggregators/common/MessageAggregator.js
@@ -20,6 +20,7 @@ import NoMessagesIndicator from './NoMessageIndicator';
 import FileDisplay from '../../FileMessage/FileMessage';
 import useSetExclusiveState from '../../../hooks/useSetExclusiveState';
 import { useRCContext } from '../../../context/RCInstance';
+import { applyHighlightToMessages } from '../../../lib/highlightUtils';
 
 export const MessageAggregator = ({
   title,
@@ -48,8 +49,22 @@ export const MessageAggregator = ({
   );
 
   const [messageRendered, setMessageRendered] = useState(false);
+
+  // Apply highlighting to search results when searchedText is provided
+  const highlightedMessages = useMemo(() => {
+    const sourceMessages = fetchedMessageList || searchFiltered || allMessages;
+    if (searchFiltered && searchProps?.searchedText) {
+      const { messages: highlighted } = applyHighlightToMessages(
+        sourceMessages,
+        searchProps.searchedText
+      );
+      return highlighted;
+    }
+    return sourceMessages;
+  }, [fetchedMessageList, searchFiltered, allMessages, searchProps?.searchedText]);
+
   const { loading, messageList } = useSetMessageList(
-    fetchedMessageList || searchFiltered || allMessages,
+    highlightedMessages,
     shouldRender
   );
 


### PR DESCRIPTION
### Adds search-term highlighting in Search Messages, similar to Rocket.Chat.

### Acceptance Criteria fulfillment


- Highlights matched words with a yellow background
- Works for plain text, inline code, links, bold/italic content
- No UI changes or new controls
- Does not mutate original message objects

Fixes #1043

## Screenshots
<img width="955" height="640" alt="Screenshot from 2025-12-17 16-28-58" src="https://github.com/user-attachments/assets/1591afbc-9d75-40f5-953c-9e696354fae3" />

## PR Test Details

**Note**: The PR will be ready for live testing at https://rocketchat.github.io/EmbeddedChat/pulls/pr-1044 after approval. 
