### PR TITLE
feat: display a floating date indicator in the chat body when scrolling.

### DIFF
--- a/packages/react/src/views/ChatBody/ChatBody.js
+++ b/packages/react/src/views/ChatBody/ChatBody.js
@@ -215,7 +215,7 @@ const ChatBody = ({
       setScrollPosition(messageListRef.current.scrollTop);
       setIsUserScrolledUp(
         messageListRef.current.scrollTop + messageListRef.current.clientHeight <
-        messageListRef.current.scrollHeight
+          messageListRef.current.scrollHeight
       );
 
       // floating date logic
@@ -261,13 +261,13 @@ const ChatBody = ({
             anonymousMode,
             ECOptions?.enableThreads
               ? {
-                query: {
-                  tmid: {
-                    $exists: false,
+                  query: {
+                    tmid: {
+                      $exists: false,
+                    },
                   },
-                },
-                offset,
-              }
+                  offset,
+                }
               : undefined,
             anonymousMode ? false : isChannelPrivate
           );
@@ -322,7 +322,7 @@ const ChatBody = ({
     setPopupVisible,
     setOtherUserMessage,
     firstUnreadMessageId,
-    messages
+    messages,
   ]);
 
   const showNewMessagesPopup = () => {
@@ -338,7 +338,7 @@ const ChatBody = ({
     if (announcementRef.current) {
       setIsOverflowing(
         announcementRef.current.scrollWidth >
-        announcementRef.current.clientWidth
+          announcementRef.current.clientWidth
       );
     }
   };
@@ -430,10 +430,7 @@ const ChatBody = ({
         </Modal>
       )}
       {floatingDate && (
-        <Box
-          css={styles.dateIndicatorStyles}
-          className="ec-date-indicator"
-        >
+        <Box css={styles.dateIndicatorStyles} className="ec-date-indicator">
           {floatingDate}
         </Box>
       )}

--- a/packages/react/src/views/ChatBody/ChatBody.js
+++ b/packages/react/src/views/ChatBody/ChatBody.js
@@ -6,6 +6,7 @@ import React, {
   useState,
   useRef,
 } from 'react';
+import { format } from 'date-fns';
 import PropTypes from 'prop-types';
 import { css } from '@emotion/react';
 import {
@@ -206,13 +207,47 @@ const ChatBody = ({
     setPopupVisible(false);
   };
 
+  const [floatingDate, setFloatingDate] = useState(null);
+  const floatingDateTimerRef = useRef(null);
+
   const handleScroll = useCallback(async () => {
     if (messageListRef && messageListRef.current) {
       setScrollPosition(messageListRef.current.scrollTop);
       setIsUserScrolledUp(
         messageListRef.current.scrollTop + messageListRef.current.clientHeight <
-          messageListRef.current.scrollHeight
+        messageListRef.current.scrollHeight
       );
+
+      // floating date logic
+      const list = messageListRef.current;
+      const listRect = list.getBoundingClientRect();
+      const x = listRect.left + listRect.width / 2;
+      // sampling point: slightly down from the top padding to catch the first visible message
+      const y = listRect.top + 10;
+
+      const topElement = document.elementFromPoint(x, y);
+
+      // attempt to find closest message container if we hit a child element
+      const messageElement = topElement?.closest('.ec-message');
+
+      if (messageElement) {
+        const bodyElement = messageElement.querySelector('.ec-message-body');
+        if (bodyElement && bodyElement.id) {
+          const id = bodyElement.id.replace('ec-message-body-', '');
+          const msg = messages.find((m) => m._id === id);
+          if (msg) {
+            const dateStr = format(new Date(msg.ts), 'MMMM d, yyyy');
+            setFloatingDate(dateStr);
+
+            if (floatingDateTimerRef.current) {
+              clearTimeout(floatingDateTimerRef.current);
+            }
+            floatingDateTimerRef.current = setTimeout(() => {
+              setFloatingDate(null);
+            }, 1000);
+          }
+        }
+      }
 
       if (
         messageListRef.current.scrollTop === 0 &&
@@ -226,13 +261,13 @@ const ChatBody = ({
             anonymousMode,
             ECOptions?.enableThreads
               ? {
-                  query: {
-                    tmid: {
-                      $exists: false,
-                    },
+                query: {
+                  tmid: {
+                    $exists: false,
                   },
-                  offset,
-                }
+                },
+                offset,
+              }
               : undefined,
             anonymousMode ? false : isChannelPrivate
           );
@@ -287,6 +322,7 @@ const ChatBody = ({
     setPopupVisible,
     setOtherUserMessage,
     firstUnreadMessageId,
+    messages
   ]);
 
   const showNewMessagesPopup = () => {
@@ -302,7 +338,7 @@ const ChatBody = ({
     if (announcementRef.current) {
       setIsOverflowing(
         announcementRef.current.scrollWidth >
-          announcementRef.current.clientWidth
+        announcementRef.current.clientWidth
       );
     }
   };
@@ -392,6 +428,14 @@ const ChatBody = ({
             </Button>
           </Modal.Footer>
         </Modal>
+      )}
+      {floatingDate && (
+        <Box
+          css={styles.dateIndicatorStyles}
+          className="ec-date-indicator"
+        >
+          {floatingDate}
+        </Box>
       )}
       <Box
         ref={messageListRef}

--- a/packages/react/src/views/ChatBody/ChatBody.styles.js
+++ b/packages/react/src/views/ChatBody/ChatBody.styles.js
@@ -32,6 +32,24 @@ export const getChatbodyStyles = (theme, mode) => {
       text-overflow: ellipsis;
       white-space: nowrap;
     `,
+
+    dateIndicatorStyles: css`
+      position: absolute;
+      top: 30px; 
+      left: 50%;
+      transform: translateX(-50%);
+      z-index: 1050; 
+      padding: 1px 8px;
+      border-radius: 2px;
+      font-size: 0.75rem;
+      font-weight: 600;
+      background-color: ${theme.colors.secondary};
+      color: ${theme.colors.primary};
+      box-shadow: ${theme.shadows[1]};
+      opacity: 0.9;
+      pointer-events: none;
+      transition: opacity 0.3s ease-in-out;
+    `,
   };
 
   return styles;

--- a/packages/react/src/views/ChatBody/ChatBody.styles.js
+++ b/packages/react/src/views/ChatBody/ChatBody.styles.js
@@ -35,10 +35,10 @@ export const getChatbodyStyles = (theme, mode) => {
 
     dateIndicatorStyles: css`
       position: absolute;
-      top: 30px; 
+      top: 30px;
       left: 50%;
       transform: translateX(-50%);
-      z-index: 1050; 
+      z-index: 1050;
       padding: 1px 8px;
       border-radius: 2px;
       font-size: 0.75rem;


### PR DESCRIPTION
# Show floating date indicator while scrolling

---

## Acceptance Criteria fulfillment

- [x] A floating date indicator appears at the top of the message list while scrolling
- [x] The indicator updates dynamically when scrolling into messages from a different date
- [x] The indicator disappears shortly after scrolling stops
- [x] The indicator does not block message interaction
- [x] Existing inline date separators continue to function as before

---

Fixes #1115

---

## Video/Screenshots

**Before (indicator not present):**

https://github.com/user-attachments/assets/795c92be-81f0-409a-9365-bce8f8210aa6



**After (indicator present):**

https://github.com/user-attachments/assets/ea9fa85e-0b06-4220-b415-9af9c4f667d4



---

## PR Test Details

- Tested in EmbeddedChat with long conversations
- Confirmed correct date updates when crossing date separators
- Confirmed no interaction issues with messages while indicator is visible

**Note**: The PR will be ready for live testing at  
https://rocketchat.github.io/EmbeddedChat/pulls/pr-<pr_number>  
after approval. Contributors are requested to replace `<pr_number>` with the actual PR number.
