### PR TITLE
Fix #1182: correct HTML closing tag in error output

### DIFF
--- a/packages/api/playground/playground.js
+++ b/packages/api/playground/playground.js
@@ -42,7 +42,7 @@ async function printResult(result) {
     if (outputElement) {
       const escapedMessage = escapeHTML(result.message);
       const escapedStack = escapeHTML(result.stack);
-      outputElement.innerHTML = `<code>\nError: ${escapedMessage}\nStack: ${escapedStack}</co>`;
+      outputElement.innerHTML = `<code>\nError: ${escapedMessage}\nStack: ${escapedStack}</code>`;
     }
   } else {
     outputElement.innerHTML = "\n" + JSON.stringify(result, null, 2);

--- a/packages/auth/playground/playground.js
+++ b/packages/auth/playground/playground.js
@@ -55,7 +55,7 @@ async function printResult(result) {
     if (outputElement) {
       const escapedMessage = escapeHTML(result.message);
       const escapedStack = escapeHTML(result.stack);
-      outputElement.innerHTML = `<code>\nError: ${escapedMessage}\nStack: ${escapedStack}</co>`;
+      outputElement.innerHTML = `<code>\nError: ${escapedMessage}\nStack: ${escapedStack}</code>`;
     }
   } else {
     outputElement.innerHTML = "\n" + JSON.stringify(result, null, 2);


### PR DESCRIPTION
# Brief Title

## Acceptance Criteria fulfillment

- [ ] Replaced malformed </co> tag with </code> in the auth package playground (playground.js).
- [ ] Replaced malformed </co> tag with </code> in the api package playground (playground.js).
- [ ] Verified error messages render correctly without breaking the HTML structure.

Fixes #1182 

## PR Test Details

- Navigate to the playground files in the auth or api packages.
- Trigger an error within the playground (e.g., failed login).
- Observe the output element; the error should now be properly formatted inside a <code> block.

**Note**: The PR will be ready for live testing at https://rocketchat.github.io/EmbeddedChat/pulls/pr-1189 after approval.
