### PR TITLE
fix: mobile header layout overlap

### DIFF
--- a/packages/react/src/views/ChatHeader/ChatHeader.js
+++ b/packages/react/src/views/ChatHeader/ChatHeader.js
@@ -399,6 +399,9 @@ const ChatHeader = ({
                       <div
                         css={css`
                           font-size: ${fullScreen ? '1.3rem' : '1.25rem'};
+                          overflow: hidden;
+                          text-overflow: ellipsis;
+                          white-space: nowrap;
                         `}
                       >
                         {channelInfo.name || channelName || 'channelName'}

--- a/packages/react/src/views/ChatHeader/ChatHeader.styles.js
+++ b/packages/react/src/views/ChatHeader/ChatHeader.styles.js
@@ -18,6 +18,8 @@ const getChatHeaderStyles = ({ theme, mode }) => {
       padding: 0 0.75rem;
       justify-content: space-between;
       width: 100%;
+      flex-wrap: wrap;
+      gap: 0.5rem;
     `,
 
     chatHeaderParent: css`
@@ -42,7 +44,7 @@ const getChatHeaderStyles = ({ theme, mode }) => {
     channelDescription: css`
       ${rowCentreAlign}
       flex: 1;
-      min-width: 0;
+      min-width: 120px;
       gap: 0.5rem;
       overflow: hidden;
     `,
@@ -52,8 +54,10 @@ const getChatHeaderStyles = ({ theme, mode }) => {
       position: relative;
       gap: 0.5rem;
       flex-shrink: 0;
-      @media (max-width: 480px) {
+      @media (max-width: 380px) {
         gap: 0.25rem;
+        flex-wrap: wrap;
+        justify-content: flex-end;
       }
     `,
     channelName: css`

--- a/packages/react/src/views/ChatHeader/ChatHeader.styles.js
+++ b/packages/react/src/views/ChatHeader/ChatHeader.styles.js
@@ -44,18 +44,26 @@ const getChatHeaderStyles = ({ theme, mode }) => {
       flex: 1;
       min-width: 0;
       gap: 0.5rem;
+      overflow: hidden;
     `,
 
     chatHeaderIconRow: css`
       ${rowCentreAlign}
-      position:relative;
+      position: relative;
       gap: 0.5rem;
+      flex-shrink: 0;
+      @media (max-width: 480px) {
+        gap: 0.25rem;
+      }
     `,
     channelName: css`
       display: flex;
       align-items: center;
       gap: 0.1rem;
       cursor: pointer;
+      overflow: hidden;
+      text-overflow: ellipsis;
+      white-space: nowrap;
     `,
     channelTopic: css`
       opacity: 0.8rem;


### PR DESCRIPTION
# Brief Title
Fix mobile header layout overlap

## Acceptance Criteria fulfillment

- [x] Header icons wrap naturally when there are too many (Stormy Seas variant)
- [x] Light theme with fewer icons stays on one line
- [x] Channel name maintains minimum width (120px) and doesn't get squished
- [x] Icons wrap to second row at narrow widths (≤380px) when needed

Fixes #1065

## Video/Screenshots

https://github.com/user-attachments/assets/bd3c0617-7778-4d61-94f3-8a82ee13aa7a


## PR Test Details

**Note**: The PR will be ready for live testing at https://rocketchat.github.io/EmbeddedChat/pulls/pr-1066 after approval. Contributors are requested to replace `<pr_number>` with the actual PR number.
