### PR TITLE
fix: deleteing message cause a jump to feed ending

### DIFF
--- a/packages/react/src/views/ChatBody/ChatBody.js
+++ b/packages/react/src/views/ChatBody/ChatBody.js
@@ -307,11 +307,18 @@ const ChatBody = ({
     }
   };
 
+  const prevMessagesLength = useRef(0);
+
   useEffect(() => {
-    if (messageListRef.current) {
+    if (
+      messageListRef.current &&
+      messages.length > prevMessagesLength.current &&
+      !loadingOlderMessages
+    ) {
       messageListRef.current.scrollTop = messageListRef.current.scrollHeight;
     }
-  }, [messages]);
+    prevMessagesLength.current = messages.length;
+  }, [messages, loadingOlderMessages]);
 
   useEffect(() => {
     checkOverflow();


### PR DESCRIPTION
# Fix unstable feed behavior after message deletion

## Acceptance Criteria fulfillment

- [x] Prevent jumps to bottom when a message is deleted

Fixes #1145 

## Video/Screenshots

### Before (Buggy)
https://github.com/user-attachments/assets/19a822d7-b19a-4ec3-8ae7-c89cad6b1f47

### Current (fixed)
https://github.com/user-attachments/assets/a5a2b488-fe89-4614-b2e1-5d85e33b65d9

## PR Test Details

1. Scroll up to view older messages.
2. Delete a message from the middle of the feed.
3. Verify: The chat feed should not jump to the bottom. it should stay at the current feed position.

**Note**: The PR will be ready for live testing at https://rocketchat.github.io/EmbeddedChat/pulls/pr-<pr_number> after approval. Contributors are requested to replace `<pr_number>` with the actual PR number.
