### PR TITLE
fix(auth): namespace storage key to prevent cross-instance collision

### DIFF
--- a/packages/react/src/lib/auth.js
+++ b/packages/react/src/lib/auth.js
@@ -1,22 +1,3 @@
-async function saveTokenLocalStorage(token) {
-  if (typeof localStorage !== 'undefined') {
-    localStorage.setItem('ec_token', token);
-  }
-}
-
-async function getTokenLocalStorage() {
-  if (typeof localStorage !== 'undefined') {
-    return localStorage.getItem('ec_token');
-  }
-  return null;
-}
-
-async function deleteTokenLocalStorage() {
-  if (typeof localStorage !== 'undefined') {
-    localStorage.removeItem('ec_token');
-  }
-}
-
 async function saveTokenSecure(token) {
   this.handleSecureLogin('save', token);
 }
@@ -30,7 +11,7 @@ async function deleteTokenSecure() {
   this.handleSecureLogin('delete');
 }
 
-export function getTokenStorage(secure = false) {
+export function getTokenStorage(secure = false, key = 'ec_token') {
   if (secure) {
     return {
       saveToken: saveTokenSecure,
@@ -39,8 +20,21 @@ export function getTokenStorage(secure = false) {
     };
   }
   return {
-    saveToken: saveTokenLocalStorage,
-    getToken: getTokenLocalStorage,
-    deleteToken: deleteTokenLocalStorage,
+    saveToken: (token) => {
+      if (typeof localStorage !== 'undefined') {
+        localStorage.setItem(key, token);
+      }
+    },
+    getToken: () => {
+      if (typeof localStorage !== 'undefined') {
+        return localStorage.getItem(key);
+      }
+      return null;
+    },
+    deleteToken: () => {
+      if (typeof localStorage !== 'undefined') {
+        localStorage.removeItem(key);
+      }
+    },
   };
 }

--- a/packages/react/src/views/EmbeddedChat.js
+++ b/packages/react/src/views/EmbeddedChat.js
@@ -64,7 +64,14 @@ const EmbeddedChat = (props) => {
   const { classNames, styleOverrides } = useComponentOverrides('EmbeddedChat');
   const [fullScreen, setFullScreen] = useState(false);
   const [isSynced, setIsSynced] = useState(!remoteOpt);
-  const { getToken, saveToken, deleteToken } = getTokenStorage(secure);
+  const storageKey = useMemo(
+    () => `ec_token_${host}_${roomId}`,
+    [host, roomId]
+  );
+  const { getToken, saveToken, deleteToken } = useMemo(
+    () => getTokenStorage(secure, storageKey),
+    [secure, storageKey]
+  );
   const {
     setIsUserAuthenticated,
     setUsername: setAuthenticatedUsername,


### PR DESCRIPTION
This PR fixes a critical authentication issue where multiple EmbeddedChat instances running on the same domain were overwriting each other’s login sessions.

The problem was caused by a hardcoded `localStorage` key (`ec_token`) used by all instances. As a result, logging into one EmbeddedChat instance would invalidate the session of another.

This fix introduces **namespaced storage keys**, ensuring that each EmbeddedChat instance maintains an isolated authentication session based on its configuration.

---

Closes  #1105

## Solution

* Token storage is now **scoped per instance** using a dynamic storage key.
* Each EmbeddedChat instance generates its own unique key using:

  ```
  ec_token_${host}_${roomId}
  ```
* This guarantees session isolation across different servers or rooms.

---

## Changes Made

### 1. `auth.js`

* Refactored `getTokenStorage` to accept a **dynamic storage key** instead of using a hardcoded value.
* The function now returns closures that are bound to the provided key, ensuring correct token access per instance.

### 2. `EmbeddedChat.js`

* Generates a unique storage key using `host` and `roomId`.
* Passes this key to the authentication module.
* Wrapped `getTokenStorage` in `useMemo` to prevent unnecessary re-renders, since it returns new function references on each call.

---

## Performance Consideration

* `useMemo` is used to memoize the token storage handlers.
* This avoids repeated re-creation of functions during re-renders and keeps component behavior stable.