### PR TITLE
fix: resolve broken message insertion logic

### DIFF
--- a/packages/react/src/lib/messageListHelpers.js
+++ b/packages/react/src/lib/messageListHelpers.js
@@ -2,12 +2,12 @@ import cloneArray from './cloneArray';
 
 // Caution: Not a pure function
 export const insertMessage = (messages, message) => {
-  const idx = messages.findIndex((m) => new Date(m.ts) < new Date(message.ts));
+  const idx = messages.findIndex((m) => new Date(m.ts) > new Date(message.ts));
   if (idx === -1) {
-    // all the messages are newer than the current message, insert at last
+    // all the messages are older than the current message, insert at last
     messages.push(message);
   } else if (idx === 0) {
-    // the message is the latest one, insert at front
+    // the message is the oldest one, insert at front
     messages.unshift(message);
   } else {
     messages.splice(idx, 0, message);

--- a/packages/react/src/store/messageStore.js
+++ b/packages/react/src/store/messageStore.js
@@ -23,9 +23,10 @@ const useMessageStore = create((set, get) => ({
   setFilter: (filter) => set(() => ({ filtered: filter })),
   setMessages: (newMessages, append = false) =>
     set((state) => {
+      const incomingAscending = [...newMessages].reverse();
       const allMessages = append
-        ? [...state.messages, ...newMessages]
-        : newMessages;
+        ? [...incomingAscending, ...state.messages]
+        : incomingAscending;
       const uniqueMessages = Array.from(
         new Map(allMessages.map((msg) => [msg._id, msg])).values()
       );

--- a/packages/react/src/views/MessageAggregators/common/MessageAggregator.js
+++ b/packages/react/src/views/MessageAggregators/common/MessageAggregator.js
@@ -43,7 +43,7 @@ export const MessageAggregator = ({
   const messages = useMessageStore((state) => state.messages);
   const threadMessages = useMessageStore((state) => state.threadMessages) || [];
   const allMessages = useMemo(
-    () => [...messages, ...[...threadMessages].reverse()],
+    () => [...messages, ...threadMessages],
     [messages, threadMessages]
   );
 

--- a/packages/react/src/views/MessageList/MessageList.js
+++ b/packages/react/src/views/MessageList/MessageList.js
@@ -76,37 +76,34 @@ const MessageList = ({
               <Throbber />
             </Box>
           )}
-          {filteredMessages
-            .slice()
-            .reverse()
-            .map((msg, index, arr) => {
-              const prev = arr[index - 1];
-              const next = arr[index + 1];
+          {filteredMessages.slice().map((msg, index, arr) => {
+            const prev = arr[index - 1];
+            const next = arr[index + 1];
 
-              if (!msg) return null;
-              const newDay = isMessageNewDay(msg, prev);
-              const sequential = isMessageSequential(msg, prev, 300);
-              const lastSequential =
-                sequential && isMessageLastSequential(msg, next);
-              const showUnreadDivider =
-                firstUnreadMessageId && msg._id === firstUnreadMessageId;
+            if (!msg) return null;
+            const newDay = isMessageNewDay(msg, prev);
+            const sequential = isMessageSequential(msg, prev, 300);
+            const lastSequential =
+              sequential && isMessageLastSequential(msg, next);
+            const showUnreadDivider =
+              firstUnreadMessageId && msg._id === firstUnreadMessageId;
 
-              return (
-                <React.Fragment key={msg._id}>
-                  {showUnreadDivider && (
-                    <MessageDivider unread>Unread Messages</MessageDivider>
-                  )}
-                  <Message
-                    message={msg}
-                    newDay={newDay}
-                    sequential={sequential}
-                    lastSequential={lastSequential}
-                    type="default"
-                    showAvatar
-                  />
-                </React.Fragment>
-              );
-            })}
+            return (
+              <React.Fragment key={msg._id}>
+                {showUnreadDivider && (
+                  <MessageDivider unread>Unread Messages</MessageDivider>
+                )}
+                <Message
+                  message={msg}
+                  newDay={newDay}
+                  sequential={sequential}
+                  lastSequential={lastSequential}
+                  type="default"
+                  showAvatar
+                />
+              </React.Fragment>
+            );
+          })}
           {showReportMessage && (
             <MessageReportWindow
               messageId={messageToReport}


### PR DESCRIPTION
This PR fixes incorrect message insertion behavior and removes inconsistencies in how messages are stored and rendered across the application.

Closes  #1082

---

## Solution

This PR **standardizes message storage across the application** by using a single, consistent order:

**Ascending order (Oldest → Newest)** everywhere.

### Key Changes

* **Updated `insertMessage`**
  The insertion logic now supports ascending lists by finding the correct index where the next message is newer:

  ```
  new Date(m.ts) > new Date(message.ts)
  ```

* **Updated `messageStore`**
  The `setMessages` action now reverses the server response (which is descending by default) **before storing it**, ensuring all messages in the store are ascending.