### PR TITLE
feat: sync room info in real time from system messages

### DIFF
--- a/packages/react/src/hooks/useRoomInfoUpdater.js
+++ b/packages/react/src/hooks/useRoomInfoUpdater.js
@@ -1,0 +1,55 @@
+import { useEffect } from 'react';
+import { useRCContext } from '../context/RCInstance';
+import { useChannelStore } from '../store';
+
+const useRoomInfoUpdater = () => {
+  const { RCInstance } = useRCContext();
+  const setChannelInfo = useChannelStore((state) => state.setChannelInfo);
+  const setIsChannelPrivate = useChannelStore(
+    (state) => state.setIsChannelPrivate
+  );
+  const setIsRoomTeam = useChannelStore((state) => state.setIsRoomTeam);
+  const setIsChannelReadOnly = useChannelStore(
+    (state) => state.setIsChannelReadOnly
+  );
+
+  useEffect(() => {
+    const handleMessage = async (message) => {
+      const roomUpdateTypes = [
+        'r',
+        'room_changed_description',
+        'room_changed_announcement',
+        'room_changed_topic',
+        'room_changed_privacy',
+        'room_changed_avatar',
+      ];
+
+      if (!roomUpdateTypes.includes(message.t)) {
+        return;
+      }
+
+      try {
+        const res = await RCInstance.channelInfo();
+        if (res?.success) {
+          setChannelInfo(res.room);
+          setIsChannelPrivate(res.room.t === 'p');
+          setIsRoomTeam(Boolean(res.room?.teamMain));
+          setIsChannelReadOnly(Boolean(res.room.ro));
+        }
+      } catch (error) {
+        console.error('Failed to update room info:', error);
+      }
+    };
+
+    RCInstance.addMessageListener(handleMessage);
+    return () => RCInstance.removeMessageListener(handleMessage);
+  }, [
+    RCInstance,
+    setChannelInfo,
+    setIsChannelPrivate,
+    setIsRoomTeam,
+    setIsChannelReadOnly,
+  ]);
+};
+
+export default useRoomInfoUpdater;

--- a/packages/react/src/views/ChatHeader/ChatHeader.js
+++ b/packages/react/src/views/ChatHeader/ChatHeader.js
@@ -31,6 +31,7 @@ import useSettingsStore from '../../store/settingsStore';
 import getChatHeaderStyles from './ChatHeader.styles';
 import useSetExclusiveState from '../../hooks/useSetExclusiveState';
 import SurfaceMenu from '../SurfaceMenu/SurfaceMenu';
+import useRoomInfoUpdater from '../../hooks/useRoomInfoUpdater';
 
 const ChatHeader = ({
   isClosable,
@@ -56,6 +57,7 @@ const ChatHeader = ({
 }) => {
   const { classNames, styleOverrides, configOverrides } =
     useComponentOverrides('ChatHeader');
+  useRoomInfoUpdater();
 
   const surfaceItems =
     configOverrides.optionConfig?.surfaceItems || optionConfig.surfaceItems;


### PR DESCRIPTION
# Sync room information in real time in EmbeddedChat

## Acceptance Criteria fulfillment

- [x] Room information (topic, announcement, description, privacy) updates are reflected in real time
- [x] Room Information sidebar updates without requiring a page refresh
- [x] Chat header reflects updated room information automatically

Fixes #1119 

## Video/Screenshots

https://github.com/user-attachments/assets/24e0be55-9ce2-46c4-aa7e-410042529d55



## PR Test Details

**Manual Testing**
- Open EmbeddedChat and join a room
- Open the Room Information sidebar
- From another client (e.g., Rocket.Chat main app), update:
  - room topic
  - room announcement
  - room description
  - room privacy
- Verify the Room Information sidebar updates in real time
- Verify the chat header updates in real time
- Confirm no page refresh is required

**Note**: The PR will be ready for live testing at  
https://rocketchat.github.io/EmbeddedChat/pulls/pr-<pr_number>  
after approval. Contributors are requested to replace `<pr_number>` with the actual PR number.
