### PR TITLE
fix: replace import assertion with readFileSync in rollup configs

### DIFF
--- a/packages/api/rollup.config.js
+++ b/packages/api/rollup.config.js
@@ -1,7 +1,13 @@
 import dts from 'rollup-plugin-dts'
 import esbuild from 'rollup-plugin-esbuild'
 import path from 'path';
-import packageJson from './package.json' with { type: 'json' };
+import { createRequire } from 'module';
+import { fileURLToPath } from 'url';
+
+const __filename = fileURLToPath(import.meta.url);
+const __dirname = path.dirname(__filename);
+const require = createRequire(import.meta.url);
+const packageJson = require(path.resolve(__dirname, './package.json'));
 
 const name = packageJson.main.replace(/\.js$/, '');
 

--- a/packages/api/rollup.config.js
+++ b/packages/api/rollup.config.js
@@ -1,9 +1,7 @@
 import dts from 'rollup-plugin-dts'
 import esbuild from 'rollup-plugin-esbuild'
 import path from 'path';
-import { readFileSync } from 'fs';
-
-const packageJson = JSON.parse(readFileSync('./package.json', 'utf-8'));
+import packageJson from './package.json' with { type: 'json' };
 
 const name = packageJson.main.replace(/\.js$/, '');
 

--- a/packages/api/rollup.config.js
+++ b/packages/api/rollup.config.js
@@ -1,7 +1,9 @@
 import dts from 'rollup-plugin-dts'
 import esbuild from 'rollup-plugin-esbuild'
-import packageJson from './package.json' assert { type: 'json' };
 import path from 'path';
+import { readFileSync } from 'fs';
+
+const packageJson = JSON.parse(readFileSync('./package.json', 'utf-8'));
 
 const name = packageJson.main.replace(/\.js$/, '');
 

--- a/packages/auth/rollup.config.js
+++ b/packages/auth/rollup.config.js
@@ -1,7 +1,13 @@
 import dts from 'rollup-plugin-dts'
 import esbuild from 'rollup-plugin-esbuild'
 import path from 'path';
-import packageJson from './package.json' with { type: 'json' };
+import { createRequire } from 'module';
+import { fileURLToPath } from 'url';
+
+const __filename = fileURLToPath(import.meta.url);
+const __dirname = path.dirname(__filename);
+const require = createRequire(import.meta.url);
+const packageJson = require(path.resolve(__dirname, './package.json'));
 
 const name = packageJson.main.replace(/\.js$/, '');
 

--- a/packages/auth/rollup.config.js
+++ b/packages/auth/rollup.config.js
@@ -1,9 +1,7 @@
 import dts from 'rollup-plugin-dts'
 import esbuild from 'rollup-plugin-esbuild'
 import path from 'path';
-import { readFileSync } from 'fs';
-
-const packageJson = JSON.parse(readFileSync('./package.json', 'utf-8'));
+import packageJson from './package.json' with { type: 'json' };
 
 const name = packageJson.main.replace(/\.js$/, '');
 

--- a/packages/auth/rollup.config.js
+++ b/packages/auth/rollup.config.js
@@ -1,7 +1,9 @@
 import dts from 'rollup-plugin-dts'
 import esbuild from 'rollup-plugin-esbuild'
 import path from 'path';
-import packageJson from './package.json' assert { type: 'json' };
+import { readFileSync } from 'fs';
+
+const packageJson = JSON.parse(readFileSync('./package.json', 'utf-8'));
 
 const name = packageJson.main.replace(/\.js$/, '');
 


### PR DESCRIPTION
- Replace 'import packageJson from ./package.json assert { type: 'json' }' with readFileSync
- Fixes build error: SyntaxError: Unexpected identifier 'assert'
- Affects packages/auth and packages/api rollup.config.js files
- Uses Node.js fs.readFileSync which is compatible with Rollup parser


Closes #1050

Mac Recording
https://github.com/user-attachments/assets/257f6cb5-2632-4da9-9157-99849ca26934


