### PR TITLE
fix: align quoted message UI order and styling with official Rocket.Chat

### DIFF
--- a/packages/react/src/views/AttachmentHandler/AudioAttachment.js
+++ b/packages/react/src/views/AttachmentHandler/AudioAttachment.js
@@ -39,7 +39,8 @@ const AudioAttachment = ({
           (type ? variantStyles.pinnedContainer : '') ||
             css`
               ${type === 'file'
-                ? `border: 3px solid ${theme.colors.border};`
+                ? `border-inline-start: 2px solid ${theme.colors.border};
+                   background: ${theme.colors.primaryForeground};`
                 : ''}
             `,
         ]}
@@ -61,7 +62,7 @@ const AudioAttachment = ({
                 alt="avatar"
                 size="1.2em"
               />
-              <Box>@{authorName}</Box>
+              <Box>{authorName}</Box>
             </Box>
           </>
         ) : (
@@ -106,7 +107,8 @@ const AudioAttachment = ({
                     : variantStyles.quoteContainer) ||
                     css`
                       ${nestedAttachment.type === 'file'
-                        ? `border: 3px solid ${theme.colors.border};`
+                        ? `border-inline-start: 2px solid ${theme.colors.border};
+                           background: ${theme.colors.primaryForeground};`
                         : ''}
                     `,
                 ]}
@@ -128,7 +130,7 @@ const AudioAttachment = ({
                         alt="avatar"
                         size="1.2em"
                       />
-                      <Box>@{nestedAttachment.author_name}</Box>
+                      <Box>{nestedAttachment.author_name}</Box>
                     </Box>
                   </>
                 ) : (

--- a/packages/react/src/views/AttachmentHandler/ImageAttachment.js
+++ b/packages/react/src/views/AttachmentHandler/ImageAttachment.js
@@ -48,7 +48,8 @@ const ImageAttachment = ({
           (type ? variantStyles.pinnedContainer : '') ||
             css`
               ${type === 'file'
-                ? `border: 2px solid ${theme.colors.border};`
+                ? `border-inline-start: 2px solid ${theme.colors.border};
+                 background: ${theme.colors.primaryForeground};`
                 : ''}
             `,
         ]}
@@ -70,7 +71,7 @@ const ImageAttachment = ({
                 alt="avatar"
                 size="1.2em"
               />
-              <Box>@{authorName}</Box>
+              <Box>{authorName}</Box>
             </Box>
           </>
         ) : (
@@ -123,7 +124,8 @@ const ImageAttachment = ({
                     : variantStyles.quoteContainer) ||
                     css`
                       ${nestedAttachment.attachments[0].type === 'file'
-                        ? `border: 2px solid ${theme.colors.border};`
+                        ? `border-inline-start: 2px solid ${theme.colors.border};
+                         background: ${theme.colors.primaryForeground};`
                         : ''}
                     `,
                 ]}
@@ -145,7 +147,7 @@ const ImageAttachment = ({
                         alt="avatar"
                         size="1.2em"
                       />
-                      <Box>@{nestedAttachment.author_name}</Box>
+                      <Box>{nestedAttachment.author_name}</Box>
                     </Box>
                   </>
                 ) : (

--- a/packages/react/src/views/AttachmentHandler/TextAttachment.js
+++ b/packages/react/src/views/AttachmentHandler/TextAttachment.js
@@ -105,12 +105,13 @@ const FileAttachment = ({
             border-radius: 4px;
             line-height: 0;
             padding: 0.5rem;
-            background: ${theme.colors.background};
+            background: ${theme.colors.primaryForeground};
+            border-inline-start: 2px solid ${theme.colors.border};
           `,
           (type ? variantStyles.pinnedContainer : '') ||
             css`
               ${type === 'file'
-                ? `border: 2px solid ${theme.colors.border};`
+                ? `border-inline-start: 3px solid ${theme.colors.border};`
                 : ''}
             `,
         ]}
@@ -131,7 +132,7 @@ const FileAttachment = ({
               alt="avatar"
               size="1.2em"
             />
-            <Box>@{attachment?.author_name}</Box>
+            <Box>{attachment?.author_name}</Box>
             {getTimeString(attachment?.ts) && (
               <Box
                 onClick={() => handleQuoteClick(attachment)}
@@ -146,88 +147,6 @@ const FileAttachment = ({
               >
                 {getTimeString(attachment.ts)}
               </Box>
-            )}
-          </Box>
-        )}
-
-        {!attachment?.text && !attachment?.attachments && (
-          <AttachmentMetadata
-            attachment={attachment}
-            url={host + attachment.title_link}
-            variantStyles={variantStyles}
-            msg={msg}
-            onExpandCollapseClick={toggleExpanded}
-            isExpanded={isExpanded}
-          />
-        )}
-        {isExpanded && (attachment?.title_link || attachment?.text) && (
-          <Box
-            css={css`
-              margin-top: 0.5rem;
-              white-space: pre-line;
-              background: ${theme.colors.background};
-              padding: 8px 12px;
-              border-radius: 4px;
-              border: 1px solid ${theme.colors.border};
-              line-height: normal;
-            `}
-          >
-            {attachment?.text ? (
-              attachment.text[0] === '[' ? (
-                attachment.text.match(/\n(.*)/)?.[1] || ''
-              ) : (
-                <Markdown
-                  body={attachment.text}
-                  md={parse(attachment?.text)}
-                  isReaction={false}
-                />
-              )
-            ) : !attachment.attachments ? (
-              <Box
-                css={css`
-                  display: flex;
-                  align-items: center;
-                  margin-top: 0.5rem;
-                  background: ${theme.colors.background};
-                  padding: 8px 12px;
-                  border-radius: 4px;
-                  gap: 8px;
-                  border: 1px solid ${theme.colors.border};
-                `}
-              >
-                <Icon name="file" size="40px" />
-                <Box
-                  css={css`
-                    display: flex;
-                    flex-direction: column;
-                    gap: 2px;
-                    line-height: normal;
-                  `}
-                >
-                  <a
-                    href={host + attachment.title_link}
-                    download={attachment.title_link_download}
-                    css={css`
-                      text-decoration: none;
-                      font-size: 0.875rem;
-                      &:hover {
-                        text-decoration: underline;
-                      }
-                    `}
-                  >
-                    {attachment.title}
-                  </a>
-                  <Box
-                    css={css`
-                      font-size: 0.75rem;
-                    `}
-                  >
-                    {getFileSizeWithFormat(attachment.size, attachment.format)}
-                  </Box>
-                </Box>
-              </Box>
-            ) : (
-              ''
             )}
           </Box>
         )}
@@ -336,8 +255,10 @@ const FileAttachment = ({
                     font-size: 0.875rem;
                     font-weight: 400;
                     word-break: break-word;
-                    border-inline-start: 3px solid ${theme.colors.border};
+                    background: ${theme.colors.primaryForeground};
+                    border-inline-start: 2px solid ${theme.colors.border};
                     margin-top: 0.75rem;
+                    margin-inline-start: 1rem;
                     padding: 0.5rem;
                   `,
                   (nestedAttachment?.type
@@ -345,7 +266,7 @@ const FileAttachment = ({
                     : '') ||
                     css`
                       ${!attachment?.type
-                        ? `border: 2px solid ${theme.colors.border};`
+                        ? `border-inline-start: 2px solid ${theme.colors.border};`
                         : ''}
                     `,
                   css`
@@ -374,7 +295,7 @@ const FileAttachment = ({
                         alt="avatar"
                         size="1.2em"
                       />
-                      <Box>@{nestedAttachment?.author_name}</Box>
+                      <Box>{nestedAttachment?.author_name}</Box>
                       {getTimeString(nestedAttachment?.ts) && (
                         <Box
                           onClick={() => handleQuoteClick(nestedAttachment)}
@@ -393,7 +314,6 @@ const FileAttachment = ({
                     </>
                   )}
                 </Box>
-
                 {!nestedAttachment?.text && !nestedAttachment?.attachments && (
                   <AttachmentMetadata
                     attachment={nestedAttachment}
@@ -403,7 +323,6 @@ const FileAttachment = ({
                     isExpanded={isExpanded}
                   />
                 )}
-
                 {isExpanded && (
                   <Box
                     css={css`
@@ -427,7 +346,7 @@ const FileAttachment = ({
                           display: flex;
                           align-items: center;
                           margin-top: 0.5rem;
-                          background: ${theme.colors.background};
+                          background: ${theme.colors.primaryForeground};
                           padding: 8px 12px;
                           border-radius: 4px;
                           gap: 8px;
@@ -474,6 +393,86 @@ const FileAttachment = ({
               </Box>
             );
           })}
+
+        {!attachment?.text && !attachment?.attachments && (
+          <AttachmentMetadata
+            attachment={attachment}
+            url={host + attachment.title_link}
+            variantStyles={variantStyles}
+            msg={msg}
+            onExpandCollapseClick={toggleExpanded}
+            isExpanded={isExpanded}
+          />
+        )}
+        {isExpanded && (attachment?.title_link || attachment?.text) && (
+          <Box
+            css={css`
+              margin-top: 0.5rem;
+              white-space: pre-line;
+              background: ${theme.colors.primaryForeground};
+              padding: 8px 12px;
+              line-height: normal;
+            `}
+          >
+            {attachment?.text ? (
+              attachment.text[0] === '[' ? (
+                attachment.text.match(/\n(.*)/)?.[1] || ''
+              ) : (
+                <Markdown
+                  body={attachment.text}
+                  md={parse(attachment?.text)}
+                  isReaction={false}
+                />
+              )
+            ) : !attachment.attachments ? (
+              <Box
+                css={css`
+                  display: flex;
+                  align-items: center;
+                  margin-top: 0.5rem;
+                  background: ${theme.colors.primaryForeground};
+                  padding: 8px 12px;
+                  border-radius: 4px;
+                  gap: 8px;
+                  border: 1px solid ${theme.colors.border};
+                `}
+              >
+                <Icon name="file" size="40px" />
+                <Box
+                  css={css`
+                    display: flex;
+                    flex-direction: column;
+                    gap: 2px;
+                    line-height: normal;
+                  `}
+                >
+                  <a
+                    href={host + attachment.title_link}
+                    download={attachment.title_link_download}
+                    css={css`
+                      text-decoration: none;
+                      font-size: 0.875rem;
+                      &:hover {
+                        text-decoration: underline;
+                      }
+                    `}
+                  >
+                    {attachment.title}
+                  </a>
+                  <Box
+                    css={css`
+                      font-size: 0.75rem;
+                    `}
+                  >
+                    {getFileSizeWithFormat(attachment.size, attachment.format)}
+                  </Box>
+                </Box>
+              </Box>
+            ) : (
+              ''
+            )}
+          </Box>
+        )}
       </Box>
     </Box>
   );

--- a/packages/react/src/views/AttachmentHandler/VideoAttachment.js
+++ b/packages/react/src/views/AttachmentHandler/VideoAttachment.js
@@ -52,7 +52,8 @@ const VideoAttachment = ({
           (type ? variantStyles.pinnedContainer : '') ||
             css`
               ${type === 'file'
-                ? `border: 3px solid ${theme.colors.border};`
+                ? `border-inline-start: 2px solid ${theme.colors.border};
+                 background: ${theme.colors.primaryForeground};`
                 : ''}
             `,
         ]}
@@ -84,7 +85,7 @@ const VideoAttachment = ({
                   }
                 `}
               >
-                @{authorName}
+                {authorName}
               </Box>
             </Box>
           </>
@@ -141,7 +142,8 @@ const VideoAttachment = ({
                     : variantStyles.quoteContainer) ||
                     css`
                       ${type === 'file'
-                        ? `border: 3px solid ${theme.colors.border};`
+                        ? `border-inline-start: 2px solid ${theme.colors.border};
+                           background: ${theme.colors.primaryForeground};`
                         : ''}
                     `,
                 ]}
@@ -167,7 +169,7 @@ const VideoAttachment = ({
                         alt="avatar"
                         size="1.2em"
                       />
-                      <Box>@{authorName}</Box>
+                      <Box>{authorName}</Box>
                     </Box>
                   </>
                 ) : (

--- a/packages/react/src/views/Message/Message.js
+++ b/packages/react/src/views/Message/Message.js
@@ -92,13 +92,13 @@ const Message = ({
   const hoverStyle = hasType
     ? {}
     : {
-        '&:hover': {
-          backgroundColor:
-            mode === 'light'
-              ? darken(theme.theme.colors.background, 0.03)
-              : lighten(theme.theme.colors.background, 1),
-        },
-      };
+      '&:hover': {
+        backgroundColor:
+          mode === 'light'
+            ? darken(theme.theme.colors.background, 0.03)
+            : lighten(theme.theme.colors.background, 1),
+      },
+    };
 
   const bubbleStyles = useBubbleStyles(isMe);
   const pinRoles = new Set(pinPermissions);
@@ -273,15 +273,15 @@ const Message = ({
               >
                 {message.attachments && message.attachments.length > 0 ? (
                   <>
-                    <Markdown
-                      body={message}
-                      md={message.md}
-                      isReaction={false}
-                    />
                     <Attachments
                       attachments={message.attachments}
                       variantStyles={variantStyles}
                       msg={message}
+                    />
+                    <Markdown
+                      body={message}
+                      md={message.md}
+                      isReaction={false}
                     />
                   </>
                 ) : (

--- a/packages/react/src/views/Message/Message.js
+++ b/packages/react/src/views/Message/Message.js
@@ -92,13 +92,13 @@ const Message = ({
   const hoverStyle = hasType
     ? {}
     : {
-      '&:hover': {
-        backgroundColor:
-          mode === 'light'
-            ? darken(theme.theme.colors.background, 0.03)
-            : lighten(theme.theme.colors.background, 1),
-      },
-    };
+        '&:hover': {
+          backgroundColor:
+            mode === 'light'
+              ? darken(theme.theme.colors.background, 0.03)
+              : lighten(theme.theme.colors.background, 1),
+        },
+      };
 
   const bubbleStyles = useBubbleStyles(isMe);
   const pinRoles = new Set(pinPermissions);

--- a/packages/react/src/views/QuoteMessage/QuoteMessage.js
+++ b/packages/react/src/views/QuoteMessage/QuoteMessage.js
@@ -113,7 +113,8 @@ const QuoteMessage = ({ className = '', style = {}, message }) => {
               {message.msg ? (
                 <Markdown body={message} md={message.md} isReaction={false} />
               ) : (
-                `${message.file?.name} (${message.file?.size ? (message.file.size / 1024).toFixed(2) : 0
+                `${message.file?.name} (${
+                  message.file?.size ? (message.file.size / 1024).toFixed(2) : 0
                 } kB)`
               )}
             </Box>

--- a/packages/react/src/views/QuoteMessage/QuoteMessage.js
+++ b/packages/react/src/views/QuoteMessage/QuoteMessage.js
@@ -59,6 +59,18 @@ const QuoteMessage = ({ className = '', style = {}, message }) => {
         <Box>{format(new Date(message.ts), 'h:mm a')}</Box>
       </Box>
       <Box css={styles.message}>
+        {message.attachments &&
+          message.attachments.length > 0 &&
+          message.msg &&
+          message.msg[0] === '[' &&
+          message.attachments.map((attachment, index) => (
+            <Attachment
+              key={index}
+              attachment={attachment}
+              type={attachment.type}
+              host={instanceHost}
+            />
+          ))}
         {message.file ? (
           message.file.type.startsWith('image/') ? (
             <div>
@@ -101,8 +113,7 @@ const QuoteMessage = ({ className = '', style = {}, message }) => {
               {message.msg ? (
                 <Markdown body={message} md={message.md} isReaction={false} />
               ) : (
-                `${message.file?.name} (${
-                  message.file?.size ? (message.file.size / 1024).toFixed(2) : 0
+                `${message.file?.name} (${message.file?.size ? (message.file.size / 1024).toFixed(2) : 0
                 } kB)`
               )}
             </Box>
@@ -112,18 +123,6 @@ const QuoteMessage = ({ className = '', style = {}, message }) => {
         ) : (
           <Markdown body={message} md={message.md} isReaction={false} />
         )}
-        {message.attachments &&
-          message.attachments.length > 0 &&
-          message.msg &&
-          message.msg[0] === '[' &&
-          message.attachments.map((attachment, index) => (
-            <Attachment
-              key={index}
-              attachment={attachment}
-              type={attachment.type}
-              host={instanceHost}
-            />
-          ))}
       </Box>
     </Box>
   );

--- a/packages/react/src/views/QuoteMessage/QuoteMessage.styles.js
+++ b/packages/react/src/views/QuoteMessage/QuoteMessage.styles.js
@@ -10,7 +10,6 @@ const getQuoteMessageStyles = (theme) => {
       color: ${theme.colors.foreground};
       padding: 0.5rem;
       z-index: 1200;
-      border: 1px solid ${theme.colors.border};
       border-radius: ${theme.radius};
       max-width: 100%;
       box-sizing: border-box;


### PR DESCRIPTION
  # Brief Title
  Align quoted message UI order and styling with official Rocket.Chat
  
  ## Acceptance Criteria fulfillment
  
- [x] Render quote UI before message content
- [x] Match quote container border styling with official Rocket.Chat
- [x] Match quote container background color with official Rocket.Chat
  
 Fixes #1094 
  
  ## Screenshots
  
<img width="1278" height="625" alt="Screenshot from 2026-01-22 17-02-03" src="https://github.com/user-attachments/assets/89fbd112-c0a5-47f7-bbc3-8aae630c88e6" />

  
 ## PR Test Details
  - Tested quoting messages with text, image, and file attachments
  - Confirmed visual consistency with the official Rocket.Chat UI
  
  **Note**: The PR will be ready for live testing at https://rocketchat.github.io/EmbeddedChat/pulls/pr-<pr_number> after approval. Contributors are requested to replace `<pr_number>` with the actual PR number.
