### PR TITLE
Feat : Add Keyboard Shortcuts modal to Embedded Chat options menu

### DIFF
--- a/packages/react/src/hooks/useSetExclusiveState.js
+++ b/packages/react/src/hooks/useSetExclusiveState.js
@@ -10,6 +10,7 @@ import {
   useStarredMessageStore,
   useFileStore,
   useSidebarStore,
+  useKeyboardShortcutStore,
 } from '../store';
 
 const useSetExclusiveState = () => {
@@ -31,6 +32,9 @@ const useSetExclusiveState = () => {
   const setShowChannelinfo = useChannelStore(
     (state) => state.setShowChannelinfo
   );
+  const setShowKeyboardShortcuts = useKeyboardShortcutStore(
+    (state) => state.setShowKeyboardShortcuts
+  );
   const stateSetters = useMemo(
     () => [
       setShowStarred,
@@ -42,12 +46,14 @@ const useSetExclusiveState = () => {
       setShowAllFiles,
       setShowMentions,
       setShowCurrentUserInfo,
+      setShowKeyboardShortcuts,
     ],
     [
       setShowAllFiles,
       setShowAllThreads,
       setShowChannelinfo,
       setShowCurrentUserInfo,
+      setShowKeyboardShortcuts,
       setShowMembers,
       setShowMentions,
       setShowPinned,

--- a/packages/react/src/store/index.js
+++ b/packages/react/src/store/index.js
@@ -11,3 +11,4 @@ export { default as useMentionsStore } from './mentionsStore';
 export { default as usePinnedMessageStore } from './pinnedMessageStore';
 export { default as useStarredMessageStore } from './starredMessageStore';
 export { default as useSidebarStore } from './sidebarStore';
+export { default as useKeyboardShortcutStore } from './keyboardShortcutStore';

--- a/packages/react/src/store/keyboardShortcutStore.js
+++ b/packages/react/src/store/keyboardShortcutStore.js
@@ -1,0 +1,9 @@
+import { create } from 'zustand';
+
+const useKeyboardShortcutStore = create((set) => ({
+  showKeyboardShortcuts: false,
+  setShowKeyboardShortcuts: (showKeyboardShortcuts) =>
+    set(() => ({ showKeyboardShortcuts })),
+}));
+
+export default useKeyboardShortcutStore;

--- a/packages/react/src/views/ChatHeader/ChatHeader.js
+++ b/packages/react/src/views/ChatHeader/ChatHeader.js
@@ -24,6 +24,7 @@ import {
   useStarredMessageStore,
   useFileStore,
   useSidebarStore,
+  useKeyboardShortcutStore,
 } from '../../store';
 import { DynamicHeader } from '../DynamicHeader';
 import useFetchChatData from '../../hooks/useFetchChatData';
@@ -50,6 +51,7 @@ const ChatHeader = ({
       'members',
       'search',
       'rInfo',
+      'keyboard',
       'logout',
     ],
   },
@@ -123,6 +125,10 @@ const ChatHeader = ({
     const host = RCInstance.getHost();
     return `${host}/avatar/${channelname}`;
   };
+  const setShowKeyboardShortcuts = useKeyboardShortcutStore(
+    (state) => state.setShowKeyboardShortcuts
+  );
+
   const handleGoBack = async () => {
     if (isUserAuthenticated) {
       getMessagesAndRoles();
@@ -300,6 +306,13 @@ const ChatHeader = ({
         iconName: 'info',
         visible: isUserAuthenticated,
       },
+      keyboard: {
+        label: 'Keyboard Shortcuts',
+        id: 'keyboard',
+        onClick: () => setExclusiveState(setShowKeyboardShortcuts),
+        iconName: 'key',
+        visible: true,
+      },
       logout: {
         label: 'Logout',
         id: 'logout',
@@ -324,6 +337,7 @@ const ChatHeader = ({
       setShowAllFiles,
       setShowSearch,
       setShowChannelinfo,
+      setShowKeyboardShortcuts,
     ]
   );
 

--- a/packages/react/src/views/ChatInput/ChatInput.js
+++ b/packages/react/src/views/ChatInput/ChatInput.js
@@ -19,7 +19,9 @@ import {
   useLoginStore,
   useChannelStore,
   useMemberStore,
+  useSearchMessageStore,
 } from '../../store';
+import useSetExclusiveState from '../../hooks/useSetExclusiveState';
 import ChatInputFormattingToolbar from './ChatInputFormattingToolbar';
 import useAttachmentWindowStore from '../../store/attachmentwindow';
 import MembersList from '../Mentions/MembersList';
@@ -126,6 +128,9 @@ const ChatInput = ({ scrollToBottom, clearUnreadDividerRef }) => {
   }));
 
   const userInfo = { _id: userId, username, name };
+
+  const setShowSearch = useSearchMessageStore((state) => state.setShowSearch);
+  const setExclusiveState = useSetExclusiveState();
 
   const dispatchToastMessage = useToastBarDispatch();
   const showCommands = useShowCommands(
@@ -447,6 +452,26 @@ const ChatInput = ({ scrollToBottom, clearUnreadDividerRef }) => {
       case e.ctrlKey && e.code === 'KeyB': {
         e.preventDefault();
         formatSelection(messageRef, '*{{text}}*');
+        break;
+      }
+      case (e.ctrlKey || e.metaKey) && (e.code === 'KeyK' || e.code === 'KeyP'):
+        e.preventDefault();
+        setExclusiveState(setShowSearch);
+        break;
+      case e.code === 'ArrowUp' &&
+        !e.shiftKey &&
+        !e.ctrlKey &&
+        !e.metaKey &&
+        !e.altKey: {
+        const { value } = messageRef.current;
+        if (!value || value.trim() === '') {
+          const { messages } = useMessageStore.getState();
+          const lastOwnMsg = messages.find((m) => m.u?.username === username);
+          if (lastOwnMsg) {
+            e.preventDefault();
+            setEditMessage(lastOwnMsg);
+          }
+        }
         break;
       }
       case (e.ctrlKey || e.metaKey || e.shiftKey) && e.code === 'Enter':

--- a/packages/react/src/views/ChatInput/ChatInput.js
+++ b/packages/react/src/views/ChatInput/ChatInput.js
@@ -454,7 +454,7 @@ const ChatInput = ({ scrollToBottom, clearUnreadDividerRef }) => {
         formatSelection(messageRef, '*{{text}}*');
         break;
       }
-      case (e.ctrlKey || e.metaKey) && (e.code === 'KeyK' || e.code === 'KeyP'):
+      case (e.ctrlKey || e.metaKey) && e.code === 'KeyK':
         e.preventDefault();
         setExclusiveState(setShowSearch);
         break;

--- a/packages/react/src/views/ChatLayout/ChatLayout.js
+++ b/packages/react/src/views/ChatLayout/ChatLayout.js
@@ -12,6 +12,7 @@ import {
   useThreadsMessageStore,
   useMemberStore,
   useSidebarStore,
+  useKeyboardShortcutStore,
 } from '../../store';
 
 import RoomMembers from '../RoomMembers/RoomMember';
@@ -22,6 +23,7 @@ import PinnedMessages from '../MessageAggregators/PinnedMessages';
 import SearchMessages from '../MessageAggregators/SearchMessages';
 import FileGallery from '../MessageAggregators/FileGallery';
 import Roominfo from '../RoomInformation/RoomInformation';
+import KeyboardShortcuts from '../KeyboardShortcuts/KeyboardShortcuts';
 import UserInformation from '../UserInformation/UserInformation';
 import ChatBody from '../ChatBody/ChatBody';
 import ChatInput from '../ChatInput/ChatInput';
@@ -60,6 +62,9 @@ const ChatLayout = () => {
   const members = useMemberStore((state) => state.members);
   const showCurrentUserInfo = useUserStore(
     (state) => state.showCurrentUserInfo
+  );
+  const showKeyboardShortcuts = useKeyboardShortcutStore(
+    (state) => state.showKeyboardShortcuts
   );
   const attachmentWindowOpen = useAttachmentWindowStore(
     (state) => state.attachmentWindowOpen
@@ -134,6 +139,7 @@ const ChatLayout = () => {
           {showPinned && <PinnedMessages />}
           {showStarred && <StarredMessages />}
           {showCurrentUserInfo && <UserInformation />}
+          {showKeyboardShortcuts && <KeyboardShortcuts />}
           {uiKitContextualBarOpen && (
             <UiKitContextualBar
               key={Math.random()}

--- a/packages/react/src/views/KeyboardShortcuts/KeyboardShortcuts.js
+++ b/packages/react/src/views/KeyboardShortcuts/KeyboardShortcuts.js
@@ -1,0 +1,97 @@
+import React from 'react';
+import { css } from '@emotion/react';
+import { Box, Sidebar, useTheme } from '@embeddedchat/ui-elements';
+import useSetExclusiveState from '../../hooks/useSetExclusiveState';
+
+const isMac =
+  typeof navigator !== 'undefined' && /Mac/.test(navigator.platform);
+const mod = isMac ? '⌘' : 'Ctrl';
+const alt = isMac ? '⌥' : 'Alt';
+
+const shortcuts = [
+  {
+    action: 'Open Channel / User search',
+    keys: `${mod} + K`,
+  },
+  {
+    action: 'Edit previous message',
+    keys: '↑ (Up Arrow)',
+  },
+  {
+    action: 'Move to the beginning of the message',
+    keys: `${mod} / ${alt} + ←`,
+  },
+  {
+    action: 'Move to the beginning of the message',
+    keys: `${mod} / ${alt} + ↑`,
+  },
+  {
+    action: 'Move to the end of the message',
+    keys: `${mod} / ${alt} + →`,
+  },
+  {
+    action: 'Move to the end of the message',
+    keys: `${mod} / ${alt} + ↓`,
+  },
+  {
+    action: 'New line in message compose input',
+    keys: 'Shift + Enter',
+  },
+];
+
+const getStyles = (theme) => ({
+  list: css`
+    display: flex;
+    flex-direction: column;
+    padding: 0.75rem;
+    gap: 0.25rem;
+  `,
+  row: css`
+    display: flex;
+    justify-content: space-between;
+    align-items: center;
+    padding: 0.5rem 0.5rem;
+    border-bottom: 1px solid ${theme.colors.border};
+    gap: 0.75rem;
+  `,
+  action: css`
+    font-size: 0.875rem;
+    color: ${theme.colors.foreground};
+    flex: 1;
+  `,
+  keys: css`
+    font-size: 0.8125rem;
+    font-family: monospace;
+    color: ${theme.colors.secondaryForeground};
+    background: ${theme.colors.background};
+    border: 1px solid ${theme.colors.border};
+    border-radius: 4px;
+    padding: 0.2rem 0.5rem;
+    white-space: nowrap;
+  `,
+});
+
+const KeyboardShortcuts = () => {
+  const { theme } = useTheme();
+  const styles = getStyles(theme);
+  const setExclusiveState = useSetExclusiveState();
+
+  return (
+    <Sidebar
+      title="Keyboard Shortcuts"
+      iconName="key"
+      onClose={() => setExclusiveState(null)}
+    >
+      <Box css={styles.list}>
+        {shortcuts.map((shortcut) => (
+          <Box key={`${shortcut.action}-${shortcut.keys}`} css={styles.row}>
+            <span css={styles.action}>{shortcut.action}</span>
+            <span css={styles.keys}>{shortcut.keys}</span>
+          </Box>
+        ))}
+      </Box>
+    </Sidebar>
+  );
+};
+
+export default KeyboardShortcuts;

--- a/packages/react/src/views/KeyboardShortcuts/KeyboardShortcuts.js
+++ b/packages/react/src/views/KeyboardShortcuts/KeyboardShortcuts.js
@@ -4,7 +4,8 @@ import { Box, Sidebar, useTheme } from '@embeddedchat/ui-elements';
 import useSetExclusiveState from '../../hooks/useSetExclusiveState';
 
 const isMac =
-  typeof navigator !== 'undefined' && /Mac/.test(navigator.platform);
+  typeof navigator !== 'undefined' &&
+  /Mac/.test(navigator.userAgentData?.platform || navigator.platform);
 const mod = isMac ? '⌘' : 'Ctrl';
 const alt = isMac ? '⌥' : 'Alt';
 
@@ -16,6 +17,14 @@ const shortcuts = [
   {
     action: 'Edit previous message',
     keys: '↑ (Up Arrow)',
+  },
+  {
+    action: 'Bold message',
+    keys: `${mod} + B`,
+  },
+  {
+    action: 'Italic message',
+    keys: `${mod} + I`,
   },
   {
     action: 'Move to the beginning of the message',


### PR DESCRIPTION
# Description 
 This PR adds a "Keyboard Shortcuts" entry to the Embedded Chat three-dot options menu that opens a reference modal listing all supported shortcuts.

## Acceptance Criteria 
- [X]  "Keyboard Shortcuts" option appears in the Embedded Chat three-dot menu
- [X]  No regressions in existing Embedded Chat behavior
- [X]  All keyboard shortcuts works properly 

Fixes #1169 

## Video/Screenshots
[Screencast from 2026-02-27 01-38-01.webm](https://github.com/user-attachments/assets/08277902-5d7a-49ca-8c67-b63235d79613)

**NOTE**
The ⌘/Alt + Arrow cursor movement shortcuts and Shift + Enter for newline are not custom implemented — these are handled natively by the browser and work out of the box. They are listed in the modal for discoverability only, no additional code was written to support them.