### PR TITLE
fix(api): remove deprecated query/fields params, filter threads client-side

### DIFF
--- a/packages/api/src/EmbeddedChatApi.ts
+++ b/packages/api/src/EmbeddedChatApi.ts
@@ -550,34 +550,16 @@ export default class EmbeddedChatApi {
 
   /**
    * @param {boolean} anonymousMode
-   * @param {Object} options This object should include query or fields.
-   * query - json object which accepts MongoDB query operators.
-   * fields - json object with properties that have either 1 or 0 to include them or exclude them
+   * @param {boolean} isChannelPrivate
    * @returns messages
    */
-  async getMessages(
-    anonymousMode = false,
-    options: {
-      query?: object | undefined;
-      field?: object | undefined;
-    } = {
-      query: undefined,
-      field: undefined,
-    },
-    isChannelPrivate = false
-  ) {
+  async getMessages(anonymousMode = false, isChannelPrivate = false) {
     const roomType = isChannelPrivate ? "groups" : "channels";
     const endp = anonymousMode ? "anonymousread" : "messages";
-    const query = options?.query
-      ? `&query=${JSON.stringify(options.query)}`
-      : "";
-    const field = options?.field
-      ? `&field=${JSON.stringify(options.field)}`
-      : "";
     try {
       const { userId, authToken } = (await this.auth.getCurrentUser()) || {};
       const messages = await fetch(
-        `${this.host}/api/v1/${roomType}.${endp}?roomId=${this.rid}${query}${field}`,
+        `${this.host}/api/v1/${roomType}.${endp}?roomId=${this.rid}`,
         {
           headers: {
             "Content-Type": "application/json",
@@ -589,36 +571,26 @@ export default class EmbeddedChatApi {
       );
       return await messages.json();
     } catch (err) {
-      console.log(err);
+      console.error(err);
     }
   }
 
   async getOlderMessages(
     anonymousMode = false,
     options: {
-      query?: object | undefined;
-      field?: object | undefined;
       offset?: number;
     } = {
-      query: undefined,
-      field: undefined,
       offset: 50,
     },
     isChannelPrivate = false
   ) {
     const roomType = isChannelPrivate ? "groups" : "channels";
     const endp = anonymousMode ? "anonymousread" : "messages";
-    const query = options?.query
-      ? `&query=${JSON.stringify(options.query)}`
-      : "";
-    const field = options?.field
-      ? `&field=${JSON.stringify(options.field)}`
-      : "";
     const offset = options?.offset ? options.offset : 0;
     try {
       const { userId, authToken } = (await this.auth.getCurrentUser()) || {};
       const messages = await fetch(
-        `${this.host}/api/v1/${roomType}.${endp}?roomId=${this.rid}${query}${field}&offset=${offset}`,
+        `${this.host}/api/v1/${roomType}.${endp}?roomId=${this.rid}&offset=${offset}`,
         {
           headers: {
             "Content-Type": "application/json",

--- a/packages/react/src/hooks/useFetchChatData.js
+++ b/packages/react/src/hooks/useFetchChatData.js
@@ -123,19 +123,17 @@ const useFetchChatData = (showRoles) => {
           return;
         }
 
-        const { messages, count } = await RCInstance.getMessages(
+        const result = await RCInstance.getMessages(
           anonymousMode,
-          ECOptions?.enableThreads
-            ? {
-                query: {
-                  tmid: {
-                    $exists: false,
-                  },
-                },
-              }
-            : undefined,
           anonymousMode ? false : isChannelPrivate
         );
+
+        let { messages } = result || {};
+        const { count } = result || {};
+
+        if (messages && ECOptions?.enableThreads) {
+          messages = messages.filter((msg) => !msg.tmid);
+        }
 
         if (messages) {
           setMessages(messages.filter((message) => message._hidden !== true));

--- a/packages/react/src/views/ChatBody/ChatBody.js
+++ b/packages/react/src/views/ChatBody/ChatBody.js
@@ -224,18 +224,15 @@ const ChatBody = ({
         try {
           const olderMessages = await RCInstance.getOlderMessages(
             anonymousMode,
-            ECOptions?.enableThreads
-              ? {
-                  query: {
-                    tmid: {
-                      $exists: false,
-                    },
-                  },
-                  offset,
-                }
-              : undefined,
+            { offset },
             anonymousMode ? false : isChannelPrivate
           );
+
+          if (ECOptions?.enableThreads && olderMessages?.messages) {
+            olderMessages.messages = olderMessages.messages.filter(
+              (msg) => !msg.tmid
+            );
+          }
           const messageList = messageListRef.current;
           if (olderMessages?.messages?.length) {
             const previousScrollHeight = messageList.scrollHeight;


### PR DESCRIPTION
The query and fields URL parameters for REST API endpoints were deprecated in RC 5.0, disabled by default in RC 7.0, and are scheduled for removal in RC 9.0. EmbeddedChat was passing MongoDB query operators ($exists) via these params to filter thread messages server-side.

This removes all query/fields usage from getMessages() and getOlderMessages() and moves thread filtering client-side (!msg.tmid).
 
 Reference: [RC Deprecated Features](https://developer.rocket.chat/docs/deprecated-endpoints)
 
 PR Test Details
Note: The PR will be ready for live testing at https://rocketchat.github.io/EmbeddedChat/pulls/pr-1175 after approval. Contributors are requested to replace <pr_number> with the actual PR number.

