### PR TITLE
Fix: Render App Engine image attachments correctly

### DIFF
--- a/packages/react/src/views/AttachmentHandler/Attachment.js
+++ b/packages/react/src/views/AttachmentHandler/Attachment.js
@@ -32,7 +32,11 @@ const Attachment = ({ attachment, host, type, variantStyles = {}, msg }) => {
       />
     );
   }
-  if (attachment && attachment.image_url) {
+  if (
+    attachment &&
+    (attachment.image_url ||
+      (attachment.image_type?.startsWith('image/') && attachment.title_link))
+  ) {
     return (
       <ImageAttachment
         attachment={attachment}

--- a/packages/react/src/views/AttachmentHandler/ImageAttachment.js
+++ b/packages/react/src/views/AttachmentHandler/ImageAttachment.js
@@ -35,6 +35,16 @@ const ImageAttachment = ({
     setIsExpanded((prevState) => !prevState);
   };
 
+  const getImageUrl = (url) => {
+    if (!url) {
+      return;
+    }
+    if (url.startsWith('http') || url.startsWith('//')) {
+      return url;
+    }
+    return `${host}${url}`;
+  };
+
   return (
     <Box css={variantStyles.imageAttachmentContainer}>
       <Box
@@ -86,7 +96,7 @@ const ImageAttachment = ({
         >
           <AttachmentMetadata
             attachment={attachment}
-            url={host + (attachment.title_link || attachment.image_url)}
+            url={getImageUrl(attachment.title_link || attachment.image_url)}
             variantStyles={variantStyles}
             msg={msg}
             onExpandCollapseClick={toggleExpanded}
@@ -94,9 +104,20 @@ const ImageAttachment = ({
           />
         </Box>
         {isExpanded && (
-          <Box onClick={() => setShowGallery(true)}>
+          <Box
+            onClick={() =>
+              extractIdFromUrl(attachment.title_link)
+                ? setShowGallery(true)
+                : null
+            }
+            style={{
+              cursor: extractIdFromUrl(attachment.title_link)
+                ? 'pointer'
+                : 'default',
+            }}
+          >
             <img
-              src={host + attachment.image_url}
+              src={getImageUrl(attachment.image_url || attachment.title_link)}
               style={{
                 maxWidth: '100%',
                 objectFit: 'contain',
@@ -110,10 +131,16 @@ const ImageAttachment = ({
           attachment.attachments.map((nestedAttachment, index) => (
             <Box css={variantStyles.imageAttachmentContainer} key={index}>
               <Box
-                onClick={() => setShowGallery(true)}
+                onClick={() =>
+                  extractIdFromUrl(nestedAttachment.title_link)
+                    ? setShowGallery(true)
+                    : null
+                }
                 css={[
                   css`
-                    cursor: pointer;
+                    cursor: ${extractIdFromUrl(nestedAttachment.title_link)
+                      ? 'pointer'
+                      : 'default'};
                     border-radius: inherit;
                     line-height: 0;
                     padding: 0.5rem;
@@ -153,14 +180,15 @@ const ImageAttachment = ({
                 )}
                 <AttachmentMetadata
                   attachment={nestedAttachment}
-                  url={
-                    host +
-                    (nestedAttachment.title_link || nestedAttachment.image_url)
-                  }
+                  url={getImageUrl(
+                    nestedAttachment.title_link || nestedAttachment.image_url
+                  )}
                   variantStyles={variantStyles}
                 />
                 <img
-                  src={host + nestedAttachment.image_url}
+                  src={getImageUrl(
+                    nestedAttachment.image_url || nestedAttachment.title_link
+                  )}
                   style={{
                     maxWidth: '100%',
                     objectFit: 'contain',


### PR DESCRIPTION
This PR fixes an issue where image attachments sent via the Rocket.Chat App Engine were rendered as generic file attachments instead of inline images.

The issue occurred because the `Attachment` component strictly required an `image_url` property to render an `ImageAttachment`. However, App Engine payloads often provide `image_type` and `title_link` without an explicit `image_url`, causing valid image attachments to fall back to the generic file view.

Additionally, this PR fixes broken image links and non-functional download buttons for these attachments by correctly handling absolute URLs.
---

Closes  #1140

## Changes

### `Attachment.js`

* Updated the rendering condition to treat attachments as images when:

  * `image_type` starts with `image/`, and
  * a valid `title_link` is present,
    even if `image_url` is missing.

### `ImageAttachment.js`

* Added fallback logic to use `title_link` as the image source when `image_url` is not available.
* Implemented `getImageUrl` helper to correctly resolve absolute URLs (e.g., external storage like Google Cloud), preventing double-host prefixing issues.
* Updated `AttachmentMetadata` to receive the resolved, correct URL, fixing broken download button behavior.

---

Screenshots

Before
<img width="1561" height="269" alt="Screenshot from 2026-02-09 20-09-49" src="https://github.com/user-attachments/assets/8bd90e4f-e2be-49cf-8994-59af82f5d942" />

After
<img width="1600" height="678" alt="Screenshot from 2026-02-09 20-11-55" src="https://github.com/user-attachments/assets/6a48c9ec-04d6-4dcb-8568-ad954e9580d6" />

## How to Test

1. Send a message with an attachment resembling an App Engine payload:

   * Missing `image_url`
   * Includes `title_link`
   * Includes `image_type: "image/png"`
2. Verify the attachment renders as an **inline image** instead of a generic file card.
