### PR TITLE
fix: add user-friendly error notification for login failures

### DIFF
--- a/packages/react/src/hooks/useRCAuth.js
+++ b/packages/react/src/hooks/useRCAuth.js
@@ -63,7 +63,11 @@ export const useRCAuth = () => {
         }
       }
     } catch (e) {
-      console.error('A error occurred while setting up user', e);
+      console.error('An error occurred while setting up user', e);
+      dispatchToastMessage({
+        type: 'error',
+        message: 'Unable to connect to server. Please check your connection and try again.',
+      });
     }
   };
 


### PR DESCRIPTION
Problem
Currently, when login fails due to network errors or unexpected server issues, users receive no feedback. The error is only logged to the console, leaving users confused about why login isn't working.

 Solution
Added a user-friendly toast notification that appears when login fails unexpectedly. This provides clear feedback to users that there's a connection issue and suggests checking their network.

 Changes
- Enhanced error handling in [useRCAuth.js](cci:7://file:///C:/Users/KIIT/.gemini/antigravity/scratch/EmbeddedChat/packages/react/src/hooks/useRCAuth.js:0:0-0:0) hook
- Added toast notification using existing `dispatchToastMessage` utility
- Fixed typo: "A error" → "An error"

Testing
- Build passes successfully
- Uses existing toast infrastructure (no new dependencies)
- Maintains existing error logging for debugging

 User Impact
Users will now see: "Unable to connect to server. Please check your connection and try again." instead of being left wondering why login failed.