### PR TITLE
fix: resolve memory leak in MediaRecorder event listeners

### DIFF
--- a/packages/react/src/hooks/useMediaRecorder.js
+++ b/packages/react/src/hooks/useMediaRecorder.js
@@ -28,19 +28,29 @@ export function useMediaRecorder({ constraints, onStop, videoRef }) {
     const stream = await getStream(constraints, true);
     chunks.current = [];
     const _recorder = new MediaRecorder(stream);
+
+    const handleDataAvailable = (event) => {
+      chunks.current.push(event.data);
+    };
+
+    const handleStop = () => {
+      onStop && onStop(chunks.current);
+      _recorder.removeEventListener('dataavailable', handleDataAvailable);
+      _recorder.removeEventListener('stop', handleStop);
+    };
+
+    _recorder.addEventListener('dataavailable', handleDataAvailable);
+    _recorder.addEventListener('stop', handleStop);
+
     _recorder.start();
     setRecorder(_recorder);
-    _recorder.addEventListener('dataavailable', (event) => {
-      chunks.current.push(event.data);
-    });
-    _recorder.addEventListener('stop', () => {
-      onStop && onStop(chunks.current);
-    });
   }
 
   async function stop() {
     if (recorder) {
-      recorder.stop();
+      if (recorder.state !== 'inactive') {
+        recorder.stop();
+      }
       (await getStream()).getTracks().forEach((track) => track.stop());
     }
   }
@@ -77,17 +87,23 @@ export function useNewMediaRecorder({ constraints, videoRef, onStop }) {
 
     chunks.current = [];
     const _recorder = new MediaRecorder(stream);
-    _recorder.start();
-    setRecorder(_recorder);
 
-    _recorder.addEventListener('dataavailable', (event) => {
+    const handleDataAvailable = (event) => {
       chunks.current.push(event.data);
-    });
+    };
 
-    _recorder.addEventListener('stop', () => {
+    const handleStop = () => {
       setRecordingData(new Blob(chunks.current, { type: 'video/mp4' }));
       onStop && onStop(chunks.current);
-    });
+      _recorder.removeEventListener('dataavailable', handleDataAvailable);
+      _recorder.removeEventListener('stop', handleStop);
+    };
+
+    _recorder.addEventListener('dataavailable', handleDataAvailable);
+    _recorder.addEventListener('stop', handleStop);
+
+    _recorder.start();
+    setRecorder(_recorder);
   }
 
   async function stopRecording() {


### PR DESCRIPTION
This PR fixes a memory leak in the useMediaRecorder and useNewMediaRecorder hooks where event listeners attached to MediaRecorder instances were never removed, causing unused recorder instances to remain in memory after each recording session.

Closes #1073

## Video/Screenshots

## PR Test Details

**Note**: The PR will be ready for live testing at https://rocketchat.github.io/EmbeddedChat/pulls/pr-1077 after approval. Contributors are requested to replace `<pr_number>` with the actual PR number.
