### PR TITLE
fix: pass number instead of array as setTimeout delay

### DIFF
--- a/packages/react/src/views/ChatInput/ChatInput.js
+++ b/packages/react/src/views/ChatInput/ChatInput.js
@@ -261,7 +261,7 @@ const ChatInput = ({ scrollToBottom, clearUnreadDividerRef }) => {
         typingRef.current = true;
         timerRef.current = setTimeout(() => {
           typingRef.current = false;
-        }, [15000]);
+        }, 15000);
         await RCInstance.sendTypingStatus(username, true);
       } else {
         clearTimeout(timerRef.current);


### PR DESCRIPTION
# Fix: pass number instead of array as setTimeout delay

This PR updates the setTimeout delay argument from an array ([15000]) to a number (15000). Although the previous implementation worked due to JavaScript type coercion, passing a number directly is clearer and follows the expected setTimeout(callback, delay) API.

Fixis #1204 

### Changes

`Replaced [15000] with 15000 in the setTimeout call.`

### Before
```
timerRef.current = setTimeout(() => {
  typingRef.current = false;
}, [15000]);
```

### After
```
timerRef.current = setTimeout(() => {
  typingRef.current = false;
}, 15000);
```

### Why

Using [15000] relies on implicit type coercion ([15000] → "15000" → 15000). While it works, it may be confusing and could lead to unexpected behavior if the array structure changes.

This change improves code clarity and ensures the correct type is used for the delay parameter.

## PR Test Details

**Note**: The PR will be ready for live testing at https://rocketchat.github.io/EmbeddedChat/pulls/pr-1205 after approval.