### PR TITLE
fix: unknown slash commands crash & incorrect handling

### DIFF
--- a/packages/react/src/hooks/useShowCommands.js
+++ b/packages/react/src/hooks/useShowCommands.js
@@ -9,7 +9,11 @@ const useShowCommands = (commands, setFilteredCommands, setShowCommandList) =>
       const cursor = e.target.selectionStart;
       const tokens = e.target.value.slice(0, cursor).split(/\s+/);
 
-      if (tokens.length === 1 && tokens[0].startsWith('/')) {
+      if (
+        tokens.length === 1 &&
+        tokens[0].startsWith('/') &&
+        getFilteredCommands(tokens[0]).length > 0
+      ) {
         setFilteredCommands(getFilteredCommands(tokens[0]));
         setShowCommandList(true);
       } else {

--- a/packages/react/src/views/ChatInput/ChatInput.js
+++ b/packages/react/src/views/ChatInput/ChatInput.js
@@ -354,8 +354,25 @@ const ChatInput = ({ scrollToBottom, clearUnreadDividerRef }) => {
 
   const handleCommandExecution = async (message) => {
     const execCommand = async (command, params) => {
-      await RCInstance.execCommand({ command, params, tmid: threadId });
-      setFilteredCommands([]);
+      try {
+        const result = await RCInstance.execCommand({
+          command,
+          params,
+          tmid: threadId,
+        });
+        if (!result.success) {
+          dispatchToastMessage({
+            type: 'error',
+            message: result.error || 'No such command',
+          });
+        }
+        setFilteredCommands([]);
+      } catch (e) {
+        dispatchToastMessage({
+          type: 'error',
+          message: 'No such command',
+        });
+      }
     };
 
     const [command, ...paramsArray] = message.split(' ');
@@ -366,7 +383,14 @@ const ChatInput = ({ scrollToBottom, clearUnreadDividerRef }) => {
       setDisableButton(true);
       setEditMessage({});
       await execCommand(command.replace('/', ''), params);
+      return true;
     }
+
+    messageRef.current.value = '';
+    setDisableButton(true);
+    setEditMessage({});
+    await execCommand(command.replace('/', ''), params);
+    return true;
   };
 
   const sendMessage = async () => {
@@ -392,7 +416,7 @@ const ChatInput = ({ scrollToBottom, clearUnreadDividerRef }) => {
       return;
     }
     if (message.startsWith('/')) {
-      handleCommandExecution(message);
+      await handleCommandExecution(message);
       return;
     }
 

--- a/packages/react/src/views/CommandList/CommandsList.js
+++ b/packages/react/src/views/CommandList/CommandsList.js
@@ -51,7 +51,9 @@ function CommandsList({
       switch (event.key) {
         case 'Enter': {
           const selectedItem = filteredCommands[commandIndex];
-          handleCommandClick(selectedItem);
+          if (selectedItem) {
+            handleCommandClick(selectedItem);
+          }
           break;
         }
         case 'ArrowDown':


### PR DESCRIPTION
This PR fixes a bug where the app crashed if a user typed an unknown slash command (for example, `/hello`) and pressed Enter.

Now, unknown slash commands are treated as command attempts instead of normal chat messages. If the command does not exist on the server, the user will see a "No such command" message.

---
Closes: #1144

Screenshots
<img width="857" height="149" alt="Screenshot from 2026-02-17 01-40-40" src="https://github.com/user-attachments/assets/176bfa68-6ec9-4357-8bf6-80e3d26599fa" />

## Changes Made

### 1. packages/react/src/views/CommandList/CommandsList.js

* Added a safety check in `handleKeyPress`.
* Prevents the app from trying to access data when the command list is empty.
* This fixes the crash.

### 2. packages/react/src/hooks/useShowCommands.js

* Updated the logic so the command list is not shown when there are no matching commands.
* Keeps the UI clean and avoids unexpected behavior.

### 3. packages/react/src/views/ChatInput/ChatInput.js

#### handleCommandExecution

* Now tries to execute all slash commands using the API.
* Even if the command is not in the local list, it is sent to the server.
* If the server returns a 400 error (invalid command), a "No such command" toast is shown.

#### sendMessage

* Prevents slash commands from being sent as normal chat messages.
* Ensures they are handled only as commands.