### PR TITLE
Fix unsafe null destructuring in auth credentials

### DIFF
--- a/packages/api/src/EmbeddedChatApi.ts
+++ b/packages/api/src/EmbeddedChatApi.ts
@@ -397,7 +397,7 @@ export default class EmbeddedChatApi {
 
   async updateUserNameThroughSuggestion(userid: string) {
     try {
-      const { userId, authToken } = (await this.auth.getCurrentUser()) || {};
+      const { userId, authToken } = (await this.auth.getCurrentUser()) ?? { userId: '', authToken: '' };
       const response = await fetch(
         `${this.host}/api/v1/users.getUsernameSuggestion`,
         {
@@ -440,7 +440,7 @@ export default class EmbeddedChatApi {
 
     if (usernameRegExp.test(newUserName)) {
       try {
-        const { userId, authToken } = (await this.auth.getCurrentUser()) || {};
+        const { userId, authToken } = (await this.auth.getCurrentUser()) ?? { userId: '', authToken: '' };
         const response = await fetch(`${this.host}/api/v1/users.update`, {
           body: JSON.stringify({
             userId: userid,
@@ -473,7 +473,7 @@ export default class EmbeddedChatApi {
 
   async channelInfo() {
     try {
-      const { userId, authToken } = (await this.auth.getCurrentUser()) || {};
+      const { userId, authToken } = (await this.auth.getCurrentUser()) ?? { userId: '', authToken: '' };
       const response = await fetch(
         `${this.host}/api/v1/rooms.info?roomId=${this.rid}`,
         {
@@ -493,7 +493,7 @@ export default class EmbeddedChatApi {
 
   async getRoomInfo() {
     try {
-      const { userId, authToken } = (await this.auth.getCurrentUser()) || {};
+      const { userId, authToken } = (await this.auth.getCurrentUser()) ?? { userId: '', authToken: '' };
       const response = await fetch(
         `${this.host}/api/v1/method.call/rooms%3Aget`,
         {
@@ -528,7 +528,7 @@ export default class EmbeddedChatApi {
 
   async permissionInfo() {
     try {
-      const { userId, authToken } = (await this.auth.getCurrentUser()) || {};
+      const { userId, authToken } = (await this.auth.getCurrentUser()) ?? { userId: '', authToken: '' };
       const response = await fetch(`${this.host}/api/v1/permissions.listAll`, {
         headers: {
           "Content-Type": "application/json",
@@ -575,7 +575,7 @@ export default class EmbeddedChatApi {
       ? `&field=${JSON.stringify(options.field)}`
       : "";
     try {
-      const { userId, authToken } = (await this.auth.getCurrentUser()) || {};
+      const { userId, authToken } = (await this.auth.getCurrentUser()) ?? { userId: '', authToken: '' };
       const messages = await fetch(
         `${this.host}/api/v1/${roomType}.${endp}?roomId=${this.rid}${query}${field}`,
         {
@@ -616,7 +616,7 @@ export default class EmbeddedChatApi {
       : "";
     const offset = options?.offset ? options.offset : 0;
     try {
-      const { userId, authToken } = (await this.auth.getCurrentUser()) || {};
+      const { userId, authToken } = (await this.auth.getCurrentUser()) ?? { userId: '', authToken: '' };
       const messages = await fetch(
         `${this.host}/api/v1/${roomType}.${endp}?roomId=${this.rid}${query}${field}&offset=${offset}`,
         {
@@ -636,7 +636,7 @@ export default class EmbeddedChatApi {
 
   async getThreadMessages(tmid: string, isChannelPrivate = false) {
     try {
-      const { userId, authToken } = (await this.auth.getCurrentUser()) || {};
+      const { userId, authToken } = (await this.auth.getCurrentUser()) ?? { userId: '', authToken: '' };
       const messages = await fetch(
         `${this.host}/api/v1/chat.getThreadMessages?tmid=${tmid}`,
         {
@@ -657,7 +657,7 @@ export default class EmbeddedChatApi {
   async getChannelRoles(isChannelPrivate = false) {
     const roomType = isChannelPrivate ? "groups" : "channels";
     try {
-      const { userId, authToken } = (await this.auth.getCurrentUser()) || {};
+      const { userId, authToken } = (await this.auth.getCurrentUser()) ?? { userId: '', authToken: '' };
       const roles = await fetch(
         `${this.host}/api/v1/${roomType}.roles?roomId=${this.rid}`,
         {
@@ -677,7 +677,7 @@ export default class EmbeddedChatApi {
 
   async getUsersInRole(role: string) {
     try {
-      const { userId, authToken } = (await this.auth.getCurrentUser()) || {};
+      const { userId, authToken } = (await this.auth.getCurrentUser()) ?? { userId: '', authToken: '' };
       const roles = await fetch(
         `${this.host}/api/v1/roles.getUsersInRole?role=${role}`,
         {
@@ -697,7 +697,7 @@ export default class EmbeddedChatApi {
 
   async getUserRoles() {
     try {
-      const { userId, authToken } = (await this.auth.getCurrentUser()) || {};
+      const { userId, authToken } = (await this.auth.getCurrentUser()) ?? { userId: '', authToken: '' };
       const response = await fetch(
         `${this.host}/api/v1/method.call/getUserRoles`,
         {
@@ -762,7 +762,7 @@ export default class EmbeddedChatApi {
       messageObj.tmid = threadId;
     }
     try {
-      const { userId, authToken } = (await this.auth.getCurrentUser()) || {};
+      const { userId, authToken } = (await this.auth.getCurrentUser()) ?? { userId: '', authToken: '' };
       const response = await fetch(`${this.host}/api/v1/chat.sendMessage`, {
         body: JSON.stringify({ message: messageObj }),
         headers: {
@@ -780,7 +780,7 @@ export default class EmbeddedChatApi {
 
   async deleteMessage(msgId: string) {
     try {
-      const { userId, authToken } = (await this.auth.getCurrentUser()) || {};
+      const { userId, authToken } = (await this.auth.getCurrentUser()) ?? { userId: '', authToken: '' };
       const response = await fetch(`${this.host}/api/v1/chat.delete`, {
         body: JSON.stringify({ roomId: this.rid, msgId }),
         headers: {
@@ -798,7 +798,7 @@ export default class EmbeddedChatApi {
 
   async updateMessage(msgId: string, text: string) {
     try {
-      const { userId, authToken } = (await this.auth.getCurrentUser()) || {};
+      const { userId, authToken } = (await this.auth.getCurrentUser()) ?? { userId: '', authToken: '' };
       const response = await fetch(`${this.host}/api/v1/chat.update`, {
         body: JSON.stringify({ roomId: this.rid, msgId, text }),
         headers: {
@@ -817,7 +817,7 @@ export default class EmbeddedChatApi {
   async getAllFiles(isChannelPrivate = false, typeGroup: string) {
     const roomType = isChannelPrivate ? "groups" : "channels";
     try {
-      const { userId, authToken } = (await this.auth.getCurrentUser()) || {};
+      const { userId, authToken } = (await this.auth.getCurrentUser()) ?? { userId: '', authToken: '' };
       const url =
         typeGroup === ""
           ? `${this.host}/api/v1/${roomType}.files?roomId=${this.rid}`
@@ -838,7 +838,7 @@ export default class EmbeddedChatApi {
 
   async getAllImages() {
     try {
-      const { userId, authToken } = (await this.auth.getCurrentUser()) || {};
+      const { userId, authToken } = (await this.auth.getCurrentUser()) ?? { userId: '', authToken: '' };
       const response = await fetch(
         `${this.host}/api/v1/rooms.images?roomId=${this.rid}`,
         {
@@ -858,7 +858,7 @@ export default class EmbeddedChatApi {
 
   async starMessage(mid: string) {
     try {
-      const { userId, authToken } = (await this.auth.getCurrentUser()) || {};
+      const { userId, authToken } = (await this.auth.getCurrentUser()) ?? { userId: '', authToken: '' };
       const response = await fetch(`${this.host}/api/v1/chat.starMessage`, {
         body: JSON.stringify({ messageId: mid }),
         headers: {
@@ -876,7 +876,7 @@ export default class EmbeddedChatApi {
 
   async unstarMessage(mid: string) {
     try {
-      const { userId, authToken } = (await this.auth.getCurrentUser()) || {};
+      const { userId, authToken } = (await this.auth.getCurrentUser()) ?? { userId: '', authToken: '' };
       const response = await fetch(`${this.host}/api/v1/chat.unStarMessage`, {
         body: JSON.stringify({ messageId: mid }),
         headers: {
@@ -894,7 +894,7 @@ export default class EmbeddedChatApi {
 
   async getStarredMessages() {
     try {
-      const { userId, authToken } = (await this.auth.getCurrentUser()) || {};
+      const { userId, authToken } = (await this.auth.getCurrentUser()) ?? { userId: '', authToken: '' };
       const response = await fetch(
         `${this.host}/api/v1/chat.getStarredMessages?roomId=${this.rid}`,
         {
@@ -914,7 +914,7 @@ export default class EmbeddedChatApi {
 
   async getPinnedMessages() {
     try {
-      const { userId, authToken } = (await this.auth.getCurrentUser()) || {};
+      const { userId, authToken } = (await this.auth.getCurrentUser()) ?? { userId: '', authToken: '' };
       const response = await fetch(
         `${this.host}/api/v1/chat.getPinnedMessages?roomId=${this.rid}`,
         {
@@ -934,7 +934,7 @@ export default class EmbeddedChatApi {
 
   async getMentionedMessages() {
     try {
-      const { userId, authToken } = (await this.auth.getCurrentUser()) || {};
+      const { userId, authToken } = (await this.auth.getCurrentUser()) ?? { userId: '', authToken: '' };
       const response = await fetch(
         `${this.host}/api/v1/chat.getMentionedMessages?roomId=${this.rid}`,
         {
@@ -954,7 +954,7 @@ export default class EmbeddedChatApi {
 
   async pinMessage(mid: string) {
     try {
-      const { userId, authToken } = (await this.auth.getCurrentUser()) || {};
+      const { userId, authToken } = (await this.auth.getCurrentUser()) ?? { userId: '', authToken: '' };
       const response = await fetch(`${this.host}/api/v1/chat.pinMessage`, {
         body: JSON.stringify({ messageId: mid }),
         headers: {
@@ -974,7 +974,7 @@ export default class EmbeddedChatApi {
 
   async unpinMessage(mid: string) {
     try {
-      const { userId, authToken } = (await this.auth.getCurrentUser()) || {};
+      const { userId, authToken } = (await this.auth.getCurrentUser()) ?? { userId: '', authToken: '' };
       const response = await fetch(`${this.host}/api/v1/chat.unPinMessage`, {
         body: JSON.stringify({ messageId: mid }),
         headers: {
@@ -992,7 +992,7 @@ export default class EmbeddedChatApi {
 
   async reactToMessage(emoji: string, messageId: string, shouldReact: string) {
     try {
-      const { userId, authToken } = (await this.auth.getCurrentUser()) || {};
+      const { userId, authToken } = (await this.auth.getCurrentUser()) ?? { userId: '', authToken: '' };
       const response = await fetch(`${this.host}/api/v1/chat.react`, {
         body: JSON.stringify({
           messageId,
@@ -1014,7 +1014,7 @@ export default class EmbeddedChatApi {
 
   async reportMessage(messageId: string, description: string) {
     try {
-      const { userId, authToken } = (await this.auth.getCurrentUser()) || {};
+      const { userId, authToken } = (await this.auth.getCurrentUser()) ?? { userId: '', authToken: '' };
       const response = await fetch(`${this.host}/api/v1/chat.reportMessage`, {
         body: JSON.stringify({ messageId, description }),
         headers: {
@@ -1032,7 +1032,7 @@ export default class EmbeddedChatApi {
 
   async findOrCreateInvite() {
     try {
-      const { userId, authToken } = (await this.auth.getCurrentUser()) || {};
+      const { userId, authToken } = (await this.auth.getCurrentUser()) ?? { userId: '', authToken: '' };
       const response = await fetch(`${this.host}/api/v1/findOrCreateInvite`, {
         method: "POST",
         body: JSON.stringify({ rid: this.rid, days: 1, maxUses: 10 }),
@@ -1055,7 +1055,7 @@ export default class EmbeddedChatApi {
     threadId = undefined
   ) {
     try {
-      const { userId, authToken } = (await this.auth.getCurrentUser()) || {};
+      const { userId, authToken } = (await this.auth.getCurrentUser()) ?? { userId: '', authToken: '' };
       const form = new FormData();
       if (threadId) {
         form.append("tmid", threadId);
@@ -1081,7 +1081,7 @@ export default class EmbeddedChatApi {
 
   async me() {
     try {
-      const { userId, authToken } = (await this.auth.getCurrentUser()) || {};
+      const { userId, authToken } = (await this.auth.getCurrentUser()) ?? { userId: '', authToken: '' };
       const response = await fetch(`${this.host}/api/v1/me`, {
         headers: {
           "Content-Type": "application/json",
@@ -1099,7 +1099,7 @@ export default class EmbeddedChatApi {
   async getChannelMembers(isChannelPrivate = false) {
     const roomType = isChannelPrivate ? "groups" : "channels";
     try {
-      const { userId, authToken } = (await this.auth.getCurrentUser()) || {};
+      const { userId, authToken } = (await this.auth.getCurrentUser()) ?? { userId: '', authToken: '' };
       const response = await fetch(
         `${this.host}/api/v1/${roomType}.members?roomId=${this.rid}`,
         {
@@ -1119,7 +1119,7 @@ export default class EmbeddedChatApi {
 
   async getSearchMessages(text: string) {
     try {
-      const { userId, authToken } = (await this.auth.getCurrentUser()) || {};
+      const { userId, authToken } = (await this.auth.getCurrentUser()) ?? { userId: '', authToken: '' };
       const response = await fetch(
         `${this.host}/api/v1/chat.search?roomId=${this.rid}&searchText=${text}`,
         {
@@ -1139,7 +1139,7 @@ export default class EmbeddedChatApi {
 
   async getMessageLimit() {
     try {
-      const { userId, authToken } = (await this.auth.getCurrentUser()) || {};
+      const { userId, authToken } = (await this.auth.getCurrentUser()) ?? { userId: '', authToken: '' };
       const response = await fetch(
         `${this.host}/api/v1/settings/Message_MaxAllowedSize`,
         {
@@ -1159,7 +1159,7 @@ export default class EmbeddedChatApi {
 
   async handleUiKitInteraction(appId: string, userInteraction: any) {
     try {
-      const { userId, authToken } = (await this.auth.getCurrentUser()) || {};
+      const { userId, authToken } = (await this.auth.getCurrentUser()) ?? { userId: '', authToken: '' };
 
       const triggerId = Math.random().toString(32).slice(2, 16);
 
@@ -1188,7 +1188,7 @@ export default class EmbeddedChatApi {
   }
 
   async getCommandsList() {
-    const { userId, authToken } = (await this.auth.getCurrentUser()) || {};
+    const { userId, authToken } = (await this.auth.getCurrentUser()) ?? { userId: '', authToken: '' };
     const response = await fetch(`${this.host}/api/v1/commands.list`, {
       headers: {
         "Content-Type": "application/json",
@@ -1210,7 +1210,7 @@ export default class EmbeddedChatApi {
     params: string;
     tmid?: string;
   }) {
-    const { userId, authToken } = (await this.auth.getCurrentUser()) || {};
+    const { userId, authToken } = (await this.auth.getCurrentUser()) ?? { userId: '', authToken: '' };
     const response = await fetch(`${this.host}/api/v1/commands.run`, {
       headers: {
         "Content-Type": "application/json",
@@ -1231,7 +1231,7 @@ export default class EmbeddedChatApi {
   }
 
   async getUserStatus(reqUserId: string) {
-    const { userId, authToken } = (await this.auth.getCurrentUser()) || {};
+    const { userId, authToken } = (await this.auth.getCurrentUser()) ?? { userId: '', authToken: '' };
     const response = await fetch(
       `${this.host}/api/v1/users.getStatus?userId=${reqUserId}`,
       {
@@ -1248,7 +1248,7 @@ export default class EmbeddedChatApi {
   }
 
   async userInfo(reqUserId: string) {
-    const { userId, authToken } = (await this.auth.getCurrentUser()) || {};
+    const { userId, authToken } = (await this.auth.getCurrentUser()) ?? { userId: '', authToken: '' };
     const response = await fetch(
       `${this.host}/api/v1/users.info?userId=${reqUserId}`,
       {
@@ -1265,7 +1265,7 @@ export default class EmbeddedChatApi {
   }
 
   async userData(username: string) {
-    const { userId, authToken } = (await this.auth.getCurrentUser()) || {};
+    const { userId, authToken } = (await this.auth.getCurrentUser()) ?? { userId: '', authToken: '' };
     const response = await fetch(
       `${this.host}/api/v1/users.info?username=${username}`,
       {


### PR DESCRIPTION
## Fix unsafe null destructuring in auth credentials

## Acceptance Criteria fulfillment

- [x] Replace unsafe `|| {}` pattern with nullish coalescing `?? { userId: '', authToken: '' }`
- [x] Fix all 37 occurrences across API methods
- [x] Ensure empty strings are sent instead of literal `"undefined"` string in headers
- [x] Maintain backward compatibility with existing UI code

Fixes #1133 

## Description

Fixed a bug where unauthenticated API calls were sending the literal string `"undefined"` in HTTP headers instead of empty values. The original pattern `(await this.auth.getCurrentUser()) || {}` caused destructuring of an empty object, resulting in `undefined` values that JavaScript's `Headers.set()` converted to the string `"undefined"`.

**Changes:**

 `|| {}` → `?? { userId: '', authToken: '' }` (37 occurrences)

**Impact:** Headers now contain clean empty strings instead of `"undefined"`.

