### PR TITLE
feat: Enabling users to send thread messages as preview in main chat

### DIFF
--- a/packages/api/src/EmbeddedChatApi.ts
+++ b/packages/api/src/EmbeddedChatApi.ts
@@ -741,7 +741,11 @@ export default class EmbeddedChatApi {
    * @param {*} message should be a string or an rc message object
    * Refer https://developer.rocket.chat/reference/api/schema-definition/message#message-object
    */
-  async sendMessage(message: any, threadId: string, isAlsoSendToChannel: boolean) {
+  async sendMessage(
+    message: any,
+    threadId: string,
+    isAlsoSendToChannel: boolean
+  ) {
     const messageObj =
       typeof message === "string"
         ? {
@@ -750,34 +754,35 @@ export default class EmbeddedChatApi {
           }
         : {
             ...message,
-            rid: this.rid,  
+            rid: this.rid,
           };
     if (threadId) {
       messageObj.tmid = threadId;
     }
-    if(isAlsoSendToChannel){
-      messageObj.tshow = true
+    if (isAlsoSendToChannel) {
+      messageObj.tshow = true;
     }
     try {
       const { userId, authToken } = (await this.auth.getCurrentUser()) || {};
-      const response = await fetch(`${this.host}/api/v1/method.call/sendMessage`, {
-        body: JSON.stringify({
-          message: JSON.stringify({
-            msg: "method",
-            id: null,
-            method: "sendMessage",
-            params: [
-              messageObj
-            ],
+      const response = await fetch(
+        `${this.host}/api/v1/method.call/sendMessage`,
+        {
+          body: JSON.stringify({
+            message: JSON.stringify({
+              msg: "method",
+              id: null,
+              method: "sendMessage",
+              params: [messageObj],
+            }),
           }),
-        }),
-        headers: {
-          "Content-Type": "application/json",
-          "X-Auth-Token": authToken,
-          "X-User-Id": userId,
-        },
-        method: "POST",
-      });
+          headers: {
+            "Content-Type": "application/json",
+            "X-Auth-Token": authToken,
+            "X-User-Id": userId,
+          },
+          method: "POST",
+        }
+      );
       const result = await response.json();
       return result;
     } catch (err) {

--- a/packages/api/src/EmbeddedChatApi.ts
+++ b/packages/api/src/EmbeddedChatApi.ts
@@ -741,7 +741,7 @@ export default class EmbeddedChatApi {
    * @param {*} message should be a string or an rc message object
    * Refer https://developer.rocket.chat/reference/api/schema-definition/message#message-object
    */
-  async sendMessage(message: any, threadId: string) {
+  async sendMessage(message: any, threadId: string, isAlsoSendToChannel: boolean) {
     const messageObj =
       typeof message === "string"
         ? {
@@ -750,15 +750,27 @@ export default class EmbeddedChatApi {
           }
         : {
             ...message,
-            rid: this.rid,
+            rid: this.rid,  
           };
     if (threadId) {
       messageObj.tmid = threadId;
     }
+    if(isAlsoSendToChannel){
+      messageObj.tshow = true
+    }
     try {
       const { userId, authToken } = (await this.auth.getCurrentUser()) || {};
-      const response = await fetch(`${this.host}/api/v1/chat.sendMessage`, {
-        body: JSON.stringify({ message: messageObj }),
+      const response = await fetch(`${this.host}/api/v1/method.call/sendMessage`, {
+        body: JSON.stringify({
+          message: JSON.stringify({
+            msg: "method",
+            id: null,
+            method: "sendMessage",
+            params: [
+              messageObj
+            ],
+          }),
+        }),
         headers: {
           "Content-Type": "application/json",
           "X-Auth-Token": authToken,
@@ -766,7 +778,8 @@ export default class EmbeddedChatApi {
         },
         method: "POST",
       });
-      return await response.json();
+      const result = await response.json();
+      return result;
     } catch (err) {
       console.error(err);
     }

--- a/packages/react-native/src/components/ChatInput/ChatInput.js
+++ b/packages/react-native/src/components/ChatInput/ChatInput.js
@@ -112,7 +112,7 @@ const ChatInput = ({ style }) => {
 					await RCInstance.logout();
 					setIsUserAuthenticated(false);
 				} else {
-					replaceMessage(pendingMessage._id, res.message);
+					replaceMessage(pendingMessage._id, res.message.id);
 				}
 			} else {
 				// A message is being edited

--- a/packages/react/src/lib/isMessageSequential.js
+++ b/packages/react/src/lib/isMessageSequential.js
@@ -5,7 +5,7 @@ const isMessageSequential = (current, previous, groupingRange) => {
     return false;
   }
 
-  if (current.t || previous.t) {
+  if (current.t || previous.t || current.tshow || previous.tshow) {
     return false;
   }
 

--- a/packages/react/src/store/messageStore.js
+++ b/packages/react/src/store/messageStore.js
@@ -41,6 +41,11 @@ const useMessageStore = create((set, get) => ({
           threadMessages: upsertMessage(state.threadMessages, message),
         }));
       }
+      if (message.tshow) {
+        set((state) => ({
+          messages: upsertMessage(state.messages, message),
+        }));
+      }
     } else {
       set((state) => ({
         messages: upsertMessage(state.messages, message),

--- a/packages/react/src/views/ChatInput/ChatInput.js
+++ b/packages/react/src/views/ChatInput/ChatInput.js
@@ -11,6 +11,7 @@ import {
   useToastBarDispatch,
   useComponentOverrides,
   useTheme,
+  CheckBox,
 } from '@embeddedchat/ui-elements';
 import { useRCContext } from '../../context/RCInstance';
 import {
@@ -34,7 +35,6 @@ import useShowCommands from '../../hooks/useShowCommands';
 import useSearchMentionUser from '../../hooks/useSearchMentionUser';
 import formatSelection from '../../lib/formatSelection';
 import { parseEmoji } from '../../lib/emoji';
-import { CheckBox } from '@embeddedchat/ui-elements';
 
 const ChatInput = ({ scrollToBottom }) => {
   const { styleOverrides, classNames } = useComponentOverrides('ChatInput');
@@ -145,9 +145,7 @@ const ChatInput = ({ scrollToBottom }) => {
     setShowMembersList
   );
 
-  const [isThreadOpen] = useMessageStore((state) => ([
-    state.isThreadOpen
-  ]))
+  const [isThreadOpen] = useMessageStore((state) => [state.isThreadOpen]);
 
   useEffect(() => {
     RCInstance.auth.onAuthChange((user) => {
@@ -335,11 +333,11 @@ const ChatInput = ({ scrollToBottom }) => {
         _id: pendingMessage._id,
       },
       ECOptions.enableThreads ? threadId : undefined,
-      ECOptions.enableThreads && threadId && isAlsoSendToChannel? true: false
+      ECOptions.enableThreads && threadId && isAlsoSendToChannel
     );
 
     if (res.success) {
-      setIsAlsoSendToChannel(false)
+      setIsAlsoSendToChannel(false);
       clearQuoteMessages();
       replaceMessage(pendingMessage, res.message);
     }
@@ -441,9 +439,9 @@ const ChatInput = ({ scrollToBottom }) => {
     }
   };
 
-  const handleAlsoSendToChannel =() => {
-    setIsAlsoSendToChannel(!isAlsoSendToChannel)
-  }
+  const handleAlsoSendToChannel = () => {
+    setIsAlsoSendToChannel(!isAlsoSendToChannel);
+  };
 
   const onKeyDown = (e) => {
     switch (true) {
@@ -597,104 +595,109 @@ const ChatInput = ({ scrollToBottom }) => {
 
         <TypingUsers />
       </Box>
-      
+
       <Box
         css={css`
           display: flex;
           flex-direction: column;
           width: 100%;
-
         `}
       >
-        {isThreadOpen && ( 
-          <Box
+        {isThreadOpen && (
+          <Box css={[styles.sendToChannelCheckBox]}>
+            <CheckBox
+              onClick={handleAlsoSendToChannel}
+              checked={isAlsoSendToChannel}
+            />
+            <p
+              css={css`
+                display: inline;
+              `}
+            >
+              Also Send to channel
+            </p>
+          </Box>
+        )}
+
+        <Box
+          ref={chatInputContainer}
           css={[
-            styles.sendToChannelCheckBox,
+            styles.inputWithFormattingBox,
+            (editMessage.msg || editMessage.attachments) && styles.editMessage,
           ]}
         >
-         <CheckBox 
-          onClick={handleAlsoSendToChannel}
-          checked={isAlsoSendToChannel}
-         />
-         <p css={css`
-            display: inline
-          `}>Also Send to channel</p>
-        </Box>)}
-       
-      <Box
-        ref={chatInputContainer}
-        css={[
-          styles.inputWithFormattingBox,
-          (editMessage.msg || editMessage.attachments) && styles.editMessage,
-        ]}
-      >  
-        <Box css={styles.inputBox}>  
-          <Input
-            textArea
-            rows={1}
-            disabled={
-              !isUserAuthenticated ||
-              !canSendMsg ||
-              isRecordingMessage ||
-              isChannelArchived
-            }
-            placeholder={
-              isUserAuthenticated
-                ? isChannelArchived
-                  ? 'Room archived'
-                  : canSendMsg
-                  ? `Message #${channelInfo.name}`
-                  : 'This room is read only'
-                : 'Sign in to chat'
-            }
-            css={css`
-              ${styles.textInput}
-              ${isChannelArchived &&
-              isUserAuthenticated &&
-              `text-align: center;`}
-            `}
-            onChange={onTextChange}
-            onBlur={() => {
-              sendTypingStop();
-              handleBlur();
-            }}
-            onFocus={handleFocus}
-            onKeyDown={onKeyDown}
-            ref={messageRef}
-          />
+          <Box css={styles.inputBox}>
+            <Input
+              textArea
+              rows={1}
+              disabled={
+                !isUserAuthenticated ||
+                !canSendMsg ||
+                isRecordingMessage ||
+                isChannelArchived
+              }
+              placeholder={
+                isUserAuthenticated
+                  ? isChannelArchived
+                    ? 'Room archived'
+                    : canSendMsg
+                    ? `Message #${channelInfo.name}`
+                    : 'This room is read only'
+                  : 'Sign in to chat'
+              }
+              css={css`
+                ${styles.textInput}
+                ${isChannelArchived &&
+                isUserAuthenticated &&
+                `text-align: center;`}
+              `}
+              onChange={onTextChange}
+              onBlur={() => {
+                sendTypingStop();
+                handleBlur();
+              }}
+              onFocus={handleFocus}
+              onKeyDown={onKeyDown}
+              ref={messageRef}
+            />
 
-          <input type="file" hidden ref={inputRef} onChange={sendAttachment} />
-          <Box
-            css={css`
-              padding: 0.25rem;
-            `}
-          >
-            {isUserAuthenticated ? (
-              !isChannelArchived ? (
-                <ActionButton
-                  ghost
-                  size="large"
-                  onClick={() => sendMessage()}
-                  type="primary"
-                  disabled={disableButton || isRecordingMessage}
-                  icon="send"
-                />
-              ) : null
-            ) : (
-              <Button onClick={onJoin} type="primary" disabled={isLoginIn}>
-                {isLoginIn ? <Throbber /> : 'JOIN'}
-              </Button>
-            )}
+            <input
+              type="file"
+              hidden
+              ref={inputRef}
+              onChange={sendAttachment}
+            />
+            <Box
+              css={css`
+                padding: 0.25rem;
+              `}
+            >
+              {isUserAuthenticated ? (
+                !isChannelArchived ? (
+                  <ActionButton
+                    ghost
+                    size="large"
+                    onClick={() => sendMessage()}
+                    type="primary"
+                    disabled={disableButton || isRecordingMessage}
+                    icon="send"
+                  />
+                ) : null
+              ) : (
+                <Button onClick={onJoin} type="primary" disabled={isLoginIn}>
+                  {isLoginIn ? <Throbber /> : 'JOIN'}
+                </Button>
+              )}
+            </Box>
           </Box>
+          {isUserAuthenticated && !isChannelArchived && (
+            <ChatInputFormattingToolbar
+              messageRef={messageRef}
+              inputRef={inputRef}
+              triggerButton={onTextChange}
+            />
+          )}
         </Box>
-        {isUserAuthenticated && !isChannelArchived && (
-          <ChatInputFormattingToolbar
-            messageRef={messageRef}
-            inputRef={inputRef}
-            triggerButton={onTextChange}
-          />
-        )}
-      </Box>
       </Box>
       {isMsgLong && (
         <Modal

--- a/packages/react/src/views/ChatInput/ChatInput.js
+++ b/packages/react/src/views/ChatInput/ChatInput.js
@@ -34,6 +34,7 @@ import useShowCommands from '../../hooks/useShowCommands';
 import useSearchMentionUser from '../../hooks/useSearchMentionUser';
 import formatSelection from '../../lib/formatSelection';
 import { parseEmoji } from '../../lib/emoji';
+import { CheckBox } from '@embeddedchat/ui-elements';
 
 const ChatInput = ({ scrollToBottom }) => {
   const { styleOverrides, classNames } = useComponentOverrides('ChatInput');
@@ -57,6 +58,7 @@ const ChatInput = ({ scrollToBottom }) => {
   const [showCommandList, setShowCommandList] = useState(false);
   const [filteredCommands, setFilteredCommands] = useState([]);
   const [isMsgLong, setIsMsgLong] = useState(false);
+  const [isAlsoSendToChannel, setIsAlsoSendToChannel] = useState(false);
 
   const {
     isUserAuthenticated,
@@ -142,6 +144,10 @@ const ChatInput = ({ scrollToBottom }) => {
     setMentionIndex,
     setShowMembersList
   );
+
+  const [isThreadOpen] = useMessageStore((state) => ([
+    state.isThreadOpen
+  ]))
 
   useEffect(() => {
     RCInstance.auth.onAuthChange((user) => {
@@ -328,10 +334,12 @@ const ChatInput = ({ scrollToBottom }) => {
         msg: pendingMessage.msg,
         _id: pendingMessage._id,
       },
-      ECOptions.enableThreads ? threadId : undefined
+      ECOptions.enableThreads ? threadId : undefined,
+      ECOptions.enableThreads && threadId && isAlsoSendToChannel? true: false
     );
 
     if (res.success) {
+      setIsAlsoSendToChannel(false)
       clearQuoteMessages();
       replaceMessage(pendingMessage, res.message);
     }
@@ -432,6 +440,10 @@ const ChatInput = ({ scrollToBottom }) => {
       chatInputContainer.current.classList.remove('focused');
     }
   };
+
+  const handleAlsoSendToChannel =() => {
+    setIsAlsoSendToChannel(!isAlsoSendToChannel)
+  }
 
   const onKeyDown = (e) => {
     switch (true) {
@@ -585,14 +597,38 @@ const ChatInput = ({ scrollToBottom }) => {
 
         <TypingUsers />
       </Box>
+      
+      <Box
+        css={css`
+          display: flex;
+          flex-direction: column;
+          width: 100%;
+
+        `}
+      >
+        {isThreadOpen && ( 
+          <Box
+          css={[
+            styles.sendToChannelCheckBox,
+          ]}
+        >
+         <CheckBox 
+          onClick={handleAlsoSendToChannel}
+          checked={isAlsoSendToChannel}
+         />
+         <p css={css`
+            display: inline
+          `}>Also Send to channel</p>
+        </Box>)}
+       
       <Box
         ref={chatInputContainer}
         css={[
           styles.inputWithFormattingBox,
           (editMessage.msg || editMessage.attachments) && styles.editMessage,
         ]}
-      >
-        <Box css={styles.inputBox}>
+      >  
+        <Box css={styles.inputBox}>  
           <Input
             textArea
             rows={1}
@@ -658,6 +694,7 @@ const ChatInput = ({ scrollToBottom }) => {
             triggerButton={onTextChange}
           />
         )}
+      </Box>
       </Box>
       {isMsgLong && (
         <Modal

--- a/packages/react/src/views/ChatInput/ChatInput.styles.js
+++ b/packages/react/src/views/ChatInput/ChatInput.styles.js
@@ -3,6 +3,12 @@ import { darken, lighten } from '@embeddedchat/ui-elements';
 
 export const getChatInputStyles = (theme) => {
   const styles = {
+    sendToChannelCheckBox :
+      css`
+         margin: 0.5rem 0rem 0rem 2rem;
+         display: flex,
+         flex-direction: row;
+      `,
     inputWithFormattingBox: css`
       border: 1px solid ${theme.colors.border};
       border-radius: ${theme.radius};

--- a/packages/react/src/views/ChatInput/ChatInput.styles.js
+++ b/packages/react/src/views/ChatInput/ChatInput.styles.js
@@ -3,8 +3,7 @@ import { darken, lighten } from '@embeddedchat/ui-elements';
 
 export const getChatInputStyles = (theme) => {
   const styles = {
-    sendToChannelCheckBox :
-      css`
+    sendToChannelCheckBox: css`
          margin: 0.5rem 0rem 0rem 2rem;
          display: flex,
          flex-direction: row;

--- a/packages/react/src/views/ChatInput/ChatInputFormattingToolbar.js
+++ b/packages/react/src/views/ChatInput/ChatInputFormattingToolbar.js
@@ -1,4 +1,4 @@
-import React, { useState, useRef, useEffect } from 'react';
+import React, { useState, useRef } from 'react';
 import { css } from '@emotion/react';
 import {
   Box,

--- a/packages/react/src/views/Message/Message.js
+++ b/packages/react/src/views/Message/Message.js
@@ -42,7 +42,7 @@ const Message = ({
   showRoles = true,
   isLinkPreview = true,
   isInSidebar = false,
-  prev
+  prev,
 }) => {
   const { classNames, styleOverrides, variantOverrides } =
     useComponentOverrides(
@@ -52,7 +52,9 @@ const Message = ({
     );
 
   const { RCInstance, ECOptions } = useContext(RCContext);
-  showAvatar = (type === 'thread') || (ECOptions?.showAvatar && showAvatar && (!message.tshow));
+  showAvatar =
+    type === 'thread' ||
+    (ECOptions?.showAvatar && showAvatar && !message.tshow);
   const { showSidebar, setShowSidebar } = useSidebarStore();
   const authenticatedUserId = useUserStore((state) => state.userId);
   const authenticatedUserUsername = useUserStore((state) => state.username);
@@ -224,7 +226,9 @@ const Message = ({
   const isStarred = message.starred?.find((u) => u._id === authenticatedUserId);
   const isPinned = message.pinned;
   // const shouldShowHeader = (!sequential || (!showAvatar && isStarred)) && !message.tshow;
-   const shouldShowHeader = (type === 'thread' && !sequential) || (type === 'default' && (!sequential && !message.tshow));
+  const shouldShowHeader =
+    (type === 'thread' && !sequential) ||
+    (type === 'default' && !sequential && !message.tshow);
 
   return (
     <>
@@ -378,12 +382,12 @@ const Message = ({
             />
           ) : null}
           {!!message.tshow && type !== 'thread' ? (
-            <ThreadMessagePreview 
+            <ThreadMessagePreview
               message={message}
               sequential={sequential}
               prev={prev}
             />
-          ):null}
+          ) : null}
         </MessageBodyContainer>
       </Box>
     </>

--- a/packages/react/src/views/Message/Message.js
+++ b/packages/react/src/views/Message/Message.js
@@ -27,6 +27,7 @@ import { getMessageStyles } from './Message.styles';
 import useBubbleStyles from './BubbleVariant/useBubbleStyles';
 import UiKitMessageBlock from './uiKit/UiKitMessageBlock';
 import useFetchChatData from '../../hooks/useFetchChatData';
+import { ThreadMessagePreview } from './ThreadMessagePreview';
 
 const Message = ({
   message,
@@ -41,6 +42,7 @@ const Message = ({
   showRoles = true,
   isLinkPreview = true,
   isInSidebar = false,
+  prev
 }) => {
   const { classNames, styleOverrides, variantOverrides } =
     useComponentOverrides(
@@ -50,7 +52,7 @@ const Message = ({
     );
 
   const { RCInstance, ECOptions } = useContext(RCContext);
-  showAvatar = ECOptions?.showAvatar && showAvatar;
+  showAvatar = (type === 'thread') || (ECOptions?.showAvatar && showAvatar && (!message.tshow));
   const { showSidebar, setShowSidebar } = useSidebarStore();
   const authenticatedUserId = useUserStore((state) => state.userId);
   const authenticatedUserUsername = useUserStore((state) => state.username);
@@ -221,7 +223,8 @@ const Message = ({
 
   const isStarred = message.starred?.find((u) => u._id === authenticatedUserId);
   const isPinned = message.pinned;
-  const shouldShowHeader = !sequential || (!showAvatar && isStarred);
+  // const shouldShowHeader = (!sequential || (!showAvatar && isStarred)) && !message.tshow;
+   const shouldShowHeader = (type === 'thread' && !sequential) || (type === 'default' && (!sequential && !message.tshow));
 
   return (
     <>
@@ -260,7 +263,7 @@ const Message = ({
               })}
             />
           )}
-          {!message.t ? (
+          {!message.t && (type === 'thread' || !message.tshow) ? (
             <>
               <MessageBody
                 className="ec-message-body"
@@ -374,6 +377,13 @@ const Message = ({
               variantStyles={variantStyles}
             />
           ) : null}
+          {!!message.tshow && type !== 'thread' ? (
+            <ThreadMessagePreview 
+              message={message}
+              sequential={sequential}
+              prev={prev}
+            />
+          ):null}
         </MessageBodyContainer>
       </Box>
     </>

--- a/packages/react/src/views/Message/Message.styles.js
+++ b/packages/react/src/views/Message/Message.styles.js
@@ -332,13 +332,12 @@ export const getThreadPreviewContainerStyles = () => {
       display: flex;
       flex-direction: row;
       gap: '5px';
-      alignItems: 'center';
+      alignitems: 'center';
       gap: 5px;
-      
-    `
-  }
-  return styles
-}
+    `,
+  };
+  return styles;
+};
 
 export const getThreadPreviewAvatarStylesContainer = (theme) => {
   const styles = {

--- a/packages/react/src/views/Message/Message.styles.js
+++ b/packages/react/src/views/Message/Message.styles.js
@@ -325,3 +325,31 @@ export const getMessageBodyContainerStyles = () => {
 
   return styles;
 };
+
+export const getThreadPreviewContainerStyles = () => {
+  const styles = {
+    container: css`
+      display: flex;
+      flex-direction: row;
+      gap: '5px';
+      alignItems: 'center';
+      gap: 5px;
+      
+    `
+  }
+  return styles
+}
+
+export const getThreadPreviewAvatarStylesContainer = (theme) => {
+  const styles = {
+    container: css`
+      margin: 3px;
+      width: 2.25em;
+      max-height: 2.25em;
+      display: flex;
+      justify-content: flex-end;
+      color: ${theme.colors.primary};
+    `,
+  };
+  return styles;
+};

--- a/packages/react/src/views/Message/ThreadMessageAvatarContainer.js
+++ b/packages/react/src/views/Message/ThreadMessageAvatarContainer.js
@@ -1,0 +1,44 @@
+import React, { useContext } from 'react';
+import {
+  Box,
+  Avatar,
+  Icon,
+  Tooltip,
+  useTheme,
+} from '@embeddedchat/ui-elements';
+import RCContext from '../../context/RCInstance';
+import { getMessageAvatarContainerStyles } from './Message.styles';
+
+import useSetExclusiveState from '../../hooks/useSetExclusiveState';
+import { useUserStore } from '../../store';
+
+export const ThreadMessageAvatarContainer = ({
+  message,
+  sequential,
+  isStarred,
+  isPinned,
+}) => {
+  const { RCInstance } = useContext(RCContext);
+  const { theme } = useTheme();
+  const getUserAvatarUrl = (username) => {
+    const host = RCInstance.getHost();
+    const URL = `${host}/avatar/${username}`;
+    return URL;
+  };
+
+  const setExclusiveState = useSetExclusiveState();
+  const { setShowCurrentUserInfo, setCurrentUser } = useUserStore((state) => ({
+    setShowCurrentUserInfo: state.setShowCurrentUserInfo, // don't think we need these both as we are opening a container
+    setCurrentUser: state.setCurrentUser,
+  }));
+
+  return (
+    <Box>
+      <Avatar
+        url={getUserAvatarUrl(message.u.username)}
+        alt="avatar"
+        size="1em"
+      />
+    </Box>
+  );
+};

--- a/packages/react/src/views/Message/ThreadMessagePreview.js
+++ b/packages/react/src/views/Message/ThreadMessagePreview.js
@@ -1,0 +1,57 @@
+import React from 'react';
+import {
+  appendClassNames,
+  Box,
+  Icon,
+  Skeleton,
+} from '@embeddedchat/ui-elements';
+import { ThreadMessageAvatarContainer } from './ThreadMessageAvatarContainer';
+import { getThreadPreviewContainerStyles } from './Message.styles';
+import useMessageStore from '../../store/messageStore';
+
+export const ThreadMessagePreview = ({
+  message,
+  showUserAvatar,
+  sequential,
+  prev,
+  ...props
+}) => {
+  const styles = getThreadPreviewContainerStyles();
+  const messages = useMessageStore((state) => state.messages);
+  const threadMessages = useMessageStore((state) => state.threadMessages);
+  const parentMessage = messages.find((msg) => msg._id === message.tmid);
+
+  return (
+    <>
+      {sequential ? (
+        <Box className={appendClassNames('ec-message')} css={styles.container}>
+          <ThreadMessageAvatarContainer
+            message={message}
+            sequential={sequential}
+          />
+          <Box css={{ display: 'inline' }}>{message.msg}</Box>
+        </Box>
+      ) : (
+        <Box>
+          <Box>
+            {parentMessage && parentMessage._id !== prev?._id && (
+              <Box css={styles.container}>
+                <Icon name="thread" size="1.2em" />
+                {parentMessage.msg}
+              </Box>
+            )}
+            <Box css={styles.container}>
+              <Box>
+                <ThreadMessageAvatarContainer
+                  message={message}
+                  sequential={sequential}
+                />
+              </Box>
+              <Box css={{ display: 'inline' }}>{message.msg}</Box>
+            </Box>
+          </Box>
+        </Box>
+      )}
+    </>
+  );
+};

--- a/packages/react/src/views/MessageList/MessageList.js
+++ b/packages/react/src/views/MessageList/MessageList.js
@@ -10,6 +10,7 @@ import { Message } from '../Message';
 import isMessageLastSequential from '../../lib/isMessageLastSequential';
 import { MessageBody } from '../Message/MessageBody';
 
+
 const MessageList = ({
   messages,
   loadingOlderMessages,
@@ -24,8 +25,10 @@ const MessageList = ({
   const isMessageNewDay = (current, previous) =>
     !previous || !isSameDay(new Date(current.ts), new Date(previous.ts));
 
-  const filteredMessages = messages.filter((msg) => !msg.tmid);
 
+  const filteredMessages = messages.filter((msg) => (
+    (!!msg.tmid && msg.tshow) || (!msg.tmid)
+  ))
   const reportedMessage = messages.find((msg) => msg._id === messageToReport);
 
   return (
@@ -96,6 +99,7 @@ const MessageList = ({
                   lastSequential={lastSequential}
                   type="default"
                   showAvatar
+                  prev={prev}
                 />
               );
             })}

--- a/packages/react/src/views/MessageList/MessageList.js
+++ b/packages/react/src/views/MessageList/MessageList.js
@@ -10,7 +10,6 @@ import { Message } from '../Message';
 import isMessageLastSequential from '../../lib/isMessageLastSequential';
 import { MessageBody } from '../Message/MessageBody';
 
-
 const MessageList = ({
   messages,
   loadingOlderMessages,
@@ -25,10 +24,9 @@ const MessageList = ({
   const isMessageNewDay = (current, previous) =>
     !previous || !isSameDay(new Date(current.ts), new Date(previous.ts));
 
-
-  const filteredMessages = messages.filter((msg) => (
-    (!!msg.tmid && msg.tshow) || (!msg.tmid)
-  ))
+  const filteredMessages = messages.filter(
+    (msg) => (!!msg.tmid && msg.tshow) || !msg.tmid
+  );
   const reportedMessage = messages.find((msg) => msg._id === messageToReport);
 
   return (


### PR DESCRIPTION
# Brief Title
Enable previewing thread messages in the main chat flow

## Acceptance Criteria fulfillment

- [x] Enabling the checkbox should send a preview of the thread message in the main channel
- [x] UI for sequential threadPreview and not sequential should be handled.

Fixes #1053 

## Video/Screenshots
<img width="715" height="876" alt="image" src="https://github.com/user-attachments/assets/44096e05-79d3-46ed-ac62-8c489e9a342d" />
<img width="695" height="332" alt="image" src="https://github.com/user-attachments/assets/c90b01f6-9a61-485d-b4cc-181fd711cef9" />
<img width="742" height="663" alt="image" src="https://github.com/user-attachments/assets/37deb110-4373-469b-9cdd-65ed83abeb8f" />


## PR Test Details

**Note**: The PR will be ready for live testing at https://rocketchat.github.io/EmbeddedChat/pulls/pr-<pr_number> after approval. Contributors are requested to replace `<pr_number>` with the actual PR number.
