### PR TITLE
feat: add unread messages divider 

### DIFF
--- a/packages/react/src/views/ChatInput/ChatInput.js
+++ b/packages/react/src/views/ChatInput/ChatInput.js
@@ -35,7 +35,7 @@ import useSearchMentionUser from '../../hooks/useSearchMentionUser';
 import formatSelection from '../../lib/formatSelection';
 import { parseEmoji } from '../../lib/emoji';
 
-const ChatInput = ({ scrollToBottom }) => {
+const ChatInput = ({ scrollToBottom, clearUnreadDividerRef }) => {
   const { styleOverrides, classNames } = useComponentOverrides('ChatInput');
   const { RCInstance, ECOptions } = useRCContext();
   const { theme } = useTheme();
@@ -398,6 +398,10 @@ const ChatInput = ({ scrollToBottom }) => {
 
     handleSendNewMessage(message);
     scrollToBottom();
+    // Clear unread divider when user sends a message
+    if (clearUnreadDividerRef?.current) {
+      clearUnreadDividerRef.current();
+    }
   };
 
   const sendAttachment = (event) => {

--- a/packages/react/src/views/ChatLayout/ChatLayout.js
+++ b/packages/react/src/views/ChatLayout/ChatLayout.js
@@ -1,4 +1,4 @@
-import React, { useEffect, useRef, useCallback, useState } from 'react';
+import React, { useEffect, useRef, useCallback } from 'react';
 import { Box, useComponentOverrides } from '@embeddedchat/ui-elements';
 import styles from './ChatLayout.styles';
 import {
@@ -35,6 +35,7 @@ import useUiKitStore from '../../store/uiKitStore';
 
 const ChatLayout = () => {
   const messageListRef = useRef(null);
+  const clearUnreadDividerRef = useRef(null);
   const { classNames, styleOverrides } = useComponentOverrides('ChatBody');
   const { RCInstance, ECOptions } = useRCContext();
   const anonymousMode = ECOptions?.anonymousMode;
@@ -113,8 +114,12 @@ const ChatLayout = () => {
           showRoles={showRoles}
           messageListRef={messageListRef}
           scrollToBottom={scrollToBottom}
+          clearUnreadDividerRef={clearUnreadDividerRef}
         />
-        <ChatInput scrollToBottom={scrollToBottom} />
+        <ChatInput
+          scrollToBottom={scrollToBottom}
+          clearUnreadDividerRef={clearUnreadDividerRef}
+        />
         <div id="emoji-popup" />
       </Box>
 

--- a/packages/react/src/views/Message/Message.styles.js
+++ b/packages/react/src/views/Message/Message.styles.js
@@ -108,6 +108,58 @@ export const getMessageDividerStyles = (theme) => {
   return styles;
 };
 
+export const getUnreadMessageDividerStyles = (theme, mode) => {
+  // Use destructive (red) for light themes, warningForeground (orange) for dark themes
+  const dividerColor =
+    mode === 'light'
+      ? theme.colors.destructive
+      : theme.colors.warningForeground;
+
+  const styles = {
+    divider: css`
+      letter-spacing: 0rem;
+      font-size: 0.75rem;
+      font-weight: 700;
+      line-height: 1rem;
+      position: relative;
+      display: flex;
+      z-index: 1000;
+      align-items: center;
+      margin-top: 0.5rem;
+      margin-bottom: 0.75rem;
+      padding-left: 1.25rem;
+      padding-right: 1.25rem;
+      @media (max-width: 780px) {
+        z-index: 1;
+      }
+    `,
+
+    dividerContent: css`
+      margin-top: 0.5rem;
+      margin-bottom: 0.5rem;
+      padding-left: 0.5rem;
+      padding-right: 0.5rem;
+      background-color: ${theme.colors.background};
+      color: ${dividerColor};
+      position: absolute;
+      left: 50%;
+      transform: translateX(-50%);
+      border-radius: ${theme.radius};
+    `,
+
+    bar: css`
+      display: flex;
+      justify-content: flex-end;
+      align-items: center;
+      flex-grow: 1;
+      height: 1px;
+      background-color: ${dividerColor};
+    `,
+  };
+
+  return styles;
+};
+
 export const getMessageHeaderStyles = (theme) => {
   const styles = {
     header: css`

--- a/packages/react/src/views/Message/MessageDivider.js
+++ b/packages/react/src/views/Message/MessageDivider.js
@@ -6,11 +6,15 @@ import {
   useTheme,
 } from '@embeddedchat/ui-elements';
 
-import { getMessageDividerStyles } from './Message.styles';
+import {
+  getMessageDividerStyles,
+  getUnreadMessageDividerStyles,
+} from './Message.styles';
 
 export const MessageDivider = ({
   children,
   unreadLabel,
+  unread = false,
   className = '',
   style = {},
   ...props
@@ -20,8 +24,10 @@ export const MessageDivider = ({
     className,
     style
   );
-  const { theme } = useTheme();
-  const styles = getMessageDividerStyles(theme);
+  const { theme, mode } = useTheme();
+  const styles = unread
+    ? getUnreadMessageDividerStyles(theme, mode)
+    : getMessageDividerStyles(theme);
   return (
     <Box
       role="separator"

--- a/packages/react/src/views/MessageList/MessageList.js
+++ b/packages/react/src/views/MessageList/MessageList.js
@@ -9,12 +9,14 @@ import isMessageSequential from '../../lib/isMessageSequential';
 import { Message } from '../Message';
 import isMessageLastSequential from '../../lib/isMessageLastSequential';
 import { MessageBody } from '../Message/MessageBody';
+import { MessageDivider } from '../Message/MessageDivider';
 
 const MessageList = ({
   messages,
   loadingOlderMessages,
   isUserAuthenticated,
   hasMoreMessages,
+  firstUnreadMessageId,
 }) => {
   const showReportMessage = useMessageStore((state) => state.showReportMessage);
   const messageToReport = useMessageStore((state) => state.messageToReport);
@@ -86,17 +88,23 @@ const MessageList = ({
               const sequential = isMessageSequential(msg, prev, 300);
               const lastSequential =
                 sequential && isMessageLastSequential(msg, next);
+              const showUnreadDivider =
+                firstUnreadMessageId && msg._id === firstUnreadMessageId;
 
               return (
-                <Message
-                  key={msg._id}
-                  message={msg}
-                  newDay={newDay}
-                  sequential={sequential}
-                  lastSequential={lastSequential}
-                  type="default"
-                  showAvatar
-                />
+                <React.Fragment key={msg._id}>
+                  {showUnreadDivider && (
+                    <MessageDivider unread>Unread Messages</MessageDivider>
+                  )}
+                  <Message
+                    message={msg}
+                    newDay={newDay}
+                    sequential={sequential}
+                    lastSequential={lastSequential}
+                    type="default"
+                    showAvatar
+                  />
+                </React.Fragment>
               );
             })}
           {showReportMessage && (


### PR DESCRIPTION
# Add unread messages divider 

## Acceptance Criteria fulfillment

- [x] Show an "Unread Messages" divider above the first unread message after clicking the "New Messages" popup
- [x] Render only one divider even when multiple unread messages exist
- [x] Remove the divider on user activity (send message, reopen chat, scroll to bottom)

Fixes #1046

## Screenshots
### Light Mode
<img width="1613" height="498" alt="Screenshot from 2025-12-18 21-57-24" src="https://github.com/user-attachments/assets/bade46e6-f811-471e-8572-56a75a8e72a7" />
### Dark Mode
<img width="1613" height="498" alt="Screenshot from 2025-12-18 21-56-40" src="https://github.com/user-attachments/assets/b53cec19-5ba6-44b3-bb3a-5885886e885e" />

## PR Test Details

**Note**: The PR will be ready for live testing at  
https://rocketchat.github.io/EmbeddedChat/pulls/pr-1047
after approval. 
