### PR TITLE
fix: cleanup OAuth event listeners and interval on login success

### DIFF
--- a/packages/auth/src/loginWithRocketChatOAuth.ts
+++ b/packages/auth/src/loginWithRocketChatOAuth.ts
@@ -38,29 +38,47 @@ const loginWithRocketChatOAuth = async (config: { api: Api }) => {
     redirect_uri,
     client_id
   );
-  let params = `scrollbars=no,resizable=no,status=no,location=no,toolbar=no,menubar=no,
-width=800,height=600,left=-1000,top=-1000,rel=opener`;
+  let params = \`scrollbars=no,resizable=no,status=no,location=no,toolbar=no,menubar=no,
+width=800,height=600,left=-1000,top=-1000,rel=opener\`;
   const popup = window.open(authorizeUrl, "Login", params);
 
-  return new Promise<any>((resolve) => {
+  return new Promise<any>((resolve, reject) => {
     if (popup) {
+      let checkInterval: ReturnType<typeof setInterval>;
+      let settled = false;
+
+      const cleanup = () => {
+        clearInterval(checkInterval);
+        window.removeEventListener("message", onMessage);
+      };
+
       const onMessage = async (e: MessageEvent) => {
         if (e.data.type === "rc-oauth-callback") {
-          const { accessToken, expiresIn, serviceName } = e.data.credentials;
-          const response = await config.api.post("/api/v1/login", {
-            accessToken,
-            expiresIn,
-            serviceName,
-          });
-          popup.close();
-          resolve(response.data);
+          if (settled) return;
+          settled = true;
+          cleanup();
+          try {
+            const { accessToken, expiresIn, serviceName } = e.data.credentials;
+            const response = await config.api.post("/api/v1/login", {
+              accessToken,
+              expiresIn,
+              serviceName,
+            });
+            popup.close();
+            resolve(response.data);
+          } catch (error) {
+            popup.close();
+            reject(error);
+          }
         }
       };
       window.addEventListener("message", onMessage);
-      const checkInterval = setInterval(() => {
+      checkInterval = setInterval(() => {
         if (popup.closed) {
-          clearInterval(checkInterval);
-          window.removeEventListener("message", onMessage);
+          if (settled) return;
+          settled = true;
+          cleanup();
+          reject(new Error("OAuth popup closed before completing login"));
         }
       }, 1000);
     } else {


### PR DESCRIPTION
## Fix: OAuth event listener and interval memory leak

## Acceptance Criteria fulfillment

- [x] Event listener and interval are cleaned up immediately after successful OAuth login
- [x] Cleanup occurs when user closes popup without completing login
- [x] No race conditions when message and popup close happen simultaneously
- [x] API call errors are properly handled and rejected
- [x] Memory leaks eliminated for repeated OAuth authentication flows

Fixes #1125 

## Description

This PR fixes a memory leak in the OAuth authentication flow where event listeners and interval timers persisted after login completion.

**Before:**

Event listeners and intervals weren't cleaned up on login success, causing memory leaks and hanging promises when popup was closed manually.

**After:**

Added cleanup() function with settled flag to immediately remove listeners/intervals on success or popup close, preventing race conditions and properly handling API errors.

## PR Test Details

**Testing OAuth flow:**
1. Enable OAuth authentication in your EmbeddedChat config
2. Click login button to trigger OAuth flow
3. Complete login successfully → verify no console errors and authentication works
4. Repeat login multiple times → check browser's event listeners don't accumulate
5. Close popup without logging in → verify proper error message is displayed
