### PR TITLE
Fix logout state

### DIFF
--- a/packages/api/playground/playground.js
+++ b/packages/api/playground/playground.js
@@ -42,7 +42,7 @@ async function printResult(result) {
     if (outputElement) {
       const escapedMessage = escapeHTML(result.message);
       const escapedStack = escapeHTML(result.stack);
-      outputElement.innerHTML = `<code>\nError: ${escapedMessage}\nStack: ${escapedStack}</co>`;
+      outputElement.innerHTML = `<code>\nError: ${escapedMessage}\nStack: ${escapedStack}</code>`;
     }
   } else {
     outputElement.innerHTML = "\n" + JSON.stringify(result, null, 2);

--- a/packages/auth/playground/playground.js
+++ b/packages/auth/playground/playground.js
@@ -55,7 +55,7 @@ async function printResult(result) {
     if (outputElement) {
       const escapedMessage = escapeHTML(result.message);
       const escapedStack = escapeHTML(result.stack);
-      outputElement.innerHTML = `<code>\nError: ${escapedMessage}\nStack: ${escapedStack}</co>`;
+      outputElement.innerHTML = `<code>\nError: ${escapedMessage}\nStack: ${escapedStack}</code>`;
     }
   } else {
     outputElement.innerHTML = "\n" + JSON.stringify(result, null, 2);

--- a/packages/react/src/views/ChatHeader/ChatHeader.js
+++ b/packages/react/src/views/ChatHeader/ChatHeader.js
@@ -191,7 +191,7 @@ const ChatHeader = ({
           type: 'error',
           message: "Channel doesn't exist. Logging out.",
         });
-        await RCInstance.logout();
+        await handleLogout();
       } else if (
         'errorType' in res &&
         res.errorType === 'error-room-archived'
@@ -206,7 +206,7 @@ const ChatHeader = ({
           message:
             "You don't have permission to access this channel. Logging out",
         });
-        await RCInstance.logout();
+        await handleLogout();
       }
     };
 
@@ -218,6 +218,7 @@ const ChatHeader = ({
     isUserAuthenticated,
     RCInstance,
     setChannelInfo,
+    handleLogout,
     setIsChannelPrivate,
     dispatchToastMessage,
     isChannelPrivate,


### PR DESCRIPTION
# Clear React state correctly on error logout

## Acceptance Criteria fulfillment

- [ ] Replaced RCInstance.logout() with the unified handleLogout() function for the error-room-not-found condition.
- [ ] Replaced RCInstance.logout() with the unified handleLogout() function for the Not Allowed condition.
- [ ] Added handleLogout to the useEffect dependency array to ensure proper React hook execution.
- [ ] Verified that triggering these errors now successfully clears local React state (messages, channel info, avatars) alongside terminating the API session.

Fixes #1081 

## PR Test Details

- Authenticate and enter a private channel.
- Simulate a Not Allowed or error-room-not-found response from the API for that room.
- Observe that the user is logged out at the API level.
- Inspect the UI: Verify that the messages, channel data, and user avatar are cleared from the screen and React state, leaving no stale data behind.

**Note**: The PR will be ready for live testing at https://rocketchat.github.io/EmbeddedChat/pulls/pr-1190 after approval.
