### PR TITLE
fix: update file upload to use RC 8.x rooms.media API

### DIFF
--- a/packages/api/src/EmbeddedChatApi.ts
+++ b/packages/api/src/EmbeddedChatApi.ts
@@ -1061,7 +1061,6 @@ export default class EmbeddedChatApi {
         return;
       }
 
-      // Step 1: Upload file to rooms.media endpoint (RC 8.x)
       const form = new FormData();
       form.append("file", file, fileName);
 

--- a/packages/api/src/EmbeddedChatApi.ts
+++ b/packages/api/src/EmbeddedChatApi.ts
@@ -1046,26 +1046,55 @@ export default class EmbeddedChatApi {
   ) {
     try {
       const { userId, authToken } = (await this.auth.getCurrentUser()) || {};
-      const form = new FormData();
-      if (threadId) {
-        form.append("tmid", threadId);
+      if (!userId || !authToken) {
+        console.error("sendAttachment: User not authenticated");
+        return;
       }
+
+      // Step 1: Upload file to rooms.media endpoint (RC 8.x)
+      const form = new FormData();
       form.append("file", file, fileName);
-      form.append(
-        "description",
-        fileDescription.length !== 0 ? fileDescription : ""
+
+      const uploadResponse = await fetch(
+        `${this.host}/api/v1/rooms.media/${this.rid}`,
+        {
+          method: "POST",
+          body: form,
+          headers: {
+            "X-Auth-Token": authToken,
+            "X-User-Id": userId,
+          },
+        }
       );
-      const response = fetch(`${this.host}/api/v1/rooms.upload/${this.rid}`, {
-        method: "POST",
-        body: form,
-        headers: {
-          "X-Auth-Token": authToken,
-          "X-User-Id": userId,
-        },
-      }).then((r) => r.json());
-      return response;
+
+      const uploadResult = await uploadResponse.json();
+
+      if (!uploadResult.success || !uploadResult.file?._id) {
+        console.error("sendAttachment: Upload failed", uploadResult);
+        return uploadResult;
+      }
+
+      // Step 2: Confirm the upload with message details
+      const confirmResponse = await fetch(
+        `${this.host}/api/v1/rooms.mediaConfirm/${this.rid}/${uploadResult.file._id}`,
+        {
+          method: "POST",
+          headers: {
+            "Content-Type": "application/json",
+            "X-Auth-Token": authToken,
+            "X-User-Id": userId,
+          },
+          body: JSON.stringify(
+            threadId
+              ? { msg: "", description: fileDescription || "", tmid: threadId }
+              : { msg: "", description: fileDescription || "" }
+          ),
+        }
+      );
+
+      return await confirmResponse.json();
     } catch (err) {
-      console.log(err);
+      console.error("sendAttachment error:", err);
     }
   }
 

--- a/packages/api/src/EmbeddedChatApi.ts
+++ b/packages/api/src/EmbeddedChatApi.ts
@@ -1083,7 +1083,6 @@ export default class EmbeddedChatApi {
         return uploadResult;
       }
 
-      // Step 2: Confirm the upload with message details
       const confirmResponse = await fetch(
         `${this.host}/api/v1/rooms.mediaConfirm/${this.rid}/${uploadResult.file._id}`,
         {

--- a/packages/react/src/views/ChatInput/ChatInput.js
+++ b/packages/react/src/views/ChatInput/ChatInput.js
@@ -120,9 +120,10 @@ const ChatInput = ({ scrollToBottom, clearUnreadDividerRef }) => {
   );
   const isLoginIn = useLoginStore((state) => state.isLoginIn);
 
-  const { toggle, setData } = useAttachmentWindowStore((state) => ({
+  const { toggle, setData, data } = useAttachmentWindowStore((state) => ({
     toggle: state.toggle,
     setData: state.setData,
+    data: state.data,
   }));
 
   const userInfo = { _id: userId, username, name };
@@ -183,6 +184,13 @@ const ChatInput = ({ scrollToBottom, clearUnreadDividerRef }) => {
       setEditMessage({});
     }
   }, [deletedMessage]);
+
+ 
+  useEffect(() => {
+    if (data === null && inputRef.current) {
+      inputRef.current.value = '';
+    }
+  }, [data]);
 
   const getMessageLink = async (id) => {
     const host = RCInstance.getHost();

--- a/packages/react/src/views/ChatInput/ChatInput.js
+++ b/packages/react/src/views/ChatInput/ChatInput.js
@@ -148,7 +148,7 @@ const ChatInput = ({ scrollToBottom, clearUnreadDividerRef }) => {
     RCInstance.auth.onAuthChange((user) => {
       if (user) {
         RCInstance.getCommandsList()
-          .then((data) => setCommands(data.commands || []))
+          .then((response) => setCommands(response.commands || []))
           .catch(console.error);
 
         RCInstance.getChannelMembers(isChannelPrivate)

--- a/packages/react/src/views/ChatInput/ChatInput.js
+++ b/packages/react/src/views/ChatInput/ChatInput.js
@@ -185,7 +185,6 @@ const ChatInput = ({ scrollToBottom, clearUnreadDividerRef }) => {
     }
   }, [deletedMessage]);
 
- 
   useEffect(() => {
     if (data === null && inputRef.current) {
       inputRef.current.value = '';


### PR DESCRIPTION
- Replace deprecated rooms.upload endpoint with new two-step process
- Step 1: POST to rooms.media/:rid to upload file
- Step 2: POST to rooms.mediaConfirm/:rid/:fileId to confirm with metadata
- Fixes file upload 404 error on Rocket.Chat 8.x servers

# Brief Title
fix: update file upload to use RC 8.x rooms.media API


## Acceptance Criteria fulfillment

[x] File uploads work on Rocket.Chat 8.x servers
[x] Thread attachments supported (tmid parameter)
[x] File description is properly sent
[x] Auth headers included in both requests

Fixes #1069

## Video/Screenshots


https://github.com/user-attachments/assets/8d4ad2f5-d174-4fb0-89d7-3f8328832fd5



## PR Test Details

**Note**: The PR will be ready for live testing at https://rocketchat.github.io/EmbeddedChat/pulls/pr-1070 after approval. Contributors are requested to replace `<pr_number>` with the actual PR number.
