### PR TITLE
fix(api): replace deprecated method.call endpoints with REST equivalents

### DIFF
--- a/packages/api/src/EmbeddedChatApi.ts
+++ b/packages/api/src/EmbeddedChatApi.ts
@@ -495,32 +495,17 @@ export default class EmbeddedChatApi {
     try {
       const { userId, authToken } = (await this.auth.getCurrentUser()) || {};
       const response = await fetch(
-        `${this.host}/api/v1/method.call/rooms%3Aget`,
+        `${this.host}/api/v1/rooms.info?roomId=${this.rid}`,
         {
-          body: JSON.stringify({
-            message: JSON.stringify({
-              msg: "method",
-              id: null,
-              method: "rooms/get",
-              params: [],
-            }),
-          }),
           headers: {
             "Content-Type": "application/json",
             "X-Auth-Token": authToken,
             "X-User-Id": userId,
           },
-          method: "POST",
+          method: "GET",
         }
       );
-
-      const result = await response.json();
-
-      if (result.success && result.message) {
-        const parsedMessage = JSON.parse(result.message);
-        return parsedMessage;
-      }
-      return null;
+      return await response.json();
     } catch (err) {
       console.error(err);
     }
@@ -692,41 +677,6 @@ export default class EmbeddedChatApi {
       return await roles.json();
     } catch (err) {
       console.log(err);
-    }
-  }
-
-  async getUserRoles() {
-    try {
-      const { userId, authToken } = (await this.auth.getCurrentUser()) || {};
-      const response = await fetch(
-        `${this.host}/api/v1/method.call/getUserRoles`,
-        {
-          body: JSON.stringify({
-            message: JSON.stringify({
-              msg: "method",
-              id: null,
-              method: "getUserRoles",
-              params: [],
-            }),
-          }),
-          headers: {
-            "Content-Type": "application/json",
-            "X-Auth-Token": authToken,
-            "X-User-Id": userId,
-          },
-          method: "POST",
-        }
-      );
-
-      const result = await response.json();
-
-      if (result.success && result.message) {
-        const parsedMessage = JSON.parse(result.message);
-        return parsedMessage;
-      }
-      return null;
-    } catch (err) {
-      console.error(err);
     }
   }
 

--- a/packages/react/src/hooks/useFetchChatData.js
+++ b/packages/react/src/hooks/useFetchChatData.js
@@ -148,8 +148,8 @@ const useFetchChatData = (showRoles) => {
 
         if (showRoles) {
           const { roles } = await RCInstance.getChannelRoles(isChannelPrivate);
-          const fetchedRoles = await RCInstance.getUserRoles();
-          const fetchedAdmins = fetchedRoles?.result;
+          const fetchedRoles = await RCInstance.getUsersInRole('admin');
+          const fetchedAdmins = fetchedRoles?.users;
 
           const adminUsernames = fetchedAdmins?.map((user) => user.username);
           setAdmins(adminUsernames);

--- a/packages/react/src/views/ChatHeader/ChatHeader.js
+++ b/packages/react/src/views/ChatHeader/ChatHeader.js
@@ -198,8 +198,7 @@ const ChatHeader = ({
       ) {
         setIsChannelArchived(true);
         const roomInfo = await RCInstance.getRoomInfo();
-        const roomData = roomInfo.result[roomInfo.result.length - 1];
-        setChannelInfo(roomData);
+        setChannelInfo(roomInfo?.room);
       } else if ('errorType' in res && res.errorType === 'Not Allowed') {
         dispatchToastMessage({
           type: 'error',


### PR DESCRIPTION
Replaces two deprecated Rocket.Chat `method.call` realtime endpoints (removed in RC 8.0) with their supported REST equivalents:

| Deprecated | Replacement |
| method.call/getUserRoles | roles.getUsersInRole?role=admin |
| method.call/rooms:get | rooms.info?roomId= |

### changes

- Removed getUserRoles() method & replaced caller with existing getUsersInRole('admin')
- Replaced  getRoomInfo() internals & now uses rooms.info REST endpoint directly
- Updated response shape accessors in useFetchChatData.js and ChatHeader.js

PR Test Details
Note: The PR will be ready for live testing at https://rocketchat.github.io/EmbeddedChat/pulls/pr-1174 after approval. Contributors are requested to replace <pr_number> with the actual PR number.

