### PR TITLE
fix: show edit icon for sequential messages

### DIFF
--- a/packages/react/src/views/Message/Message.styles.js
+++ b/packages/react/src/views/Message/Message.styles.js
@@ -230,6 +230,12 @@ export const getMessageHeaderStyles = (theme) => {
       flex-shrink: 0;
       margin-left: 0.25rem;
     `,
+    messageStatus: css`
+      display: flex;
+      flex-flow: row nowrap;
+      align-items: center;
+      margin-left: 0.2rem;
+    `,
   };
 
   return styles;

--- a/packages/react/src/views/Message/MessageAvatarContainer.js
+++ b/packages/react/src/views/Message/MessageAvatarContainer.js
@@ -49,8 +49,8 @@ const MessageAvatarContainer = ({
                 ? '1.2em'
                 : '1.5em'
               : message.t
-              ? '1.5em'
-              : '2.25em'
+                ? '1.5em'
+                : '2.25em'
           }
           onClick={handleAvatarClick}
         />
@@ -58,6 +58,11 @@ const MessageAvatarContainer = ({
       {isStarred && sequential ? (
         <Tooltip text="Starred" position="top">
           <Icon style={{ opacity: 0.5 }} name="star-filled" size="1.2em" />
+        </Tooltip>
+      ) : null}
+      {message.editedAt && sequential ? (
+        <Tooltip text="Edited" position="top">
+          <Icon style={{ opacity: 0.5 }} name="edit" size="1.2em" />
         </Tooltip>
       ) : null}
       {isPinned && sequential ? (

--- a/packages/react/src/views/Message/MessageAvatarContainer.js
+++ b/packages/react/src/views/Message/MessageAvatarContainer.js
@@ -49,8 +49,8 @@ const MessageAvatarContainer = ({
                 ? '1.2em'
                 : '1.5em'
               : message.t
-                ? '1.5em'
-                : '2.25em'
+              ? '1.5em'
+              : '2.25em'
           }
           onClick={handleAvatarClick}
         />


### PR DESCRIPTION
This PR fixes an issue where the edit status and pin indicator was not visible for sequential messages.

Fixes #1078

## Video/Screenshots

Rocket chat web
<img width="1587" height="91" alt="Screenshot from 2026-01-17 21-55-32" src="https://github.com/user-attachments/assets/bbf62928-985e-45b7-96ac-eb1f9d9822e6" />

Embedded chat
<img width="1587" height="91" alt="Screenshot from 2026-01-17 21-55-52" src="https://github.com/user-attachments/assets/80b4d040-7fef-4631-b840-3dea4e63d8b1" />

## PR Test Details

**Note**: The PR will be ready for live testing at https://rocketchat.github.io/EmbeddedChat/pulls/pr-1079 after approval. Contributors are requested to replace `<pr_number>` with the actual PR number.
