### PR TITLE
fix: incorrect 'Room Archived' status in Room Information panel

### DIFF
--- a/packages/react/src/views/ChatHeader/ChatHeader.js
+++ b/packages/react/src/views/ChatHeader/ChatHeader.js
@@ -183,6 +183,11 @@ const ChatHeader = ({
           setIsChannelReadOnly(true);
           setMessageAllowed();
         }
+        if (res.room.archived) {
+          setIsChannelArchived(true);
+        } else {
+          setIsChannelArchived(false);
+        }
       } else if (
         'errorType' in res &&
         res.errorType === 'error-room-not-found'
@@ -226,6 +231,7 @@ const ChatHeader = ({
     setMessageLimit,
     workspaceLevelRoles,
     setIsChannelReadOnly,
+    setIsChannelArchived,
   ]);
 
   const options = useMemo(

--- a/packages/react/src/views/RoomInformation/RoomInformation.js
+++ b/packages/react/src/views/RoomInformation/RoomInformation.js
@@ -19,6 +19,7 @@ const Roominfo = () => {
   const channelInfo = useChannelStore((state) => state.channelInfo);
   const isChannelPrivate = useChannelStore((state) => state.isChannelPrivate);
   const isRoomTeam = useChannelStore((state) => state.isRoomTeam);
+  const isChannelArchived = useChannelStore((state) => state.isChannelArchived);
   const { variantOverrides } = useComponentOverrides('RoomMember');
   const viewType = variantOverrides.viewType || 'Sidebar';
   const setExclusiveState = useSetExclusiveState();
@@ -63,18 +64,20 @@ const Roominfo = () => {
           />
         </Box>
         <Box css={styles.infoContainer}>
-          <Box css={styles.archivedRoomInfo}>
-            <Icon
-              name="report"
-              size="1.25rem"
-              fill={
-                mode === 'light'
-                  ? theme.colors.warning
-                  : theme.colors.warningForeground
-              }
-            />
-            <Box css={styles.archivedText}>Room Archived</Box>
-          </Box>
+          {isChannelArchived && (
+            <Box css={styles.archivedRoomInfo}>
+              <Icon
+                name="report"
+                size="1.25rem"
+                fill={
+                  mode === 'light'
+                    ? theme.colors.warning
+                    : theme.colors.warningForeground
+                }
+              />
+              <Box css={styles.archivedText}>Room Archived</Box>
+            </Box>
+          )}
           <Box css={styles.infoHeader}>
             <Icon
               name={


### PR DESCRIPTION
This PR fixes an issue where the **"Room Archived"** warning banner was shown for **all channels** in the Room Information panel, even when the channel was not archived.

The fix ensures that the archived status is correctly fetched from the backend and stored in state, so the banner is displayed **only when a channel is actually archived**.

---

## Changes

### `packages/react/src/views/RoomInformation/RoomInformation.js`

* Updated the component to read `isChannelArchived` from the store.
* Wrapped the `ArchivedRoomInfo` UI block with a conditional check so it renders **only for archived channels**.

### `packages/react/src/views/ChatHeader/ChatHeader.js`

* Updated `getChannelInfo` to correctly read the `archived` field from the room data response.
* Dispatches `setIsChannelArchived(true/false)` based on the actual channel status.

---

## Issue

Closes #1109

---

## How to Test

1. Launch **Embedded Chat**.
2. Open an active, **unarchived** public channel (for example, `#general`).
3. Click the **Room Information (info)** icon in the header.

**Optional Test**

1. Archive a channel in Rocket.Chat.
2. Open the same channel in Embedded Chat.

---

## Screenshots
After
<img width="30%" height="777" alt="Screenshot from 2026-01-26 18-48-49" src="https://github.com/user-attachments/assets/1516c2a3-304f-459c-8e0a-4bfbaaf71dd0" />


