### PR TITLE
fix(ui): resolve attachment metadata text overlap on mobile viewports

### DIFF
--- a/packages/react/src/views/AttachmentHandler/AttachmentMetadata.js
+++ b/packages/react/src/views/AttachmentHandler/AttachmentMetadata.js
@@ -85,49 +85,23 @@ const AttachmentMetadata = ({
           flex-direction: row;
           align-items: center;
           gap: 8px;
-          @media (max-width: 420px) {
-            flex-direction: column;
-            align-items: flex-start;
-          }
+          flex-wrap: wrap;
         `}
       >
-        <Box
-          css={css`
-            display: flex;
-            flex-direction: row;
-            align-items: center;
-            gap: 4px;
-            @media (max-width: 420px) {
-              flex-direction: column;
-              align-items: flex-start;
-            }
-          `}
-        >
-          <Tooltip text={attachment?.title} position="down">
-            <p
-              css={css`
-                margin: 0;
-                font-size: 12px;
-                opacity: 0.7;
-              `}
-            >
-              {attachment?.title?.length > 22
-                ? `${attachment.title.substring(0, 22)}...`
-                : attachment?.title}
-            </p>
-          </Tooltip>
-          <Box
+        <Tooltip text={attachment?.title} position="down">
+          <p
             css={css`
+              margin: 0;
               font-size: 12px;
               opacity: 0.7;
-              @media (max-width: 420px) {
-                margin-left: 0;
-              }
             `}
           >
+            {attachment?.title?.length > 20
+              ? `${attachment.title.substring(0, 20)}...`
+              : attachment?.title}{' '}
             ({getFormattedFileSize()})
-          </Box>
-        </Box>
+          </p>
+        </Tooltip>
 
         <Box
           css={css`


### PR DESCRIPTION
Fixes #1194
#### Root Cause
The inner flex container in AttachmentMetadata.js switched to flex-direction: column at ≤420px with only 4px gap. The Tooltip wrapper around the title interfered with flex sizing, causing the elements to visually overlap instead of stacking properly.

#### Fix
- Combined filename and file size into a single <p> element: image.png (60.23 kB)
- Removed the broken flex-direction: column media queries that caused the overlap
- Kept the outer container using flex-wrap: wrap for the action buttons (expand/download)
- Title still truncates at 20 characters with ... and shows full name on hover via Tooltip

#### before
<img width="750" height="1334" alt="ss1" src="https://github.com/user-attachments/assets/e7bc91e6-e850-48be-a8a5-03efd2db24f3" />
#### after 
<img width="750" height="1334" alt="fixed" src="https://github.com/user-attachments/assets/b3b26e22-43e5-424c-9494-ced2337fb2cd" />

### PR Test Details
Note: The PR will be ready for live testing at https://rocketchat.github.io/EmbeddedChat/pulls/pr-1195 after approval. Contributors are requested to replace <pr_number> with the actual PR number.

