### PR TITLE
resolve missing unique key prop warnings in ChatInputFormattingToolbar

### DIFF
--- a/packages/react/src/views/ChatInput/ChatInputFormattingToolbar.js
+++ b/packages/react/src/views/ChatInput/ChatInputFormattingToolbar.js
@@ -1,4 +1,4 @@
-import React, { useState, useRef, useEffect } from 'react';
+import React, { useState, useRef } from 'react';
 import { css } from '@emotion/react';
 import {
   Box,
@@ -87,7 +87,7 @@ const ChatInputFormattingToolbar = ({
     emoji:
       isPopoverOpen && popOverItems.includes('emoji') ? (
         <Box
-          key="emoji"
+          key="emoji-popover"
           css={styles.popOverItemStyles}
           disabled={isRecordingMessage}
           onClick={() => {
@@ -116,6 +116,7 @@ const ChatInputFormattingToolbar = ({
 
     audio: (
       <AudioMessageRecorder
+        key="audio-recorder"
         displayName={
           isPopoverOpen && popOverItems.includes('audio') ? 'audio' : null
         }
@@ -125,6 +126,7 @@ const ChatInputFormattingToolbar = ({
     ),
     video: (
       <VideoMessageRecorder
+        key="video-recorder"
         displayName={
           isPopoverOpen && popOverItems.includes('video') ? 'video' : null
         }
@@ -135,7 +137,7 @@ const ChatInputFormattingToolbar = ({
     file:
       isPopoverOpen && popOverItems.includes('file') ? (
         <Box
-          key="file"
+          key="file-popover"
           css={styles.popOverItemStyles}
           disabled={isRecordingMessage}
           onClick={() => {
@@ -147,7 +149,7 @@ const ChatInputFormattingToolbar = ({
           <span>file</span>
         </Box>
       ) : (
-        <Tooltip text="Upload File" position="top" key="file">
+        <Tooltip text="Upload File" position="top" key="file-btn">
           <ActionButton
             square
             ghost
@@ -164,7 +166,7 @@ const ChatInputFormattingToolbar = ({
     link:
       isPopoverOpen && popOverItems.includes('link') ? (
         <Box
-          key="link"
+          key="link-popover"
           css={styles.popOverItemStyles}
           disabled={isRecordingMessage}
           onClick={() => {
@@ -176,7 +178,7 @@ const ChatInputFormattingToolbar = ({
           <span>link</span>
         </Box>
       ) : (
-        <Tooltip text="Link" position="top" key="link">
+        <Tooltip text="Link" position="top" key="link-btn">
           <ActionButton
             square
             ghost
@@ -194,29 +196,27 @@ const ChatInputFormattingToolbar = ({
       .map((name) => formatter.find((item) => item.name === name))
       .map((item) =>
         isPopoverOpen && popOverItems.includes('formatter') ? (
-          <>
-            <Box
-              key={item.name}
+          <Box
+            key={`popover-${item.name}`}
+            disabled={isRecordingMessage}
+            onClick={() => {
+              if (isRecordingMessage) return;
+              handleFormatterClick(item);
+            }}
+            css={styles.popOverItemStyles}
+          >
+            <Icon
               disabled={isRecordingMessage}
-              onClick={() => {
-                if (isRecordingMessage) return;
-                handleFormatterClick(item);
-              }}
-              css={styles.popOverItemStyles}
-            >
-              <Icon
-                disabled={isRecordingMessage}
-                name={item.name}
-                size="1rem"
-              />
-              <span>{item.name}</span>
-            </Box>
-          </>
+              name={item.name}
+              size="1rem"
+            />
+            <span>{item.name}</span>
+          </Box>
         ) : (
           <Tooltip
             text={item.name}
             position="top"
-            key={`formatter-${item.name}`}
+            key={`surface-formatter-${item.name}`}
           >
             <ActionButton
               square
@@ -263,7 +263,7 @@ const ChatInputFormattingToolbar = ({
             if (itemInFormatter) {
               return (
                 <Box
-                  key={itemInFormatter.name}
+                  key={`popover-item-${itemInFormatter.name}`}
                   disabled={isRecordingMessage}
                   onClick={() => handleFormatterClick(itemInFormatter)}
                   css={styles.popOverItemStyles}
@@ -296,7 +296,7 @@ const ChatInputFormattingToolbar = ({
               <Tooltip
                 text={itemInFormatter.name}
                 position="top"
-                key={`formatter-${itemInFormatter.name}`}
+                key={`small-formatter-${itemInFormatter.name}`}
               >
                 <ActionButton
                   square
@@ -351,6 +351,7 @@ const ChatInputFormattingToolbar = ({
 
       {isInsertLinkOpen && (
         <InsertLinkToolBox
+          key="link-toolbox"
           selectedText={window.getSelection().toString()}
           handleAddLink={handleAddLink}
           onClose={() => setInsertLinkOpen(false)}


### PR DESCRIPTION
…oolbar

# resolve missing unique key prop warnings in ChatInputFormattingToolbar

## Acceptance Criteria fulfillment

- [ ] Task 1 : Identified and resolved missing unique **key** props in **"ChatInputFormattingToolbar.js"**
- [ ] Task 2 : Replaced unkeyed fragments with keyed components in **.map()** functions.
- [ ] Task 3 : Verified the fix in Storybook by ensuring the React console warnings are eliminated.

Fixes # (issue) **Fixes #1098** 

## Screenshots
## Evidence of Fix
I have attached screenshots showing the successful resolution of the React **"missing key"** warning.

**Before Fix:** The browser console displays a warning: **Warning: Each child in a list should have a unique "key" prop, specifically pointing to the ChatInputFormattingToolbar.js component.**
<img width="689" height="550" alt="Screenshot 2026-01-27 170420" src="https://github.com/user-attachments/assets/a4215dbe-d10f-456d-8200-ea8f180fb66f" />


**After Fix:** Upon applying the stable keys and replacing unkeyed fragments, the console is clean and the **ChatInput** UI renders successfully without any reconciliation warnings.
<img width="1914" height="922" alt="Screenshot 2026-01-27 170827" src="https://github.com/user-attachments/assets/d09f891e-6c7d-4057-a66f-c3734a9ab28d" />


## PR Test Details
## Launched the environment using yarn storybook.
## Logged in using https://open.rocket.chat as the host to mount the ChatInput component.
## Inspected the Browser Console (F12) to confirm that the yellow "unique key prop" warning no longer appears when the toolbar renders.
**Note**: The PR will be ready for live testing at https://rocketchat.github.io/EmbeddedChat/pulls/pr-1118 after approval. Contributors are requested to replace `#1118` with the actual PR number.
