### PR TITLE
fix: resolve duplicated links when quoting multiple messages in ChatI…

### DIFF
--- a/packages/react/src/views/ChatInput/ChatInput.js
+++ b/packages/react/src/views/ChatInput/ChatInput.js
@@ -298,17 +298,17 @@ const ChatInput = ({ scrollToBottom, clearUnreadDividerRef }) => {
       //   }
       // }
 
-      const quoteArray = await Promise.all(
+      const quoteLinks = await Promise.all(
         quoteMessage.map(async (quote) => {
           const { msg, attachments, _id } = quote;
           if (msg || attachments) {
             const msgLink = await getMessageLink(_id);
-            quotedMessages += `[ ](${msgLink})`;
+            return `[ ](${msgLink})`;
           }
-          return quotedMessages;
+          return '';
         })
       );
-      quotedMessages = quoteArray.join('');
+      quotedMessages = quoteLinks.join('');
       pendingMessage = createPendingMessage(
         `${quotedMessages}\n${message}`,
         userInfo


### PR DESCRIPTION
While exploring the 
ChatInput
 component, I noticed that quoting multiple messages led to redundant content accumulation in the message body. This was caused by a string mutation inside the quoteMessage.map loop.

I've refactored the logic to use a clean functional approach (map + join), which ensures each quote correctly generates exactly one link and improves performance