### PR TITLE
fix(auth): propagate secure token request failures

### DIFF
--- a/packages/auth/src/utils/tokenRequestHandler.ts
+++ b/packages/auth/src/utils/tokenRequestHandler.ts
@@ -24,5 +24,6 @@ export async function tokenRequestHandler(
     return response.json();
   } catch (error) {
     console.error(`Error with ${method} request:`, error);
+    throw error;
   }
 }

--- a/packages/react/src/lib/auth.js
+++ b/packages/react/src/lib/auth.js
@@ -18,7 +18,7 @@ async function deleteTokenLocalStorage() {
 }
 
 async function saveTokenSecure(token) {
-  return await this.handleSecureLogin('save', token);
+  return this.handleSecureLogin('save', token);
 }
 
 async function getTokenSecure() {
@@ -27,7 +27,7 @@ async function getTokenSecure() {
 }
 
 async function deleteTokenSecure() {
-  return await this.handleSecureLogin('delete');
+  return this.handleSecureLogin('delete');
 }
 
 export function getTokenStorage(secure = false) {

--- a/packages/react/src/lib/auth.js
+++ b/packages/react/src/lib/auth.js
@@ -18,7 +18,7 @@ async function deleteTokenLocalStorage() {
 }
 
 async function saveTokenSecure(token) {
-  this.handleSecureLogin('save', token);
+  return await this.handleSecureLogin('save', token);
 }
 
 async function getTokenSecure() {
@@ -27,7 +27,7 @@ async function getTokenSecure() {
 }
 
 async function deleteTokenSecure() {
-  this.handleSecureLogin('delete');
+  return await this.handleSecureLogin('delete');
 }
 
 export function getTokenStorage(secure = false) {


### PR DESCRIPTION
# Fix secure token error propagation in auth helpers

## Acceptance Criteria fulfillment

- [x] `tokenRequestHandler` no longer swallows request failures.
- [x] Secure token save/delete helpers now await and propagate failures.
- [x] Build passes for impacted packages (`@embeddedchat/auth`, `@embeddedchat/react`).

Fixes #1141

## Video/Screenshots

N/A (logic-only change)

## PR Test Details
- `yarn lerna run build --scope @embeddedchat/auth --scope @embeddedchat/react` ✅
- Confirmed `tokenRequestHandler` rethrows in `catch`
- Confirmed secure token save/delete paths await and propagate failures
