### PR TITLE
fix(api): add missing await on response.json() in getUserStatus, userInfo, and userData

### DIFF
--- a/packages/api/src/EmbeddedChatApi.ts
+++ b/packages/api/src/EmbeddedChatApi.ts
@@ -1243,7 +1243,7 @@ export default class EmbeddedChatApi {
         },
       }
     );
-    const data = response.json();
+    const data = await response.json();
     return data;
   }
 
@@ -1260,7 +1260,7 @@ export default class EmbeddedChatApi {
         },
       }
     );
-    const data = response.json();
+    const data = await response.json();
     return data;
   }
 
@@ -1277,7 +1277,7 @@ export default class EmbeddedChatApi {
         },
       }
     );
-    const data = response.json();
+    const data = await response.json();
     return data;
   }
 }


### PR DESCRIPTION
These three methods were missing await on response.json(), causing them to return a Promise<Response> instead of the parsed JSON body. This means callers silently receive unresolved promises, and any JSON parsing errors bypass the async error handling chain.

PR Test Details
Note: The PR will be ready for live testing at https://rocketchat.github.io/EmbeddedChat/pulls/pr-1188 after approval. Contributors are requested to replace <pr_number> with the actual PR number.

