### PR TITLE
Fix/embedded chat channelname not switching

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,6 +1,10 @@
 node_modules
 .parcel-cache
 
+# Environment variables (may contain sensitive credentials)
+.env
+.env.local
+.env.*.local
 
 # yarn
 .pnp.*

--- a/.gitignore
+++ b/.gitignore
@@ -1,7 +1,6 @@
 node_modules
 .parcel-cache
 
-# Environment variables (may contain sensitive credentials)
 .env
 .env.local
 .env.*.local

--- a/packages/api/src/EmbeddedChatApi.ts
+++ b/packages/api/src/EmbeddedChatApi.ts
@@ -469,7 +469,6 @@ export default class EmbeddedChatApi {
     try {
       const currentUser = await this.auth.getCurrentUser();
       if (!currentUser || !currentUser.authToken || !currentUser.userId) {
-        // User not authenticated yet, return error response
         return {
           success: false,
           error: "User not authenticated",

--- a/packages/api/src/EmbeddedChatApi.ts
+++ b/packages/api/src/EmbeddedChatApi.ts
@@ -467,7 +467,17 @@ export default class EmbeddedChatApi {
 
   async channelInfo() {
     try {
-      const { userId, authToken } = (await this.auth.getCurrentUser()) || {};
+      const currentUser = await this.auth.getCurrentUser();
+      if (!currentUser || !currentUser.authToken || !currentUser.userId) {
+        // User not authenticated yet, return error response
+        return {
+          success: false,
+          error: "User not authenticated",
+          errorType: "unauthorized",
+        };
+      }
+      
+      const { userId, authToken } = currentUser;
       const response = await fetch(
         `${this.host}/api/v1/rooms.info?roomId=${this.rid}`,
         {
@@ -482,6 +492,10 @@ export default class EmbeddedChatApi {
       return await response.json();
     } catch (err) {
       console.error(err);
+      return {
+        success: false,
+        error: err instanceof Error ? err.message : "Unknown error",
+      };
     }
   }
 

--- a/packages/api/src/EmbeddedChatApi.ts
+++ b/packages/api/src/EmbeddedChatApi.ts
@@ -475,7 +475,7 @@ export default class EmbeddedChatApi {
           errorType: "unauthorized",
         };
       }
-      
+
       const { userId, authToken } = currentUser;
       const response = await fetch(
         `${this.host}/api/v1/rooms.info?roomId=${this.rid}`,

--- a/packages/api/src/EmbeddedChatApi.ts
+++ b/packages/api/src/EmbeddedChatApi.ts
@@ -498,6 +498,46 @@ export default class EmbeddedChatApi {
     }
   }
 
+  async getRoomIdByName(channelName: string): Promise<string | null> {
+    try {
+      const currentUser = await this.auth.getCurrentUser();
+      if (!currentUser || !currentUser.authToken || !currentUser.userId) {
+        return null;
+      }
+
+      const { userId, authToken } = currentUser;
+      const response = await fetch(
+        `${this.host}/api/v1/rooms.info?roomName=${encodeURIComponent(
+          channelName
+        )}`,
+        {
+          headers: {
+            "Content-Type": "application/json",
+            "X-Auth-Token": authToken,
+            "X-User-Id": userId,
+          },
+          method: "GET",
+        }
+      );
+
+      if (!response.ok) {
+        if (response.status === 401) {
+          return null;
+        }
+        return null;
+      }
+
+      const data = await response.json();
+      if (data?.success === true && data?.room?._id) {
+        return data.room._id;
+      }
+      return null;
+    } catch (err) {
+      console.error(err);
+      return null;
+    }
+  }
+
   async getRoomInfo() {
     try {
       const { userId, authToken } = (await this.auth.getCurrentUser()) || {};

--- a/packages/react/src/hooks/useRoomId.js
+++ b/packages/react/src/hooks/useRoomId.js
@@ -30,7 +30,7 @@ export const useRoomId = (
       return { roomId, error: null };
     }
     return channelName
-      ? { roomId: null, error: null }
+      ? { roomId: 'GENERAL', error: null }
       : { roomId: 'GENERAL', error: null };
   });
 
@@ -43,6 +43,7 @@ export const useRoomId = (
 
       if (channelName) {
         if (!isUserAuthenticated) {
+          setResolvedRoomId({ roomId: 'GENERAL', error: null });
           return;
         }
 

--- a/packages/react/src/hooks/useRoomId.js
+++ b/packages/react/src/hooks/useRoomId.js
@@ -1,0 +1,92 @@
+import { useState, useEffect } from 'react';
+import { EmbeddedChatApi } from '@embeddedchat/api';
+
+/**
+ * Custom hook to resolve roomId from either explicit roomId or channelName.
+ * Returns an object with:
+ * - roomId: The resolved room ID, or null if resolution is pending/failed
+ * - error: Error message if resolution failed, or null if successful/pending
+ *
+ * @param {string|null|undefined} roomId - Explicit room ID
+ * @param {string|null|undefined} channelName - Channel name to resolve
+ * @param {string} host - Rocket.Chat host URL
+ * @param {Function} getToken - Token getter function
+ * @param {Function} deleteToken - Token deleter function
+ * @param {Function} saveToken - Token saver function
+ * @param {boolean} isUserAuthenticated - Whether user is authenticated
+ * @returns {{roomId: string|null, error: string|null}} - Resolved room ID and error state
+ */
+export const useRoomId = (
+  roomId,
+  channelName,
+  host,
+  getToken,
+  deleteToken,
+  saveToken,
+  isUserAuthenticated
+) => {
+  const [resolvedRoomId, setResolvedRoomId] = useState(() => {
+    if (roomId) {
+      return { roomId, error: null };
+    }
+    return channelName
+      ? { roomId: null, error: null }
+      : { roomId: 'GENERAL', error: null };
+  });
+
+  useEffect(() => {
+    const resolveRoomId = async () => {
+      if (roomId) {
+        setResolvedRoomId({ roomId, error: null });
+        return;
+      }
+
+      if (channelName) {
+        if (!isUserAuthenticated) {
+          return;
+        }
+
+        try {
+          const tempRCInstance = new EmbeddedChatApi(host, 'GENERAL', {
+            getToken,
+            deleteToken,
+            saveToken,
+          });
+          const roomIdFromName = await tempRCInstance.getRoomIdByName(
+            channelName
+          );
+          await tempRCInstance.close().catch(console.error);
+          if (roomIdFromName) {
+            setResolvedRoomId({ roomId: roomIdFromName, error: null });
+          } else {
+            setResolvedRoomId({
+              roomId: null,
+              error: `Channel "${channelName}" not found or you don't have access to it.`,
+            });
+          }
+        } catch (error) {
+          setResolvedRoomId({
+            roomId: null,
+            error: `Failed to resolve channel "${channelName}": ${
+              error.message || 'Unknown error'
+            }`,
+          });
+        }
+      } else {
+        setResolvedRoomId({ roomId: 'GENERAL', error: null });
+      }
+    };
+
+    resolveRoomId();
+  }, [
+    roomId,
+    channelName,
+    host,
+    getToken,
+    deleteToken,
+    saveToken,
+    isUserAuthenticated,
+  ]);
+
+  return resolvedRoomId;
+};

--- a/packages/react/src/views/ChatHeader/ChatHeader.js
+++ b/packages/react/src/views/ChatHeader/ChatHeader.js
@@ -185,6 +185,13 @@ const ChatHeader = ({
         }
       } else if (
         'errorType' in res &&
+        res.errorType === 'unauthorized'
+      ) {
+        // User not authenticated yet, wait and retry
+        // The effect will re-run when isUserAuthenticated changes
+        return;
+      } else if (
+        'errorType' in res &&
         res.errorType === 'error-room-not-found'
       ) {
         dispatchToastMessage({

--- a/packages/react/src/views/ChatHeader/ChatHeader.js
+++ b/packages/react/src/views/ChatHeader/ChatHeader.js
@@ -184,8 +184,6 @@ const ChatHeader = ({
           setMessageAllowed();
         }
       } else if ('errorType' in res && res.errorType === 'unauthorized') {
-        // User not authenticated yet, wait and retry
-        // The effect will re-run when isUserAuthenticated changes
       } else if (
         'errorType' in res &&
         res.errorType === 'error-room-not-found'

--- a/packages/react/src/views/ChatHeader/ChatHeader.js
+++ b/packages/react/src/views/ChatHeader/ChatHeader.js
@@ -183,7 +183,6 @@ const ChatHeader = ({
           setIsChannelReadOnly(true);
           setMessageAllowed();
         }
-      } else if ('errorType' in res && res.errorType === 'unauthorized') {
       } else if (
         'errorType' in res &&
         res.errorType === 'error-room-not-found'

--- a/packages/react/src/views/ChatHeader/ChatHeader.js
+++ b/packages/react/src/views/ChatHeader/ChatHeader.js
@@ -183,13 +183,9 @@ const ChatHeader = ({
           setIsChannelReadOnly(true);
           setMessageAllowed();
         }
-      } else if (
-        'errorType' in res &&
-        res.errorType === 'unauthorized'
-      ) {
+      } else if ('errorType' in res && res.errorType === 'unauthorized') {
         // User not authenticated yet, wait and retry
         // The effect will re-run when isUserAuthenticated changes
-        return;
       } else if (
         'errorType' in res &&
         res.errorType === 'error-room-not-found'

--- a/packages/react/src/views/EmbeddedChat.js
+++ b/packages/react/src/views/EmbeddedChat.js
@@ -269,7 +269,7 @@ const EmbeddedChat = (props) => {
 
   if (!isSynced) return null;
 
-  if (!RCInstance) {
+  if (!RCInstance && roomIdError) {
     return (
       <ThemeProvider
         theme={theme || DefaultTheme}
@@ -316,24 +316,26 @@ const EmbeddedChat = (props) => {
                     margin-bottom: 8px;
                   `}
                 >
-                  {roomIdError || 'Loading channel...'}
+                  {roomIdError}
                 </Box>
-                {roomIdError && (
-                  <Box
-                    css={css`
-                      font-size: 0.9rem;
-                      opacity: 0.7;
-                    `}
-                  >
-                    Please check the channel name and try again.
-                  </Box>
-                )}
+                <Box
+                  css={css`
+                    font-size: 0.9rem;
+                    opacity: 0.7;
+                  `}
+                >
+                  Please check the channel name and try again.
+                </Box>
               </Box>
             </Box>
           </ToastBarProvider>
         </Box>
       </ThemeProvider>
     );
+  }
+
+  if (!RCInstance) {
+    return null;
   }
 
   return (

--- a/packages/react/src/views/EmbeddedChat.js
+++ b/packages/react/src/views/EmbeddedChat.js
@@ -18,7 +18,12 @@ import {
 import { ChatLayout } from './ChatLayout';
 import { ChatHeader } from './ChatHeader';
 import { RCInstanceProvider } from '../context/RCInstance';
-import { useUserStore, useLoginStore, useMessageStore } from '../store';
+import {
+  useUserStore,
+  useLoginStore,
+  useMessageStore,
+  useChannelStore,
+} from '../store';
 import DefaultTheme from '../theme/DefaultTheme';
 import { getTokenStorage } from '../lib/auth';
 import { styles } from './EmbeddedChat.styles';
@@ -27,9 +32,23 @@ import { overrideECProps } from '../lib/overrideECProps';
 
 const EmbeddedChat = (props) => {
   const [config, setConfig] = useState(() => props);
+  // Track if roomId was explicitly provided (not just the default)
+  const [explicitRoomId, setExplicitRoomId] = useState(() => props.roomId);
+  // Don't default to GENERAL if channelName is provided - wait for resolution
+  const [resolvedRoomId, setResolvedRoomId] = useState(() => {
+    // If roomId is explicitly provided, use it
+    if (props.roomId) {
+      return props.roomId;
+    }
+    // If channelName is provided, we'll resolve it, so start with null to indicate pending
+    // Otherwise default to GENERAL
+    return props.channelName ? null : 'GENERAL';
+  });
 
   useEffect(() => {
     setConfig(props);
+    // Track if roomId is explicitly provided
+    setExplicitRoomId(props.roomId);
   }, [props]);
 
   const {
@@ -61,6 +80,7 @@ const EmbeddedChat = (props) => {
   } = config;
 
   const hasMounted = useRef(false);
+  const previousResolvedRoomId = useRef(resolvedRoomId);
   const { classNames, styleOverrides } = useComponentOverrides('EmbeddedChat');
   const [fullScreen, setFullScreen] = useState(false);
   const [isSynced, setIsSynced] = useState(!remoteOpt);
@@ -72,6 +92,7 @@ const EmbeddedChat = (props) => {
     setUserId: setAuthenticatedUserId,
     setName: setAuthenticatedName,
     setRoles: setAuthenticatedUserRoles,
+    isUserAuthenticated,
   } = useUserStore((state) => ({
     isUserAuthenticated: state.isUserAuthenticated,
     setIsUserAuthenticated: state.setIsUserAuthenticated,
@@ -90,34 +111,176 @@ const EmbeddedChat = (props) => {
   }
 
   const initializeRCInstance = useCallback(() => {
-    const newRCInstance = new EmbeddedChatApi(host, roomId, {
+    // Use resolvedRoomId or fallback to GENERAL if not resolved yet
+    // This ensures we always have a valid roomId for the RCInstance
+    const roomIdToUse = resolvedRoomId || 'GENERAL';
+    const newRCInstance = new EmbeddedChatApi(host, roomIdToUse, {
       getToken,
       deleteToken,
       saveToken,
     });
 
     return newRCInstance;
-  }, [host, roomId, getToken, deleteToken, saveToken]);
+  }, [host, resolvedRoomId, getToken, deleteToken, saveToken]);
 
-  const [RCInstance, setRCInstance] = useState(() => initializeRCInstance());
+  // Initialize RCInstance - use GENERAL temporarily if resolving channelName
+  const [RCInstance, setRCInstance] = useState(() => {
+    // If we're resolving channelName (resolvedRoomId is null), use GENERAL temporarily
+    // It will be re-instantiated when resolution completes
+    const initialRoomId = resolvedRoomId || 'GENERAL';
+    return new EmbeddedChatApi(host, initialRoomId, {
+      getToken,
+      deleteToken,
+      saveToken,
+    });
+  });
+  const setMessages = useMessageStore((state) => state.setMessages);
+  const setChannelInfo = useChannelStore((state) => state.setChannelInfo);
+
+  // Resolve roomId from channelName when channelName is provided and no explicit roomId
+  // Priority: explicit roomId prop > resolved channelName > 'GENERAL'
+  useEffect(() => {
+    const resolveRoomId = async () => {
+      // If roomId is explicitly provided, use it directly
+      if (explicitRoomId) {
+        setResolvedRoomId(explicitRoomId);
+        return;
+      }
+
+      // If channelName is provided but no explicit roomId, resolve it to roomId
+      if (channelName) {
+        try {
+          // We need auth token, but RCInstance might not be ready yet
+          if (!RCInstance) {
+            // Don't set resolvedRoomId yet - wait for RCInstance
+            return;
+          }
+
+          // Wait for authentication before resolving
+          if (!isUserAuthenticated) {
+            // Not authenticated yet, wait for authentication - don't set to GENERAL
+            return;
+          }
+
+          const currentUser = await RCInstance.auth.getCurrentUser();
+          const authToken = currentUser?.authToken;
+          const userId = currentUser?.userId || currentUser?._id;
+
+          if (!authToken || !userId) {
+            // No auth token available, wait - don't set to GENERAL yet
+            return;
+          }
+
+          // Resolve channelName to roomId using the API
+          const response = await fetch(
+            `${host}/api/v1/rooms.info?roomName=${encodeURIComponent(
+              channelName
+            )}`,
+            {
+              method: 'GET',
+              headers: {
+                'Content-Type': 'application/json',
+                'X-Auth-Token': authToken,
+                'X-User-Id': userId,
+              },
+            }
+          );
+
+          if (!response.ok) {
+            // Handle 401 or other errors
+            if (response.status === 401) {
+              // Don't set to GENERAL - wait for auth to complete
+              return;
+            }
+            throw new Error(`HTTP error! status: ${response.status}`);
+          }
+
+          const data = await response.json();
+          if (data?.success && data?.room?._id) {
+            // Successfully resolved channelName to roomId
+            setResolvedRoomId(data.room._id);
+          } else {
+            // Fallback to GENERAL if resolution fails
+            setResolvedRoomId('GENERAL');
+          }
+        } catch (error) {
+          // Fallback to GENERAL on error
+          setResolvedRoomId('GENERAL');
+        }
+      } else {
+        // No channelName and no explicit roomId, use GENERAL
+        setResolvedRoomId('GENERAL');
+      }
+    };
+
+    resolveRoomId();
+  }, [channelName, explicitRoomId, host, RCInstance, isUserAuthenticated]);
 
   useEffect(() => {
-    const reInstantiate = () => {
+    const reInstantiate = async () => {
+      // On first mount, mark as mounted
+      if (!hasMounted.current) {
+        hasMounted.current = true;
+        previousResolvedRoomId.current = resolvedRoomId;
+        // If resolvedRoomId is null, we're waiting for resolution - don't do anything yet
+        if (resolvedRoomId === null) {
+          return;
+        }
+        // If resolvedRoomId is already set on first mount, we're good (roomId was provided)
+        return;
+      }
+
+      // If resolvedRoomId is null, we're still waiting for resolution
+      // Don't re-instantiate yet - wait for resolution to complete
+      if (resolvedRoomId === null) {
+        return;
+      }
+
+      // Check if resolvedRoomId actually changed
+      if (previousResolvedRoomId.current === resolvedRoomId) {
+        // No change, don't re-instantiate
+        return;
+      }
+
+      // Update the ref
+      previousResolvedRoomId.current = resolvedRoomId;
+
+      // First, close the old connection completely
+      await RCInstance.close();
+
+      // Clear messages and channel info AFTER closing old connection
+      setMessages([], false);
+      setChannelInfo({});
+      useMessageStore.setState({
+        messages: [],
+        threadMessages: [],
+        filtered: false,
+        threadMainMessage: null,
+        deletedMessage: {},
+        quoteMessage: [],
+        editMessage: {},
+        messagesOffset: 0,
+        isMessageLoaded: false,
+      });
+
+      // Create new instance with new roomId
       const newRCInstance = initializeRCInstance();
       setRCInstance(newRCInstance);
     };
 
-    if (!hasMounted.current) {
-      hasMounted.current = true;
-      return;
-    }
-
-    RCInstance.close().then(reInstantiate).catch(console.error);
+    reInstantiate().catch(console.error);
 
     return () => {
       RCInstance.close().catch(console.error);
     };
-  }, [roomId, host, initializeRCInstance]);
+  }, [
+    resolvedRoomId,
+    host,
+    initializeRCInstance,
+    setMessages,
+    setChannelInfo,
+    RCInstance,
+  ]);
 
   useEffect(() => {
     const autoLogin = async () => {
@@ -138,7 +301,6 @@ const EmbeddedChat = (props) => {
       if (user) {
         RCInstance.connect()
           .then(() => {
-            console.log(`Connected to RocketChat ${RCInstance.host}`);
             const { me } = user;
             setAuthenticatedAvatarUrl(me.avatarUrl);
             setAuthenticatedUsername(me.username);
@@ -189,7 +351,7 @@ const EmbeddedChat = (props) => {
       width,
       height,
       host,
-      roomId,
+      roomId: resolvedRoomId,
       channelName,
       showName,
       showRoles,

--- a/packages/react/src/views/EmbeddedChat.js
+++ b/packages/react/src/views/EmbeddedChat.js
@@ -102,16 +102,18 @@ const EmbeddedChat = (props) => {
   const dispatchToastMessage = useToastBarDispatch();
 
   const RCInstance = useMemo(() => {
-    if (resolvedRoomId === null) {
+    const roomIdToUse = resolvedRoomId || roomId || 'GENERAL';
+    try {
+      return new EmbeddedChatApi(host, roomIdToUse, {
+        getToken,
+        deleteToken,
+        saveToken,
+      });
+    } catch (error) {
+      console.error('Failed to create RCInstance:', error);
       return null;
     }
-    const roomIdToUse = resolvedRoomId || 'GENERAL';
-    return new EmbeddedChatApi(host, roomIdToUse, {
-      getToken,
-      deleteToken,
-      saveToken,
-    });
-  }, [host, resolvedRoomId, getToken, deleteToken, saveToken]);
+  }, [host, resolvedRoomId, roomId, getToken, deleteToken, saveToken]);
 
   const setMessages = useMessageStore((state) => state.setMessages);
   const setChannelInfo = useChannelStore((state) => state.setChannelInfo);
@@ -269,7 +271,7 @@ const EmbeddedChat = (props) => {
 
   if (!isSynced) return null;
 
-  if (!RCInstance && roomIdError) {
+  if (roomIdError && !RCInstance) {
     return (
       <ThemeProvider
         theme={theme || DefaultTheme}

--- a/packages/react/src/views/EmbeddedChat.js
+++ b/packages/react/src/views/EmbeddedChat.js
@@ -32,22 +32,16 @@ import { overrideECProps } from '../lib/overrideECProps';
 
 const EmbeddedChat = (props) => {
   const [config, setConfig] = useState(() => props);
-  // Track if roomId was explicitly provided (not just the default)
   const [explicitRoomId, setExplicitRoomId] = useState(() => props.roomId);
-  // Don't default to GENERAL if channelName is provided - wait for resolution
   const [resolvedRoomId, setResolvedRoomId] = useState(() => {
-    // If roomId is explicitly provided, use it
     if (props.roomId) {
       return props.roomId;
     }
-    // If channelName is provided, we'll resolve it, so start with null to indicate pending
-    // Otherwise default to GENERAL
     return props.channelName ? null : 'GENERAL';
   });
 
   useEffect(() => {
     setConfig(props);
-    // Track if roomId is explicitly provided
     setExplicitRoomId(props.roomId);
   }, [props]);
 
@@ -111,8 +105,6 @@ const EmbeddedChat = (props) => {
   }
 
   const initializeRCInstance = useCallback(() => {
-    // Use resolvedRoomId or fallback to GENERAL if not resolved yet
-    // This ensures we always have a valid roomId for the RCInstance
     const roomIdToUse = resolvedRoomId || 'GENERAL';
     const newRCInstance = new EmbeddedChatApi(host, roomIdToUse, {
       getToken,
@@ -123,10 +115,7 @@ const EmbeddedChat = (props) => {
     return newRCInstance;
   }, [host, resolvedRoomId, getToken, deleteToken, saveToken]);
 
-  // Initialize RCInstance - use GENERAL temporarily if resolving channelName
   const [RCInstance, setRCInstance] = useState(() => {
-    // If we're resolving channelName (resolvedRoomId is null), use GENERAL temporarily
-    // It will be re-instantiated when resolution completes
     const initialRoomId = resolvedRoomId || 'GENERAL';
     return new EmbeddedChatApi(host, initialRoomId, {
       getToken,
@@ -137,28 +126,20 @@ const EmbeddedChat = (props) => {
   const setMessages = useMessageStore((state) => state.setMessages);
   const setChannelInfo = useChannelStore((state) => state.setChannelInfo);
 
-  // Resolve roomId from channelName when channelName is provided and no explicit roomId
-  // Priority: explicit roomId prop > resolved channelName > 'GENERAL'
   useEffect(() => {
     const resolveRoomId = async () => {
-      // If roomId is explicitly provided, use it directly
       if (explicitRoomId) {
         setResolvedRoomId(explicitRoomId);
         return;
       }
 
-      // If channelName is provided but no explicit roomId, resolve it to roomId
       if (channelName) {
         try {
-          // We need auth token, but RCInstance might not be ready yet
           if (!RCInstance) {
-            // Don't set resolvedRoomId yet - wait for RCInstance
             return;
           }
 
-          // Wait for authentication before resolving
           if (!isUserAuthenticated) {
-            // Not authenticated yet, wait for authentication - don't set to GENERAL
             return;
           }
 
@@ -167,11 +148,9 @@ const EmbeddedChat = (props) => {
           const userId = currentUser?.userId || currentUser?._id;
 
           if (!authToken || !userId) {
-            // No auth token available, wait - don't set to GENERAL yet
             return;
           }
 
-          // Resolve channelName to roomId using the API
           const response = await fetch(
             `${host}/api/v1/rooms.info?roomName=${encodeURIComponent(
               channelName
@@ -187,9 +166,7 @@ const EmbeddedChat = (props) => {
           );
 
           if (!response.ok) {
-            // Handle 401 or other errors
             if (response.status === 401) {
-              // Don't set to GENERAL - wait for auth to complete
               return;
             }
             throw new Error(`HTTP error! status: ${response.status}`);
@@ -197,18 +174,14 @@ const EmbeddedChat = (props) => {
 
           const data = await response.json();
           if (data?.success && data?.room?._id) {
-            // Successfully resolved channelName to roomId
             setResolvedRoomId(data.room._id);
           } else {
-            // Fallback to GENERAL if resolution fails
             setResolvedRoomId('GENERAL');
           }
         } catch (error) {
-          // Fallback to GENERAL on error
           setResolvedRoomId('GENERAL');
         }
       } else {
-        // No channelName and no explicit roomId, use GENERAL
         setResolvedRoomId('GENERAL');
       }
     };
@@ -218,37 +191,27 @@ const EmbeddedChat = (props) => {
 
   useEffect(() => {
     const reInstantiate = async () => {
-      // On first mount, mark as mounted
       if (!hasMounted.current) {
         hasMounted.current = true;
         previousResolvedRoomId.current = resolvedRoomId;
-        // If resolvedRoomId is null, we're waiting for resolution - don't do anything yet
         if (resolvedRoomId === null) {
           return;
         }
-        // If resolvedRoomId is already set on first mount, we're good (roomId was provided)
         return;
       }
 
-      // If resolvedRoomId is null, we're still waiting for resolution
-      // Don't re-instantiate yet - wait for resolution to complete
       if (resolvedRoomId === null) {
         return;
       }
 
-      // Check if resolvedRoomId actually changed
       if (previousResolvedRoomId.current === resolvedRoomId) {
-        // No change, don't re-instantiate
         return;
       }
 
-      // Update the ref
       previousResolvedRoomId.current = resolvedRoomId;
 
-      // First, close the old connection completely
       await RCInstance.close();
 
-      // Clear messages and channel info AFTER closing old connection
       setMessages([], false);
       setChannelInfo({});
       useMessageStore.setState({
@@ -263,7 +226,6 @@ const EmbeddedChat = (props) => {
         isMessageLoaded: false,
       });
 
-      // Create new instance with new roomId
       const newRCInstance = initializeRCInstance();
       setRCInstance(newRCInstance);
     };

--- a/packages/react/src/views/EmbeddedChat.js
+++ b/packages/react/src/views/EmbeddedChat.js
@@ -7,7 +7,6 @@ import {
   ToastBarProvider,
   useComponentOverrides,
   ThemeProvider,
-  useToastBarDispatch,
 } from '@embeddedchat/ui-elements';
 import { ChatLayout } from './ChatLayout';
 import { ChatHeader } from './ChatHeader';
@@ -99,8 +98,6 @@ const EmbeddedChat = (props) => {
     isUserAuthenticated
   );
 
-  const dispatchToastMessage = useToastBarDispatch();
-
   const RCInstance = useMemo(() => {
     const roomIdToUse = resolvedRoomId || roomId || 'GENERAL';
     try {
@@ -117,15 +114,6 @@ const EmbeddedChat = (props) => {
 
   const setMessages = useMessageStore((state) => state.setMessages);
   const setChannelInfo = useChannelStore((state) => state.setChannelInfo);
-
-  useEffect(() => {
-    if (roomIdError) {
-      dispatchToastMessage({
-        type: 'error',
-        message: roomIdError,
-      });
-    }
-  }, [roomIdError, dispatchToastMessage]);
 
   useEffect(() => {
     if (resolvedRoomId === null || !RCInstance) {

--- a/packages/react/src/views/EmbeddedChat.js
+++ b/packages/react/src/views/EmbeddedChat.js
@@ -100,6 +100,9 @@ const EmbeddedChat = (props) => {
 
   const RCInstance = useMemo(() => {
     const roomIdToUse = resolvedRoomId || roomId || 'GENERAL';
+    if (!roomIdToUse) {
+      return null;
+    }
     try {
       return new EmbeddedChatApi(host, roomIdToUse, {
         getToken,

--- a/packages/react/src/views/EmbeddedChat.js
+++ b/packages/react/src/views/EmbeddedChat.js
@@ -1,11 +1,4 @@
-import React, {
-  memo,
-  useEffect,
-  useMemo,
-  useState,
-  useCallback,
-  useRef,
-} from 'react';
+import React, { memo, useEffect, useMemo, useState, useCallback } from 'react';
 import PropTypes from 'prop-types';
 import { css } from '@emotion/react';
 import { EmbeddedChatApi } from '@embeddedchat/api';
@@ -14,6 +7,7 @@ import {
   ToastBarProvider,
   useComponentOverrides,
   ThemeProvider,
+  useToastBarDispatch,
 } from '@embeddedchat/ui-elements';
 import { ChatLayout } from './ChatLayout';
 import { ChatHeader } from './ChatHeader';
@@ -29,20 +23,13 @@ import { getTokenStorage } from '../lib/auth';
 import { styles } from './EmbeddedChat.styles';
 import GlobalStyles from './GlobalStyles';
 import { overrideECProps } from '../lib/overrideECProps';
+import { useRoomId } from '../hooks/useRoomId';
 
 const EmbeddedChat = (props) => {
   const [config, setConfig] = useState(() => props);
-  const [explicitRoomId, setExplicitRoomId] = useState(() => props.roomId);
-  const [resolvedRoomId, setResolvedRoomId] = useState(() => {
-    if (props.roomId) {
-      return props.roomId;
-    }
-    return props.channelName ? null : 'GENERAL';
-  });
 
   useEffect(() => {
     setConfig(props);
-    setExplicitRoomId(props.roomId);
   }, [props]);
 
   const {
@@ -73,12 +60,9 @@ const EmbeddedChat = (props) => {
     remoteOpt = false,
   } = config;
 
-  const hasMounted = useRef(false);
-  const previousResolvedRoomId = useRef(resolvedRoomId);
   const { classNames, styleOverrides } = useComponentOverrides('EmbeddedChat');
   const [fullScreen, setFullScreen] = useState(false);
   const [isSynced, setIsSynced] = useState(!remoteOpt);
-  const { getToken, saveToken, deleteToken } = getTokenStorage(secure);
   const {
     setIsUserAuthenticated,
     setUsername: setAuthenticatedUsername,
@@ -104,114 +88,49 @@ const EmbeddedChat = (props) => {
     );
   }
 
-  const initializeRCInstance = useCallback(() => {
+  const { getToken, saveToken, deleteToken } = getTokenStorage(secure);
+  const { roomId: resolvedRoomId, error: roomIdError } = useRoomId(
+    roomId,
+    channelName,
+    host,
+    getToken,
+    deleteToken,
+    saveToken,
+    isUserAuthenticated
+  );
+
+  const dispatchToastMessage = useToastBarDispatch();
+
+  const RCInstance = useMemo(() => {
+    if (resolvedRoomId === null) {
+      return null;
+    }
     const roomIdToUse = resolvedRoomId || 'GENERAL';
-    const newRCInstance = new EmbeddedChatApi(host, roomIdToUse, {
+    return new EmbeddedChatApi(host, roomIdToUse, {
       getToken,
       deleteToken,
       saveToken,
     });
-
-    return newRCInstance;
   }, [host, resolvedRoomId, getToken, deleteToken, saveToken]);
 
-  const [RCInstance, setRCInstance] = useState(() => {
-    const initialRoomId = resolvedRoomId || 'GENERAL';
-    return new EmbeddedChatApi(host, initialRoomId, {
-      getToken,
-      deleteToken,
-      saveToken,
-    });
-  });
   const setMessages = useMessageStore((state) => state.setMessages);
   const setChannelInfo = useChannelStore((state) => state.setChannelInfo);
 
   useEffect(() => {
-    const resolveRoomId = async () => {
-      if (explicitRoomId) {
-        setResolvedRoomId(explicitRoomId);
-        return;
-      }
-
-      if (channelName) {
-        try {
-          if (!RCInstance) {
-            return;
-          }
-
-          if (!isUserAuthenticated) {
-            return;
-          }
-
-          const currentUser = await RCInstance.auth.getCurrentUser();
-          const authToken = currentUser?.authToken;
-          const userId = currentUser?.userId || currentUser?._id;
-
-          if (!authToken || !userId) {
-            return;
-          }
-
-          const response = await fetch(
-            `${host}/api/v1/rooms.info?roomName=${encodeURIComponent(
-              channelName
-            )}`,
-            {
-              method: 'GET',
-              headers: {
-                'Content-Type': 'application/json',
-                'X-Auth-Token': authToken,
-                'X-User-Id': userId,
-              },
-            }
-          );
-
-          if (!response.ok) {
-            if (response.status === 401) {
-              return;
-            }
-            throw new Error(`HTTP error! status: ${response.status}`);
-          }
-
-          const data = await response.json();
-          if (data?.success && data?.room?._id) {
-            setResolvedRoomId(data.room._id);
-          } else {
-            setResolvedRoomId('GENERAL');
-          }
-        } catch (error) {
-          setResolvedRoomId('GENERAL');
-        }
-      } else {
-        setResolvedRoomId('GENERAL');
-      }
-    };
-
-    resolveRoomId();
-  }, [channelName, explicitRoomId, host, RCInstance, isUserAuthenticated]);
+    if (roomIdError) {
+      dispatchToastMessage({
+        type: 'error',
+        message: roomIdError,
+      });
+    }
+  }, [roomIdError, dispatchToastMessage]);
 
   useEffect(() => {
-    const reInstantiate = async () => {
-      if (!hasMounted.current) {
-        hasMounted.current = true;
-        previousResolvedRoomId.current = resolvedRoomId;
-        if (resolvedRoomId === null) {
-          return;
-        }
-        return;
-      }
+    if (resolvedRoomId === null || !RCInstance) {
+      return;
+    }
 
-      if (resolvedRoomId === null) {
-        return;
-      }
-
-      if (previousResolvedRoomId.current === resolvedRoomId) {
-        return;
-      }
-
-      previousResolvedRoomId.current = resolvedRoomId;
-
-      await RCInstance.close();
-
+    const cleanup = async () => {
       setMessages([], false);
       setChannelInfo({});
       useMessageStore.setState({
@@ -225,26 +144,19 @@ const EmbeddedChat = (props) => {
         messagesOffset: 0,
         isMessageLoaded: false,
       });
-
-      const newRCInstance = initializeRCInstance();
-      setRCInstance(newRCInstance);
     };
 
-    reInstantiate().catch(console.error);
+    cleanup();
 
     return () => {
       RCInstance.close().catch(console.error);
     };
-  }, [
-    resolvedRoomId,
-    host,
-    initializeRCInstance,
-    setMessages,
-    setChannelInfo,
-    RCInstance,
-  ]);
+  }, [resolvedRoomId, setMessages, setChannelInfo, RCInstance]);
 
   useEffect(() => {
+    if (!RCInstance) {
+      return;
+    }
     const autoLogin = async () => {
       setIsLoginIn(true);
       try {
@@ -259,6 +171,9 @@ const EmbeddedChat = (props) => {
   }, [RCInstance, auth, setIsLoginIn]);
 
   useEffect(() => {
+    if (!RCInstance) {
+      return;
+    }
     RCInstance.auth.onAuthChange((user) => {
       if (user) {
         RCInstance.connect()
@@ -287,6 +202,10 @@ const EmbeddedChat = (props) => {
   ]);
 
   useEffect(() => {
+    if (!RCInstance) {
+      setIsSynced(true);
+      return;
+    }
     const getConfig = async () => {
       try {
         const appInfo = await RCInstance.getRCAppInfo();
@@ -341,16 +260,88 @@ const EmbeddedChat = (props) => {
     ]
   );
 
-  const RCContextValue = useMemo(
-    () => ({ RCInstance, ECOptions }),
-    [RCInstance, ECOptions]
-  );
+  const RCContextValue = useMemo(() => {
+    if (!RCInstance) {
+      return { RCInstance: null, ECOptions };
+    }
+    return { RCInstance, ECOptions };
+  }, [RCInstance, ECOptions]);
 
   if (!isSynced) return null;
 
+  if (!RCInstance) {
+    return (
+      <ThemeProvider
+        theme={theme || DefaultTheme}
+        mode={dark ? 'dark' : 'light'}
+      >
+        <Box
+          css={[
+            styles.embeddedchat(theme || DefaultTheme, dark),
+            css`
+              width: ${width};
+              height: ${height};
+              position: relative;
+            `,
+            fullScreen && styles.fullscreen,
+          ]}
+          className={`ec-embedded-chat ${className} ${classNames}`}
+          style={{ ...style, ...styleOverrides }}
+        >
+          <GlobalStyles />
+          <ToastBarProvider position={toastBarPosition}>
+            {hideHeader ? null : (
+              <ChatHeader
+                isClosable={isClosable}
+                setClosableState={setClosableState}
+                fullScreen={fullScreen}
+                setFullScreen={setFullScreen}
+              />
+            )}
+            <Box
+              css={css`
+                display: flex;
+                align-items: center;
+                justify-content: center;
+                height: 100%;
+                padding: 20px;
+                text-align: center;
+              `}
+            >
+              <Box>
+                <Box
+                  css={css`
+                    font-size: 1.2rem;
+                    font-weight: 600;
+                    margin-bottom: 8px;
+                  `}
+                >
+                  {roomIdError || 'Loading channel...'}
+                </Box>
+                {roomIdError && (
+                  <Box
+                    css={css`
+                      font-size: 0.9rem;
+                      opacity: 0.7;
+                    `}
+                  >
+                    Please check the channel name and try again.
+                  </Box>
+                )}
+              </Box>
+            </Box>
+          </ToastBarProvider>
+        </Box>
+      </ThemeProvider>
+    );
+  }
+
   return (
     <ThemeProvider theme={theme || DefaultTheme} mode={dark ? 'dark' : 'light'}>
-      <RCInstanceProvider value={RCContextValue}>
+      <RCInstanceProvider
+        key={resolvedRoomId || 'pending'}
+        value={RCContextValue}
+      >
         <Box
           css={[
             styles.embeddedchat(theme || DefaultTheme, dark),


### PR DESCRIPTION
# Enable Channel Switching by Channel Name

Closes #452

## Overview

This PR adds the ability to switch channels using channel names instead of requiring room IDs. Previously, users had to find and provide the room ID to switch channels, which was difficult. Now, users can simply provide the channel name (e.g., "public", "embedded", "general") and the component will automatically resolve it to the correct room ID.

## Problem

Before this change, the `EmbeddedChat` component only supported switching channels using `roomId`. Channel IDs are not user-friendly and difficult to find, making it hard for developers to integrate the component with specific channels.

## Solution

The component now supports channel switching using the `channelName` prop. When `channelName` is provided:

1. The component waits for user authentication
2. Once authenticated, it calls the Rocket.Chat API to resolve the channel name to a room ID
3. The resolved room ID is used to connect to the correct channel
4. Messages and channel information are properly loaded for the resolved channel

## Changes

### Core Functionality

- Added `resolvedRoomId` state to manage dynamically resolved room IDs
- Added `explicitRoomId` state to track when a room ID is explicitly provided
- Implemented channel name to room ID resolution using `/api/v1/rooms.info?roomName=...` API endpoint
- Updated re-instantiation logic to properly clear messages when switching channels
- Added proper error handling for authentication and API failures

### UI Updates

- Updated `ChatHeader` to prioritize `channelName` prop for display
- Updated `ChatInput` placeholder to use `channelName` when available
- Added error handling for unauthorized channel info requests

### API Changes

- Updated `EmbeddedChatApi.channelInfo()` to check for authentication before making API calls
- Returns proper error response when authentication is not available

## Usage

### Using Channel Name (New)

```jsx
<EmbeddedChat
  host="http://localhost:3000"
  channelName="public"
  auth={{
    flow: 'PASSWORD'
  }}
/>
```

### Using Room ID (Still Supported)

```jsx
<EmbeddedChat
  host="http://localhost:3000"
  roomId="6956b4ced42fcf35f5783b1d"
  channelName="public"
  auth={{
    flow: 'PASSWORD'
  }}
/>
```

## How It Works

1. If `roomId` is explicitly provided, it is used directly
2. If only `channelName` is provided:
   - Component waits for user authentication
   - Once authenticated, makes API call to resolve channel name to room ID
   - Uses resolved room ID to connect to the channel
3. If neither is provided, defaults to "GENERAL" channel

## Before / After

<table>
<tr>
<th>Before</th>
</tr>
<tr>
<td align="center">
<img src="https://github.com/user-attachments/assets/6489496d-547b-43d0-95f4-57ce9ea9814a" alt="before" width="95%">
</td>
</tr>

<tr>
<th>After (with channel name)</th>
</tr>
<tr>
<td align="center">
<img src="https://github.com/user-attachments/assets/e03e7158-768e-4c58-859c-24925d04a303" alt="after channel name" width="95%">
</td>
</tr>

<tr>
<th>After (with room ID)</th>
</tr>
<tr>
<td align="center">
<img src="https://github.com/user-attachments/assets/cb6cb6d6-aee9-4758-acfb-f0ccca3ca6e2" alt="after room id" width="95%">
</td>
</tr>
</table>


## Technical Details

- The resolution happens asynchronously after authentication
- The component properly handles cases where authentication is not yet complete
- Messages and channel state are cleared when switching channels to prevent showing wrong channel data
- The component re-instantiates the connection when the resolved room ID changes

## Testing

- Tested with channel names: "public", "embedded", "general"
- Verified that channel switching works correctly with only channel name provided
- Verified that explicit room ID still works as before
- Verified that messages are properly cleared when switching channels
- Verified that authentication errors are handled gracefully
