### PR TITLE
a11y: add semantic roles, aria-live, and keyboard navigation to main containers

### DIFF
--- a/packages/react/src/views/ChatBody/ChatBody.js
+++ b/packages/react/src/views/ChatBody/ChatBody.js
@@ -400,6 +400,9 @@ const ChatBody = ({
           ...styleOverrides,
         }}
         className={`ec-chat-body ${classNames}`}
+        role="log"
+        aria-live="polite"
+        aria-label="Message list"
       >
         {isLoginIn ? (
           <Box

--- a/packages/react/src/views/ChatHeader/ChatHeader.js
+++ b/packages/react/src/views/ChatHeader/ChatHeader.js
@@ -497,6 +497,15 @@ const ChatHeader = ({
                     <Box
                       css={styles.channelName}
                       onClick={() => setExclusiveState(setShowChannelinfo)}
+                      role="button"
+                      tabIndex={0}
+                      onKeyDown={(e) => {
+                        if (e.key === 'Enter' || e.key === ' ') {
+                          e.preventDefault();
+                          setExclusiveState(setShowChannelinfo);
+                        }
+                      }}
+                      aria-label="View room information"
                     >
                       {isFederated ? (
                         <GlobeIcon size={fullScreen ? '1.25rem' : '1rem'} />

--- a/packages/react/src/views/RoomMembers/RoomMember.js
+++ b/packages/react/src/views/RoomMembers/RoomMember.js
@@ -165,7 +165,11 @@ const RoomMembers = ({ members }) => {
               <Box>
                 Showing {displayedMembers} of {displayedMembers}
               </Box>
-              <Box css={styles.memberList}>
+              <Box
+                css={styles.memberList}
+                role="list"
+                aria-label="Room members"
+              >
                 {filteredMembers.length > 0 ? (
                   filteredMembers.map((member) => (
                     <RoomMemberItem

--- a/packages/react/src/views/RoomMembers/RoomMemberItem.js
+++ b/packages/react/src/views/RoomMembers/RoomMemberItem.js
@@ -27,6 +27,15 @@ const RoomMemberItem = ({ user, host, userStatus }) => {
       css={styles.container}
       style={{ cursor: 'pointer' }}
       onClick={handleShowUserInfo}
+      role="listitem"
+      tabIndex={0}
+      onKeyDown={(e) => {
+        if (e.key === 'Enter' || e.key === ' ') {
+          e.preventDefault();
+          handleShowUserInfo();
+        }
+      }}
+      aria-label={`View info for ${user.name || user.username}`}
     >
       <Avatar
         url={avatarUrl}


### PR DESCRIPTION
- Message list: role="log" + aria-live="polite" so screen readers announce new messages
- Channel name: role="button" + keyboard nav (Enter/Space) so it's accessible without a mouse
- Member list: role="list"/role="listitem" structure + keyboard nav on each member item
WCAG: Addresses 2.1.1 (Keyboard), 4.1.2 (Name, Role, Value), 4.1.3 (Status Messages)
PR Test Details
Note: The PR will be ready for live testing at https://rocketchat.github.io/EmbeddedChat/pulls/pr-1181 after approval. Contributors are requested to replace <pr_number> with the actual PR number.

