### PR TITLE
fix: prevent attachment metadata text overlap on mobile view

### DIFF
--- a/packages/react/src/views/AttachmentHandler/AttachmentMetadata.js
+++ b/packages/react/src/views/AttachmentHandler/AttachmentMetadata.js
@@ -108,6 +108,7 @@ const AttachmentMetadata = ({
               css={css`
                 margin: 0;
                 font-size: 12px;
+                line-height: 1.5;
                 opacity: 0.7;
               `}
             >
@@ -119,6 +120,7 @@ const AttachmentMetadata = ({
           <Box
             css={css`
               font-size: 12px;
+              line-height: 1.5;
               opacity: 0.7;
               @media (max-width: 420px) {
                 margin-left: 0;


### PR DESCRIPTION
### Summary
Attachment metadata text (title and file size) overlaps on mobile view due to inheriting `line-height: 0` from parent attachment containers.

---

### Fix
Explicitly set a readable `line-height` for attachment metadata text to ensure proper vertical stacking on mobile layouts across all attachment types.

---

### Testing
- Verified layout on desktop view
- Verified layout in Storybook using viewport controls:
  - Tablet
  - Large mobile
  - Small mobile

---

### Before
<img width="1247" height="707" alt="Attachment metadata overlap on mobile (before)" src="https://github.com/user-attachments/assets/5040c7dd-a237-4205-b221-de752b3eb665" />

---

### After
<img width="1247" height="707" alt="Attachment metadata layout fixed on mobile (after)" src="https://github.com/user-attachments/assets/b6a8934d-c31f-455a-a094-f1e21dc646fc" />
