### PR TITLE
fix(api): migrate file upload from removed rooms.upload to rooms.media endpoint

### DIFF
--- a/packages/api/src/EmbeddedChatApi.ts
+++ b/packages/api/src/EmbeddedChatApi.ts
@@ -1056,26 +1056,53 @@ export default class EmbeddedChatApi {
   ) {
     try {
       const { userId, authToken } = (await this.auth.getCurrentUser()) || {};
+      const headers = {
+        "X-Auth-Token": authToken,
+        "X-User-Id": userId,
+      };
+
       const form = new FormData();
-      if (threadId) {
-        form.append("tmid", threadId);
-      }
       form.append("file", file, fileName);
-      form.append(
-        "description",
-        fileDescription.length !== 0 ? fileDescription : ""
+      if (fileDescription.length !== 0) {
+        form.append("description", fileDescription);
+      }
+
+      const uploadResponse = await fetch(
+        `${this.host}/api/v1/rooms.media/${this.rid}`,
+        {
+          method: "POST",
+          body: form,
+          headers,
+        }
       );
-      const response = fetch(`${this.host}/api/v1/rooms.upload/${this.rid}`, {
-        method: "POST",
-        body: form,
-        headers: {
-          "X-Auth-Token": authToken,
-          "X-User-Id": userId,
-        },
-      }).then((r) => r.json());
-      return response;
+      const uploadResult = await uploadResponse.json();
+
+      if (!uploadResult.success || !uploadResult.file?._id) {
+        throw new Error(uploadResult.error || "File upload failed");
+      }
+
+      const confirmBody: Record<string, any> = {};
+      if (fileDescription.length !== 0) {
+        confirmBody.description = fileDescription;
+      }
+      if (threadId) {
+        confirmBody.tmid = threadId;
+      }
+
+      const confirmResponse = await fetch(
+        `${this.host}/api/v1/rooms.mediaConfirm/${this.rid}/${uploadResult.file._id}`,
+        {
+          method: "POST",
+          headers: {
+            ...headers,
+            "Content-Type": "application/json",
+          },
+          body: JSON.stringify(confirmBody),
+        }
+      );
+      return await confirmResponse.json();
     } catch (err) {
-      console.log(err);
+      console.error(err);
     }
   }
 


### PR DESCRIPTION
Closes #1172 

The rooms.upload/:rid endpoint was deprecated in Rocket.Chat 6.10 and removed in 8.0, breaking file uploads for anyone running RC 8.x.

This migrates sendAttachment() to the new two-step rooms.media flow:

1. POST /rooms.media/:rid — uploads the file and returns a file._id
2. POST /rooms.mediaConfirm/:rid/:fileId — confirms the upload and sends it to the room
Tested locally against RC 8.x — file uploads working again.

Reference: [RC Deprecated Endpoints](https://developer.rocket.chat/docs/deprecated-endpoints)

PR Test Details
Note: The PR will be ready for live testing at https://rocketchat.github.io/EmbeddedChat/pulls/pr-1173 after approval. Contributors are requested to replace <pr_number> with the actual PR number.

