### PR TITLE
Fix/text toolbox unexpected close n alignment issues

### DIFF
--- a/packages/react/src/views/Message/BubbleVariant/Bubble.styles.js
+++ b/packages/react/src/views/Message/BubbleVariant/Bubble.styles.js
@@ -79,7 +79,7 @@ export const getBubbleStyles = (theme) => {
         display: flex;
         position: absolute;
         bottom: calc(100% - 20px);
-        left: calc(100% - 20px);
+        left: calc(100% - 10px);
         z-index: 1101;
       }
     `,
@@ -171,7 +171,7 @@ export const getBubbleStylesMe = (theme) => {
     toolboxContainerMe: css`
       .ec-message-body:hover & {
         left: auto;
-        right: calc(100% - 20px);
+        right: calc(100% - 10px);
       }
     `,
 

--- a/packages/react/src/views/Message/Message.styles.js
+++ b/packages/react/src/views/Message/Message.styles.js
@@ -350,6 +350,15 @@ export const getMessageToolboxStyles = (theme) => {
       gap: 0.25rem;
       padding: 0.25rem;
       border-radius: ${theme.radius};
+      &::before {
+        content: "";
+        position: absolute;
+        bottom: 100%;
+        left: 0;
+        right: 0;
+        height: 5px;
+        background: transparent;
+      }
     `,
 
     emojiPickerStyles: css`

--- a/packages/react/src/views/Message/MessageToolbox.js
+++ b/packages/react/src/views/Message/MessageToolbox.js
@@ -259,7 +259,7 @@ export const MessageToolbox = ({
             <Menu
               size="small"
               options={menuOptions}
-              tooltip={{ isToolTip: true, position: 'top', text: 'More' }}
+              tooltip={{ isToolTip: true, position: 'bottom', text: 'More' }}
               useWrapper={false}
               style={{ top: 'auto', bottom: `calc(100% + 2px)` }}
             />


### PR DESCRIPTION
# Text toolbox unexpected close and alignment issues


## Acceptance Criteria fulfillment

- [x] Fixed "Dead Zone" gap between the toolbox and the "More" menu to prevent unexpected closing on hover.
- [x] Positioned the toolbox to prevent it from covering the first or last letters of messages in the Bubble variant.
- [x] Standardized all tooltip/label directions to open downwards for a consistent UI.

Fixes #1179 

## Video/Screenshots


https://github.com/user-attachments/assets/d9f1634c-9849-4300-8e27-5436195a350e


## PR Test Details

**Note**: The PR will be ready for live testing at https://rocketchat.github.io/EmbeddedChat/pulls/pr-1180 after approval.
