### PR TITLE
fix(react): add missing unique key props to ChatInputFormattingToolba…

### DIFF
--- a/packages/react/src/views/ChatInput/ChatInputFormattingToolbar.js
+++ b/packages/react/src/views/ChatInput/ChatInputFormattingToolbar.js
@@ -116,6 +116,7 @@ const ChatInputFormattingToolbar = ({
 
     audio: (
       <AudioMessageRecorder
+        key="audio"
         displayName={
           isPopoverOpen && popOverItems.includes('audio') ? 'audio' : null
         }
@@ -125,6 +126,7 @@ const ChatInputFormattingToolbar = ({
     ),
     video: (
       <VideoMessageRecorder
+        key="video"
         displayName={
           isPopoverOpen && popOverItems.includes('video') ? 'video' : null
         }
@@ -194,7 +196,7 @@ const ChatInputFormattingToolbar = ({
       .map((name) => formatter.find((item) => item.name === name))
       .map((item) =>
         isPopoverOpen && popOverItems.includes('formatter') ? (
-          <>
+          <React.Fragment key={item.name}>
             <Box
               key={item.name}
               disabled={isRecordingMessage}
@@ -211,7 +213,7 @@ const ChatInputFormattingToolbar = ({
               />
               <span>{item.name}</span>
             </Box>
-          </>
+          </React.Fragment>
         ) : (
           <Tooltip
             text={item.name}


### PR DESCRIPTION
This PR fixes a common React warning:

```
Warning: Each child in a list should have a unique "key" prop
```

The warning occurred in the `ChatInputFormattingToolbar` component and was caused by several elements being rendered as part of dynamic lists without providing a unique `key` prop. This made it harder for React to correctly track and optimize updates to these elements.

---

Closes #1098

## Changes

Updated `packages/react/src/views/ChatInput/ChatInputFormattingToolbar.js`:

* Added `key="audio"` to the `AudioMessageRecorder` component.
* Added `key="video"` to the `VideoMessageRecorder` component.
* Replaced empty fragments (`<>`) with `<React.Fragment key={item.name}>` for mapped formatting buttons (bold, italic, strike, etc.).

---
