### PR TITLE
fix(api): URL-encode searchText in chat.search

### DIFF
--- a/packages/api/src/EmbeddedChatApi.ts
+++ b/packages/api/src/EmbeddedChatApi.ts
@@ -1120,8 +1120,12 @@ export default class EmbeddedChatApi {
   async getSearchMessages(text: string) {
     try {
       const { userId, authToken } = (await this.auth.getCurrentUser()) || {};
+      const queryParams = new URLSearchParams({
+        roomId: this.rid,
+        searchText: text,
+      });
       const response = await fetch(
-        `${this.host}/api/v1/chat.search?roomId=${this.rid}&searchText=${text}`,
+        `${this.host}/api/v1/chat.search?${queryParams.toString()}`,
         {
           headers: {
             "Content-Type": "application/json",


### PR DESCRIPTION
# Fix URL encoding in chat.search query params

## Acceptance Criteria fulfillment

- [x] Updated `getSearchMessages` to encode query parameters using `URLSearchParams`.
- [x] Ensured user input in `searchText` is safely encoded (`&`, `?`, `#`, `%`, `+`, spaces).
- [x] Confirmed API package builds successfully after the change.

Fixes #1149

## PR Test Details

- Ran: `yarn workspace @embeddedchat/api build` (passed).
- Verified generated request URL encodes reserved characters correctly in `searchText`.
- Confirmed no functional change for normal search inputs.