### PR TITLE
fix: Http Parameter Pollution in EmbeddedChatApi

### DIFF
--- a/packages/api/src/EmbeddedChatApi.ts
+++ b/packages/api/src/EmbeddedChatApi.ts
@@ -569,10 +569,10 @@ export default class EmbeddedChatApi {
     const roomType = isChannelPrivate ? "groups" : "channels";
     const endp = anonymousMode ? "anonymousread" : "messages";
     const query = options?.query
-      ? `&query=${JSON.stringify(options.query)}`
+      ? `&query=${encodeURIComponent(JSON.stringify(options.query))}`
       : "";
     const field = options?.field
-      ? `&field=${JSON.stringify(options.field)}`
+      ? `&field=${encodeURIComponent(JSON.stringify(options.field))}`
       : "";
     try {
       const { userId, authToken } = (await this.auth.getCurrentUser()) || {};
@@ -609,10 +609,10 @@ export default class EmbeddedChatApi {
     const roomType = isChannelPrivate ? "groups" : "channels";
     const endp = anonymousMode ? "anonymousread" : "messages";
     const query = options?.query
-      ? `&query=${JSON.stringify(options.query)}`
+      ? `&query=${encodeURIComponent(JSON.stringify(options.query))}`
       : "";
     const field = options?.field
-      ? `&field=${JSON.stringify(options.field)}`
+      ? `&field=${encodeURIComponent(JSON.stringify(options.field))}`
       : "";
     const offset = options?.offset ? options.offset : 0;
     try {


### PR DESCRIPTION
Fixed a High Severity HTTP Parameter Pollution vulnerability in [packages/api/src/EmbeddedChatApi.ts](cci:7://file:///home/deepak-bhagat/Desktop/EmbeddedChat/packages/api/src/EmbeddedChatApi.ts:0:0-0:0).
The [getMessages](cci:1://file:///home/deepak-bhagat/Desktop/EmbeddedChat/packages/api/src/EmbeddedChatApi.ts:550:2-593:3) and [getOlderMessages](cci:1://file:///home/deepak-bhagat/Desktop/EmbeddedChat/packages/api/src/EmbeddedChatApi.ts:595:2-634:3) methods were constructing API URLs by directly concatenating `JSON.stringify` output for `query` and `field` parameters.

Direct concatenation allowed malicious JSON objects containing URL special characters (like `&` or `=`) to break out of the query string parameter. This could allow attackers to inject additional parameters into the request (HTTP Parameter Pollution), potentially bypassing security filters or altering server behavior (e.g., overriding `roomId`).

Closes #1117

Updated [EmbeddedChatApi.ts](cci:7://file:///home/deepak-bhagat/Desktop/EmbeddedChat/packages/api/src/EmbeddedChatApi.ts:0:0-0:0) to strictly encode the stringified JSON using `encodeURIComponent()` before appending it to the URL.