### PR TITLE
fix(build): stabilize rollup terser on Windows by limiting workers

### DIFF
--- a/packages/markups/rollup.config.js
+++ b/packages/markups/rollup.config.js
@@ -10,6 +10,7 @@ import analyze from 'rollup-plugin-analyzer';
 import dts from 'rollup-plugin-dts';
 
 const PRODUCTION = process.env.NODE_ENV === 'production';
+const TERSER_OPTIONS = { numWorkers: 1 };
 
 export default [
   {
@@ -21,7 +22,7 @@ export default [
         sourcemap: 'hidden',
         preserveModules: true,
         preserveModulesRoot: 'src',
-        plugins: [PRODUCTION && terser()],
+        plugins: [PRODUCTION && terser(TERSER_OPTIONS)],
         exports: 'auto',
       },
 
@@ -31,7 +32,7 @@ export default [
         sourcemap: 'hidden',
         preserveModules: true,
         preserveModulesRoot: 'src',
-        plugins: [PRODUCTION && terser()],
+        plugins: [PRODUCTION && terser(TERSER_OPTIONS)],
       },
     ],
     external: [

--- a/packages/react/rollup.config.js
+++ b/packages/react/rollup.config.js
@@ -11,6 +11,7 @@ import analyze from 'rollup-plugin-analyzer';
 
 const packageJson = require('./package.json');
 const PRODUCTION = process.env.NODE_ENV === 'production';
+const TERSER_OPTIONS = { numWorkers: 1 };
 
 export default [
   {
@@ -20,13 +21,13 @@ export default [
         file: packageJson.main,
         format: 'cjs',
         sourcemap: true,
-        plugins: [PRODUCTION && terser()],
+        plugins: [PRODUCTION && terser(TERSER_OPTIONS)],
       },
       {
         file: packageJson.module,
         format: 'esm',
         sourcemap: true,
-        plugins: [PRODUCTION && terser()],
+        plugins: [PRODUCTION && terser(TERSER_OPTIONS)],
       },
     ],
     external: [

--- a/packages/ui-elements/rollup.config.js
+++ b/packages/ui-elements/rollup.config.js
@@ -10,6 +10,7 @@ import analyze from 'rollup-plugin-analyzer';
 import dts from 'rollup-plugin-dts';
 
 const PRODUCTION = process.env.NODE_ENV === 'production';
+const TERSER_OPTIONS = { numWorkers: 1 };
 
 export default [
   {
@@ -21,7 +22,7 @@ export default [
         sourcemap: 'hidden',
         preserveModules: true,
         preserveModulesRoot: 'src',
-        plugins: [PRODUCTION && terser()],
+        plugins: [PRODUCTION && terser(TERSER_OPTIONS)],
         exports: 'auto',
       },
 
@@ -31,7 +32,7 @@ export default [
         sourcemap: 'hidden',
         preserveModules: true,
         preserveModulesRoot: 'src',
-        plugins: [PRODUCTION && terser()],
+        plugins: [PRODUCTION && terser(TERSER_OPTIONS)],
       },
     ],
     external: ['react', 'react-dom', '@emotion/react'],

--- a/packages/ui-kit/rollup.config.js
+++ b/packages/ui-kit/rollup.config.js
@@ -10,6 +10,7 @@ import analyze from 'rollup-plugin-analyzer';
 import dts from 'rollup-plugin-dts';
 
 const PRODUCTION = process.env.NODE_ENV === 'production';
+const TERSER_OPTIONS = { numWorkers: 1 };
 
 export default [
   {
@@ -21,7 +22,7 @@ export default [
         sourcemap: 'hidden',
         preserveModules: true,
         preserveModulesRoot: 'src',
-        plugins: [PRODUCTION && terser()],
+        plugins: [PRODUCTION && terser(TERSER_OPTIONS)],
         exports: 'auto',
       },
 
@@ -31,7 +32,7 @@ export default [
         sourcemap: 'hidden',
         preserveModules: true,
         preserveModulesRoot: 'src',
-        plugins: [PRODUCTION && terser()],
+        plugins: [PRODUCTION && terser(TERSER_OPTIONS)],
       },
     ],
     external: [


### PR DESCRIPTION
Stabilizes Windows Rollup builds by limiting Terser worker parallelism to avoid OOM and worker spawn failures.

## Windows Rollup Build Stability

## Acceptance Criteria fulfillment

- [x] Reproduced intermittent Windows build failures in Rollup minification (`Call retries were exceeded`, `spawn UNKNOWN`, OOM).
- [x] Updated Rollup configs to use conservative Terser worker settings (`numWorkers: 1`) in affected packages.
- [x] Verified local builds succeed for impacted packages after change.

Fixes #1137

## What changed

This PR limits terser worker parallelism to avoid Windows process/memory pressure:

- `packages/markups/rollup.config.js`
- `packages/react/rollup.config.js`
- `packages/ui-elements/rollup.config.js`
- `packages/ui-kit/rollup.config.js`

Each now uses:
- `const TERSER_OPTIONS = { numWorkers: 1 }`
- `terser(TERSER_OPTIONS)` in build outputs.

## Why this is safe

This is a conservative build-time-only change.  
It preserves deterministic output and does not change runtime behavior of the packages.

## PR Test Details

Validated locally on Windows with Node `16.19.0` / Yarn `3.6.4`:

- `yarn workspace @embeddedchat/markups build` ✅
- `yarn workspace @embeddedchat/ui-elements build` ✅
- `yarn workspace @embeddedchat/ui-kit build` ✅
- `yarn workspace @embeddedchat/react build` ✅

Notes:
- Root `yarn build` may still fail in low-disk environments due to unrelated `ENOSPC` (disk space) errors.