### PR TITLE
fix: add URL encoding to EmbeddedChatApi request parameters

### DIFF
--- a/packages/api/src/EmbeddedChatApi.ts
+++ b/packages/api/src/EmbeddedChatApi.ts
@@ -475,7 +475,7 @@ export default class EmbeddedChatApi {
     try {
       const { userId, authToken } = (await this.auth.getCurrentUser()) || {};
       const response = await fetch(
-        `${this.host}/api/v1/rooms.info?roomId=${this.rid}`,
+        `${this.host}/api/v1/rooms.info?roomId=${encodeURIComponent(this.rid)}`,
         {
           headers: {
             "Content-Type": "application/json",
@@ -569,15 +569,17 @@ export default class EmbeddedChatApi {
     const roomType = isChannelPrivate ? "groups" : "channels";
     const endp = anonymousMode ? "anonymousread" : "messages";
     const query = options?.query
-      ? `&query=${JSON.stringify(options.query)}`
+      ? `&query=${encodeURIComponent(JSON.stringify(options.query))}`
       : "";
     const field = options?.field
-      ? `&field=${JSON.stringify(options.field)}`
+      ? `&field=${encodeURIComponent(JSON.stringify(options.field))}`
       : "";
     try {
       const { userId, authToken } = (await this.auth.getCurrentUser()) || {};
       const messages = await fetch(
-        `${this.host}/api/v1/${roomType}.${endp}?roomId=${this.rid}${query}${field}`,
+        `${this.host}/api/v1/${roomType}.${endp}?roomId=${encodeURIComponent(
+          this.rid
+        )}${query}${field}`,
         {
           headers: {
             "Content-Type": "application/json",
@@ -609,16 +611,18 @@ export default class EmbeddedChatApi {
     const roomType = isChannelPrivate ? "groups" : "channels";
     const endp = anonymousMode ? "anonymousread" : "messages";
     const query = options?.query
-      ? `&query=${JSON.stringify(options.query)}`
+      ? `&query=${encodeURIComponent(JSON.stringify(options.query))}`
       : "";
     const field = options?.field
-      ? `&field=${JSON.stringify(options.field)}`
+      ? `&field=${encodeURIComponent(JSON.stringify(options.field))}`
       : "";
     const offset = options?.offset ? options.offset : 0;
     try {
       const { userId, authToken } = (await this.auth.getCurrentUser()) || {};
       const messages = await fetch(
-        `${this.host}/api/v1/${roomType}.${endp}?roomId=${this.rid}${query}${field}&offset=${offset}`,
+        `${this.host}/api/v1/${roomType}.${endp}?roomId=${encodeURIComponent(
+          this.rid
+        )}${query}${field}&offset=${offset}`,
         {
           headers: {
             "Content-Type": "application/json",
@@ -638,7 +642,9 @@ export default class EmbeddedChatApi {
     try {
       const { userId, authToken } = (await this.auth.getCurrentUser()) || {};
       const messages = await fetch(
-        `${this.host}/api/v1/chat.getThreadMessages?tmid=${tmid}`,
+        `${this.host}/api/v1/chat.getThreadMessages?tmid=${encodeURIComponent(
+          tmid
+        )}`,
         {
           headers: {
             "Content-Type": "application/json",
@@ -659,7 +665,9 @@ export default class EmbeddedChatApi {
     try {
       const { userId, authToken } = (await this.auth.getCurrentUser()) || {};
       const roles = await fetch(
-        `${this.host}/api/v1/${roomType}.roles?roomId=${this.rid}`,
+        `${this.host}/api/v1/${roomType}.roles?roomId=${encodeURIComponent(
+          this.rid
+        )}`,
         {
           headers: {
             "Content-Type": "application/json",
@@ -679,7 +687,9 @@ export default class EmbeddedChatApi {
     try {
       const { userId, authToken } = (await this.auth.getCurrentUser()) || {};
       const roles = await fetch(
-        `${this.host}/api/v1/roles.getUsersInRole?role=${role}`,
+        `${this.host}/api/v1/roles.getUsersInRole?role=${encodeURIComponent(
+          role
+        )}`,
         {
           headers: {
             "Content-Type": "application/json",
@@ -820,8 +830,12 @@ export default class EmbeddedChatApi {
       const { userId, authToken } = (await this.auth.getCurrentUser()) || {};
       const url =
         typeGroup === ""
-          ? `${this.host}/api/v1/${roomType}.files?roomId=${this.rid}`
-          : `${this.host}/api/v1/${roomType}.files?roomId=${this.rid}&typeGroup=${typeGroup}`;
+          ? `${this.host}/api/v1/${roomType}.files?roomId=${encodeURIComponent(
+              this.rid
+            )}`
+          : `${this.host}/api/v1/${roomType}.files?roomId=${encodeURIComponent(
+              this.rid
+            )}&typeGroup=${encodeURIComponent(typeGroup)}`;
       const response = await fetch(url, {
         headers: {
           "Content-Type": "application/json",
@@ -840,7 +854,9 @@ export default class EmbeddedChatApi {
     try {
       const { userId, authToken } = (await this.auth.getCurrentUser()) || {};
       const response = await fetch(
-        `${this.host}/api/v1/rooms.images?roomId=${this.rid}`,
+        `${this.host}/api/v1/rooms.images?roomId=${encodeURIComponent(
+          this.rid
+        )}`,
         {
           headers: {
             "Content-Type": "application/json",
@@ -896,7 +912,9 @@ export default class EmbeddedChatApi {
     try {
       const { userId, authToken } = (await this.auth.getCurrentUser()) || {};
       const response = await fetch(
-        `${this.host}/api/v1/chat.getStarredMessages?roomId=${this.rid}`,
+        `${this.host}/api/v1/chat.getStarredMessages?roomId=${encodeURIComponent(
+          this.rid
+        )}`,
         {
           headers: {
             "Content-Type": "application/json",
@@ -916,7 +934,9 @@ export default class EmbeddedChatApi {
     try {
       const { userId, authToken } = (await this.auth.getCurrentUser()) || {};
       const response = await fetch(
-        `${this.host}/api/v1/chat.getPinnedMessages?roomId=${this.rid}`,
+        `${this.host}/api/v1/chat.getPinnedMessages?roomId=${encodeURIComponent(
+          this.rid
+        )}`,
         {
           headers: {
             "Content-Type": "application/json",
@@ -936,7 +956,9 @@ export default class EmbeddedChatApi {
     try {
       const { userId, authToken } = (await this.auth.getCurrentUser()) || {};
       const response = await fetch(
-        `${this.host}/api/v1/chat.getMentionedMessages?roomId=${this.rid}`,
+        `${this.host}/api/v1/chat.getMentionedMessages?roomId=${encodeURIComponent(
+          this.rid
+        )}`,
         {
           headers: {
             "Content-Type": "application/json",
@@ -1101,7 +1123,9 @@ export default class EmbeddedChatApi {
     try {
       const { userId, authToken } = (await this.auth.getCurrentUser()) || {};
       const response = await fetch(
-        `${this.host}/api/v1/${roomType}.members?roomId=${this.rid}`,
+        `${this.host}/api/v1/${roomType}.members?roomId=${encodeURIComponent(
+          this.rid
+        )}`,
         {
           headers: {
             "Content-Type": "application/json",
@@ -1121,7 +1145,9 @@ export default class EmbeddedChatApi {
     try {
       const { userId, authToken } = (await this.auth.getCurrentUser()) || {};
       const response = await fetch(
-        `${this.host}/api/v1/chat.search?roomId=${this.rid}&searchText=${text}`,
+        `${this.host}/api/v1/chat.search?roomId=${encodeURIComponent(
+          this.rid
+        )}&searchText=${encodeURIComponent(text)}`,
         {
           headers: {
             "Content-Type": "application/json",
@@ -1233,7 +1259,9 @@ export default class EmbeddedChatApi {
   async getUserStatus(reqUserId: string) {
     const { userId, authToken } = (await this.auth.getCurrentUser()) || {};
     const response = await fetch(
-      `${this.host}/api/v1/users.getStatus?userId=${reqUserId}`,
+      `${this.host}/api/v1/users.getStatus?userId=${encodeURIComponent(
+        reqUserId
+      )}`,
       {
         method: "GET",
         headers: {
@@ -1250,7 +1278,7 @@ export default class EmbeddedChatApi {
   async userInfo(reqUserId: string) {
     const { userId, authToken } = (await this.auth.getCurrentUser()) || {};
     const response = await fetch(
-      `${this.host}/api/v1/users.info?userId=${reqUserId}`,
+      `${this.host}/api/v1/users.info?userId=${encodeURIComponent(reqUserId)}`,
       {
         method: "GET",
         headers: {
@@ -1267,7 +1295,7 @@ export default class EmbeddedChatApi {
   async userData(username: string) {
     const { userId, authToken } = (await this.auth.getCurrentUser()) || {};
     const response = await fetch(
-      `${this.host}/api/v1/users.info?username=${username}`,
+      `${this.host}/api/v1/users.info?username=${encodeURIComponent(username)}`,
       {
         method: "GET",
         headers: {


### PR DESCRIPTION
# Brief Title

This PR fixes a bug where special characters (like &, #, or spaces) in search terms, room IDs, or usernames would break API requests because they weren't being URL-encoded.

### Why needed?

Without encoding, a search for "Test & Fix" would result in a URL like .../chat.search?searchText=Test & Fix. The server sees the & and stops reading the search text, causing incomplete or failed results.

Fixes #1192 

### Affected Methods:

- getSearchMessages (searchText, roomId)
- getMessages / getOlderMessages (query, field, roomId)
- getUsersInRole (role)
- userData / userInfo (username, userId)
- getThreadMessages (tmid)
- getAllFiles (typeGroup, roomId)
- Various other methods using this.rid in GET URLs (e.g., rooms.info, rooms.images, members).

```
// Before
`${this.host}/api/v1/chat.search?roomId=${this.rid}&searchText=${text}`

// After
`${this.host}/api/v1/chat.search?roomId=${encodeURIComponent(this.rid)}&searchText=${encodeURIComponent(text)}`
```

## PR Test Details

**Note**: The PR will be ready for live testing at https://rocketchat.github.io/EmbeddedChat/pulls/pr-1193 after approval.
