### PR TITLE
fix: privacy leak in getRoomInfo and UI crash safety

### DIFF
--- a/packages/api/src/EmbeddedChatApi.ts
+++ b/packages/api/src/EmbeddedChatApi.ts
@@ -73,21 +73,21 @@ export default class EmbeddedChatApi {
 
     const payload = acsCode
       ? JSON.stringify({
-        serviceName: "google",
-        accessToken: tokens.access_token,
-        idToken: tokens.id_token,
-        expiresIn: 3600,
-        totp: {
-          code: acsPayload,
-        },
-      })
+          serviceName: "google",
+          accessToken: tokens.access_token,
+          idToken: tokens.id_token,
+          expiresIn: 3600,
+          totp: {
+            code: acsPayload,
+          },
+        })
       : JSON.stringify({
-        serviceName: "google",
-        accessToken: tokens.access_token,
-        idToken: tokens.id_token,
-        expiresIn: 3600,
-        scope: "profile",
-      });
+          serviceName: "google",
+          accessToken: tokens.access_token,
+          idToken: tokens.id_token,
+          expiresIn: 3600,
+          scope: "profile",
+        });
 
     try {
       const req = await fetch(`${this.host}/api/v1/login`, {
@@ -363,7 +363,7 @@ export default class EmbeddedChatApi {
       typingHandlerLock = 0;
     }, 2000);
     // eslint-disable-next-line no-empty
-    while (typingHandlerLock) { }
+    while (typingHandlerLock) {}
     typingHandlerLock = 1;
     // move user to front if typing else remove it.
     const idx = this.typingUsers.indexOf(typingUser);
@@ -553,9 +553,9 @@ export default class EmbeddedChatApi {
       query?: object | undefined;
       field?: object | undefined;
     } = {
-        query: undefined,
-        field: undefined,
-      },
+      query: undefined,
+      field: undefined,
+    },
     isChannelPrivate = false
   ) {
     const roomType = isChannelPrivate ? "groups" : "channels";
@@ -592,10 +592,10 @@ export default class EmbeddedChatApi {
       field?: object | undefined;
       offset?: number;
     } = {
-        query: undefined,
-        field: undefined,
-        offset: 50,
-      },
+      query: undefined,
+      field: undefined,
+      offset: 50,
+    },
     isChannelPrivate = false
   ) {
     const roomType = isChannelPrivate ? "groups" : "channels";
@@ -743,13 +743,13 @@ export default class EmbeddedChatApi {
     const messageObj =
       typeof message === "string"
         ? {
-          rid: this.rid,
-          msg: message,
-        }
+            rid: this.rid,
+            msg: message,
+          }
         : {
-          ...message,
-          rid: this.rid,
-        };
+            ...message,
+            rid: this.rid,
+          };
     if (threadId) {
       messageObj.tmid = threadId;
     }

--- a/packages/api/src/EmbeddedChatApi.ts
+++ b/packages/api/src/EmbeddedChatApi.ts
@@ -73,21 +73,21 @@ export default class EmbeddedChatApi {
 
     const payload = acsCode
       ? JSON.stringify({
-          serviceName: "google",
-          accessToken: tokens.access_token,
-          idToken: tokens.id_token,
-          expiresIn: 3600,
-          totp: {
-            code: acsPayload,
-          },
-        })
+        serviceName: "google",
+        accessToken: tokens.access_token,
+        idToken: tokens.id_token,
+        expiresIn: 3600,
+        totp: {
+          code: acsPayload,
+        },
+      })
       : JSON.stringify({
-          serviceName: "google",
-          accessToken: tokens.access_token,
-          idToken: tokens.id_token,
-          expiresIn: 3600,
-          scope: "profile",
-        });
+        serviceName: "google",
+        accessToken: tokens.access_token,
+        idToken: tokens.id_token,
+        expiresIn: 3600,
+        scope: "profile",
+      });
 
     try {
       const req = await fetch(`${this.host}/api/v1/login`, {
@@ -363,7 +363,7 @@ export default class EmbeddedChatApi {
       typingHandlerLock = 0;
     }, 2000);
     // eslint-disable-next-line no-empty
-    while (typingHandlerLock) {}
+    while (typingHandlerLock) { }
     typingHandlerLock = 1;
     // move user to front if typing else remove it.
     const idx = this.typingUsers.indexOf(typingUser);
@@ -495,34 +495,26 @@ export default class EmbeddedChatApi {
     try {
       const { userId, authToken } = (await this.auth.getCurrentUser()) || {};
       const response = await fetch(
-        `${this.host}/api/v1/method.call/rooms%3Aget`,
+        `${this.host}/api/v1/rooms.info?roomId=${this.rid}`,
         {
-          body: JSON.stringify({
-            message: JSON.stringify({
-              msg: "method",
-              id: null,
-              method: "rooms/get",
-              params: [],
-            }),
-          }),
           headers: {
             "Content-Type": "application/json",
             "X-Auth-Token": authToken,
             "X-User-Id": userId,
           },
-          method: "POST",
+          method: "GET",
         }
       );
 
       const result = await response.json();
 
-      if (result.success && result.message) {
-        const parsedMessage = JSON.parse(result.message);
-        return parsedMessage;
+      if (result.success && result.room) {
+        return { result: [result.room] };
       }
-      return null;
+      return { result: [] };
     } catch (err) {
       console.error(err);
+      return { result: [] };
     }
   }
 
@@ -561,9 +553,9 @@ export default class EmbeddedChatApi {
       query?: object | undefined;
       field?: object | undefined;
     } = {
-      query: undefined,
-      field: undefined,
-    },
+        query: undefined,
+        field: undefined,
+      },
     isChannelPrivate = false
   ) {
     const roomType = isChannelPrivate ? "groups" : "channels";
@@ -600,10 +592,10 @@ export default class EmbeddedChatApi {
       field?: object | undefined;
       offset?: number;
     } = {
-      query: undefined,
-      field: undefined,
-      offset: 50,
-    },
+        query: undefined,
+        field: undefined,
+        offset: 50,
+      },
     isChannelPrivate = false
   ) {
     const roomType = isChannelPrivate ? "groups" : "channels";
@@ -751,13 +743,13 @@ export default class EmbeddedChatApi {
     const messageObj =
       typeof message === "string"
         ? {
-            rid: this.rid,
-            msg: message,
-          }
+          rid: this.rid,
+          msg: message,
+        }
         : {
-            ...message,
-            rid: this.rid,
-          };
+          ...message,
+          rid: this.rid,
+        };
     if (threadId) {
       messageObj.tmid = threadId;
     }

--- a/packages/react/src/views/ChatHeader/ChatHeader.js
+++ b/packages/react/src/views/ChatHeader/ChatHeader.js
@@ -199,7 +199,7 @@ const ChatHeader = ({
         setIsChannelArchived(true);
         const roomInfo = await RCInstance.getRoomInfo();
         const roomData = roomInfo.result[roomInfo.result.length - 1];
-        setChannelInfo(roomData);
+        setChannelInfo(roomData || {});
       } else if ('errorType' in res && res.errorType === 'Not Allowed') {
         dispatchToastMessage({
           type: 'error',


### PR DESCRIPTION
This PR fixes a **critical privacy issue** in `EmbeddedChatApi.getRoomInfo()` and improves UI stability when room information cannot be fetched.

---
Closes #1127

## Problem

### 1. Privacy Leak in `getRoomInfo`

Previously, `getRoomInfo()` called the Meteor method `rooms/get` with empty parameters. By default, this method returns **all rooms** (public channels, private groups, and DMs) that the authenticated user is a member of.

As a result, the Embedded Chat API exposed room data **outside the scope of the configured embedded room (`this.rid`)**, violating the principle of least privilege and leaking private user data to the embedding context.

### 2. UI Crash on Failed Room Fetch

When room information could not be retrieved (for example due to a network error or archived room access), `getRoomInfo()` returned `null`. This caused `ChatHeader` to crash when attempting to access properties on the missing data, resulting in a white screen.

---

## Solution

### Privacy Fix

* Updated `getRoomInfo()` in `EmbeddedChatApi.ts` to use the `rooms.info` REST endpoint.
* The request is now explicitly scoped to the embedded room ID (`this.rid`), ensuring only the current room’s data is returned.

### Error Handling

* Updated `getRoomInfo()` to return a safe fallback object (`{ result: [] }`) when the request fails or no room is found.

### UI Safety

* Updated `ChatHeader.js` to safely handle empty or missing room data using a defensive fallback (`roomData || {}`), preventing runtime crashes.

---

## Changes

* **packages/api/src/EmbeddedChatApi.ts**

  * Switched from `rooms/get` to `rooms.info`
  * Added scoped room lookup and safe error handling

* **packages/react/src/views/ChatHeader/ChatHeader.js**

  * Added null-check safeguards to prevent UI crashes