### PR TITLE
a11y: add aria-labels to all icon-only buttons and interactive elements

### DIFF
--- a/packages/react/src/views/ChatInput/ChatInput.js
+++ b/packages/react/src/views/ChatInput/ChatInput.js
@@ -846,6 +846,7 @@ const ChatInput = ({ scrollToBottom, clearUnreadDividerRef }) => {
                   type="primary"
                   disabled={disableButton || isRecordingMessage}
                   icon="send"
+                  aria-label="Send message"
                 />
               ) : null
             ) : (

--- a/packages/react/src/views/ChatInput/ChatInputFormattingToolbar.js
+++ b/packages/react/src/views/ChatInput/ChatInputFormattingToolbar.js
@@ -131,6 +131,7 @@ const ChatInputFormattingToolbar = ({
             square
             ghost
             disabled={isRecordingMessage}
+            aria-label="Emoji"
             onClick={() => {
               if (isRecordingMessage) return;
               openEmojiPicker();
@@ -181,6 +182,7 @@ const ChatInputFormattingToolbar = ({
             square
             ghost
             disabled={isRecordingMessage}
+            aria-label="Upload file"
             onClick={() => {
               if (isRecordingMessage) return;
               handleClickToOpenFiles();
@@ -212,6 +214,7 @@ const ChatInputFormattingToolbar = ({
             ghost
             disabled={isRecordingMessage}
             onMouseDown={(event) => event.preventDefault()}
+            aria-label="Insert link"
             onClick={() => {
               if (isRecordingMessage) return;
               openInsertLink();
@@ -253,6 +256,7 @@ const ChatInputFormattingToolbar = ({
               square
               disabled={isRecordingMessage}
               ghost
+              aria-label={item.name}
               onClick={() => {
                 if (isRecordingMessage) return;
                 formatSelection(messageRef, item.pattern);
@@ -335,6 +339,7 @@ const ChatInputFormattingToolbar = ({
                   square
                   disabled={isRecordingMessage}
                   ghost
+                  aria-label={itemInFormatter.name}
                   onClick={() =>
                     formatSelection(messageRef, itemInFormatter.pattern)
                   }
@@ -356,6 +361,7 @@ const ChatInputFormattingToolbar = ({
               square
               ghost
               disabled={isRecordingMessage}
+              aria-label="More options"
               onClick={() => {
                 if (isRecordingMessage) return;
                 setPopoverOpen(!isPopoverOpen);

--- a/packages/react/src/views/DynamicHeader/DynamicHeader.js
+++ b/packages/react/src/views/DynamicHeader/DynamicHeader.js
@@ -45,6 +45,7 @@ const DynamicHeader = ({
           display="inline"
           square
           size="small"
+          aria-label="Go back"
         >
           <Icon name={iconName} size="1.25rem" />
         </ActionButton>

--- a/packages/react/src/views/SurfaceMenu/SurfaceItem.js
+++ b/packages/react/src/views/SurfaceMenu/SurfaceItem.js
@@ -11,6 +11,7 @@ const SurfaceItem = ({ item, size }) => (
       size={size}
       iconSize="small"
       color={item.type}
+      aria-label={item.label}
     />
   </Tooltip>
 );

--- a/packages/ui-elements/src/components/Modal/ModalClose.js
+++ b/packages/ui-elements/src/components/Modal/ModalClose.js
@@ -23,7 +23,13 @@ export const ModalClose = ({
       style={{ ...style, ...styleOverrides }}
       {...props}
     >
-      <ActionButton ghost icon="cross" onClick={onClick} tabIndex={tabIndex} />
+      <ActionButton
+        ghost
+        icon="cross"
+        onClick={onClick}
+        tabIndex={tabIndex}
+        aria-label="Close"
+      />
     </Box>
   );
 };

--- a/packages/ui-elements/src/components/ToastBar/ToastBar.js
+++ b/packages/ui-elements/src/components/ToastBar/ToastBar.js
@@ -62,7 +62,13 @@ const ToastBar = ({ toast, onClose }) => {
     >
       <Icon size="1em" name={iconName} />
       {message}
-      <ActionButton icon="cross" size="small" onClick={onClose} ghost />
+      <ActionButton
+        icon="cross"
+        size="small"
+        onClick={onClose}
+        ghost
+        aria-label="Dismiss"
+      />
     </Box>
   );
 };


### PR DESCRIPTION
Adds `aria-label `attributes to every icon-only ActionButton across the chat UI. Screen readers previously announced these as just "button" with no context. Now each button is properly labeled (e.g., "Send message", "Upload file", "Emoji", "Go back", "Close").

Files: 7 files across packages/react and packages/ui-elements
WCAG: Addresses 1.1.1 (Non-text Content) and 4.1.2 (Name, Role, Value)

PR Test Details
Note: The PR will be ready for live testing at https://rocketchat.github.io/EmbeddedChat/pulls/pr-1176 after approval. Contributors are requested to replace <pr_number> with the actual PR number.

