### PR TITLE
fix(api): add anchors to username validation regex

### DIFF
--- a/packages/api/src/EmbeddedChatApi.ts
+++ b/packages/api/src/EmbeddedChatApi.ts
@@ -436,7 +436,7 @@ export default class EmbeddedChatApi {
   async updateUserUsername(userid: string, username: string) {
     const newUserName = username.replace(/\s/g, ".").toLowerCase();
 
-    const usernameRegExp = /[0-9a-zA-Z-_.]+/;
+    const usernameRegExp = /^[0-9a-zA-Z-_.]+$/;
 
     if (usernameRegExp.test(newUserName)) {
       try {


### PR DESCRIPTION
# This change hardens the username validation logic in the `@embeddedchat/api` package. Usernames that were previously "partially" valid will now be rejected, triggering the automatic username suggestion fallback.

Fixes #1201 

### Changes
- Updated `packages/api/src/EmbeddedChatApi.ts`:
- Regex changed from `/[0-9a-zA-Z-_.]+/` to `/^[0-9a-zA-Z-_.]+$/`.

### Impact
- **Security/Stability:** Prevents invalid usernames from being sent to the Rocket.Chat server during the update process.
- **User Experience:** Users with invalid display names (which are used to generate the default username) will more reliably be assigned a suggested valid username instead of an error-prone one.

### Action Items
- No manual migration steps are required for users of the library. The change is internal to the `updateUserUsername` logic.

## PR Test Details

**Note**: The PR will be ready for live testing at https://rocketchat.github.io/EmbeddedChat/pulls/pr-1202 after approval.
