### PR TITLE
fix(auth): validate origin of oauth callback to prevent login csrf

### DIFF
--- a/packages/auth/src/loginWithRocketChatOAuth.ts
+++ b/packages/auth/src/loginWithRocketChatOAuth.ts
@@ -45,6 +45,9 @@ width=800,height=600,left=-1000,top=-1000,rel=opener`;
   return new Promise<any>((resolve) => {
     if (popup) {
       const onMessage = async (e: MessageEvent) => {
+        if (e.origin !== new URL(config.api.baseUrl).origin) {
+          return;
+        }
         if (e.data.type === "rc-oauth-callback") {
           const { accessToken, expiresIn, serviceName } = e.data.credentials;
           const response = await config.api.post("/api/v1/login", {


### PR DESCRIPTION
This pull request fixes a critical security vulnerability in the OAuth login flow where the application accepted OAuth callback messages from any origin.

Previously, the `postMessage` event listener in `loginWithRocketChatOAuth` did not validate the origin of incoming messages. This allowed malicious websites to forge OAuth callbacks and potentially force users to log in with attacker-controlled accounts.

Closes #1071

### Fix

* Added validation to ensure `event.origin` matches the trusted Rocket.Chat server origin
* The expected origin is derived from `config.api.baseUrl`
* Messages from untrusted origins are ignored

Only messages from the configured Rocket.Chat server are now accepted.