### PR TITLE
Fix: File Gallery does not re-render after deleting a file

### DIFF
--- a/packages/react/src/views/ChatBody/ChatBody.js
+++ b/packages/react/src/views/ChatBody/ChatBody.js
@@ -42,6 +42,12 @@ const ChatBody = ({
   scrollToBottom,
   clearUnreadDividerRef,
 }) => {
+  const getMaxScrollTop = (messageList) =>
+    Math.max(0, messageList.scrollHeight - messageList.clientHeight);
+
+  const isAtBottom = (messageList) =>
+    getMaxScrollTop(messageList) - messageList.scrollTop <= 1;
+
   const { classNames, styleOverrides } = useComponentOverrides('ChatBody');
   const { theme, mode } = useTheme();
   const styles = getChatbodyStyles(theme, mode);
@@ -54,6 +60,8 @@ const ChatBody = ({
   const pendingFirstUnreadRef = useRef(null);
   const previousThreadOpenRef = useRef(false);
   const mainChatScrollSnapshotRef = useRef(null);
+  const lastMainChatScrollTopRef = useRef(0);
+  const wasAtBottomRef = useRef(true);
   const isRestoringFromThreadRef = useRef(false);
   const { RCInstance, ECOptions } = useContext(RCContext);
   const showAnnouncement = ECOptions?.showAnnouncement;
@@ -132,7 +140,7 @@ const ChatBody = ({
     }
 
     if (!previousThreadOpenRef.current && isThreadOpen) {
-      mainChatScrollSnapshotRef.current = messageList.scrollTop;
+      mainChatScrollSnapshotRef.current = lastMainChatScrollTopRef.current;
     }
 
     if (previousThreadOpenRef.current && !isThreadOpen) {
@@ -142,11 +150,12 @@ const ChatBody = ({
         requestAnimationFrame(() => {
           const currentMessageList = messageListRef?.current;
           if (currentMessageList) {
-            const maxScrollTop = Math.max(
-              0,
-              currentMessageList.scrollHeight - currentMessageList.clientHeight
+            currentMessageList.scrollTop = Math.min(
+              snapshot,
+              getMaxScrollTop(currentMessageList)
             );
-            currentMessageList.scrollTop = Math.min(snapshot, maxScrollTop);
+            lastMainChatScrollTopRef.current = currentMessageList.scrollTop;
+            wasAtBottomRef.current = isAtBottom(currentMessageList);
           }
 
           requestAnimationFrame(() => {
@@ -159,10 +168,21 @@ const ChatBody = ({
     previousThreadOpenRef.current = isThreadOpen;
   }, [isThreadOpen, messageListRef]);
 
+  useEffect(() => {
+    const messageList = messageListRef?.current;
+    if (!messageList || isThreadOpen) {
+      return;
+    }
+
+    lastMainChatScrollTopRef.current = messageList.scrollTop;
+    wasAtBottomRef.current = isAtBottom(messageList);
+  }, [isThreadOpen, messages, messageListRef]);
+
   const addMessage = useCallback(
     (message) => {
       if (message.u.username !== username) {
-        const isScrolledUp = messageListRef?.current?.scrollTop !== 0;
+        const isScrolledUp =
+          messageListRef?.current && !isAtBottom(messageListRef.current);
         if (isScrolledUp && !('pinned' in message) && !('starred' in message)) {
           setOtherUserMessage(true);
           // Track the first unread message (only set if not already tracking)
@@ -239,6 +259,7 @@ const ChatBody = ({
       pendingFirstUnreadRef.current = null;
     }
     scrollToBottom();
+    wasAtBottomRef.current = true;
     setIsUserScrolledUp(false);
     setOtherUserMessage(false);
     setPopupVisible(false);
@@ -246,14 +267,21 @@ const ChatBody = ({
 
   const handleScroll = useCallback(async () => {
     if (messageListRef && messageListRef.current) {
-      setScrollPosition(messageListRef.current.scrollTop);
+      const messageList = messageListRef.current;
+      const atBottom = isAtBottom(messageList);
+
+      setScrollPosition(messageList.scrollTop);
       setIsUserScrolledUp(
-        messageListRef.current.scrollTop + messageListRef.current.clientHeight <
-          messageListRef.current.scrollHeight
+        !atBottom
       );
 
+      if (!isThreadOpen) {
+        lastMainChatScrollTopRef.current = messageList.scrollTop;
+        wasAtBottomRef.current = atBottom;
+      }
+
       if (
-        messageListRef.current.scrollTop === 0 &&
+        messageList.scrollTop === 0 &&
         !loadingOlderMessages &&
         hasMoreMessages &&
         !isRestoringFromThreadRef.current
@@ -275,7 +303,6 @@ const ChatBody = ({
               : undefined,
             anonymousMode ? false : isChannelPrivate
           );
-          const messageList = messageListRef.current;
           if (olderMessages?.messages?.length) {
             const previousScrollHeight = messageList.scrollHeight;
 
@@ -285,6 +312,10 @@ const ChatBody = ({
             requestAnimationFrame(() => {
               const newScrollHeight = messageList.scrollHeight;
               messageList.scrollTop = newScrollHeight - previousScrollHeight;
+              if (!isThreadOpen) {
+                lastMainChatScrollTopRef.current = messageList.scrollTop;
+                wasAtBottomRef.current = isAtBottom(messageList);
+              }
             });
           } else {
             setHasMoreMessages(false);
@@ -298,8 +329,7 @@ const ChatBody = ({
       }
     }
 
-    const isAtBottom = messageListRef?.current?.scrollTop === 0;
-    if (isAtBottom) {
+    if (messageListRef?.current && isAtBottom(messageListRef.current)) {
       setPopupVisible(false);
       setIsUserScrolledUp(false);
       setOtherUserMessage(false);
@@ -312,6 +342,7 @@ const ChatBody = ({
     }
   }, [
     messageListRef,
+    isThreadOpen,
     offset,
     setMessagesOffset,
     setMessages,
@@ -348,7 +379,12 @@ const ChatBody = ({
 
   useEffect(() => {
     if (messageListRef.current && !isThreadOpen) {
-      messageListRef.current.scrollTop = messageListRef.current.scrollHeight;
+      if (wasAtBottomRef.current && !isRestoringFromThreadRef.current) {
+        messageListRef.current.scrollTop = getMaxScrollTop(messageListRef.current);
+      }
+
+      lastMainChatScrollTopRef.current = messageListRef.current.scrollTop;
+      wasAtBottomRef.current = isAtBottom(messageListRef.current);
     }
   }, [messages, isThreadOpen, messageListRef]);
 
@@ -357,6 +393,10 @@ const ChatBody = ({
   }, [channelInfo.announcement, showAnnouncement]);
   useEffect(() => {
     const currentRef = messageListRef.current;
+    if (!currentRef) {
+      return undefined;
+    }
+
     currentRef.addEventListener('scroll', handleScroll);
 
     return () => {
@@ -365,6 +405,10 @@ const ChatBody = ({
   }, [handleScroll, messageListRef]);
 
   useEffect(() => {
+    if (!messageListRef.current) {
+      return;
+    }
+
     const isScrolledUp =
       scrollPosition + messageListRef.current.clientHeight <
       messageListRef.current.scrollHeight;

--- a/packages/react/src/views/ChatBody/ChatBody.js
+++ b/packages/react/src/views/ChatBody/ChatBody.js
@@ -52,6 +52,9 @@ const ChatBody = ({
   const [isOverflowing, setIsOverflowing] = useState(false);
   const [firstUnreadMessageId, setFirstUnreadMessageId] = useState(null);
   const pendingFirstUnreadRef = useRef(null);
+  const previousThreadOpenRef = useRef(false);
+  const mainChatScrollSnapshotRef = useRef(null);
+  const isRestoringFromThreadRef = useRef(false);
   const { RCInstance, ECOptions } = useContext(RCContext);
   const showAnnouncement = ECOptions?.showAnnouncement;
   const messages = useMessageStore((state) => state.messages);
@@ -120,6 +123,41 @@ const ChatBody = ({
       getThreadMessages();
     }
   }, [getThreadMessages, isThreadOpen, ECOptions?.enableThreads]);
+
+  useEffect(() => {
+    const messageList = messageListRef?.current;
+    if (!messageList) {
+      previousThreadOpenRef.current = isThreadOpen;
+      return;
+    }
+
+    if (!previousThreadOpenRef.current && isThreadOpen) {
+      mainChatScrollSnapshotRef.current = messageList.scrollTop;
+    }
+
+    if (previousThreadOpenRef.current && !isThreadOpen) {
+      const snapshot = mainChatScrollSnapshotRef.current;
+      if (typeof snapshot === 'number') {
+        isRestoringFromThreadRef.current = true;
+        requestAnimationFrame(() => {
+          const currentMessageList = messageListRef?.current;
+          if (currentMessageList) {
+            const maxScrollTop = Math.max(
+              0,
+              currentMessageList.scrollHeight - currentMessageList.clientHeight
+            );
+            currentMessageList.scrollTop = Math.min(snapshot, maxScrollTop);
+          }
+
+          requestAnimationFrame(() => {
+            isRestoringFromThreadRef.current = false;
+          });
+        });
+      }
+    }
+
+    previousThreadOpenRef.current = isThreadOpen;
+  }, [isThreadOpen, messageListRef]);
 
   const addMessage = useCallback(
     (message) => {
@@ -217,7 +255,8 @@ const ChatBody = ({
       if (
         messageListRef.current.scrollTop === 0 &&
         !loadingOlderMessages &&
-        hasMoreMessages
+        hasMoreMessages &&
+        !isRestoringFromThreadRef.current
       ) {
         setLoadingOlderMessages(true);
 
@@ -308,10 +347,10 @@ const ChatBody = ({
   };
 
   useEffect(() => {
-    if (messageListRef.current) {
+    if (messageListRef.current && !isThreadOpen) {
       messageListRef.current.scrollTop = messageListRef.current.scrollHeight;
     }
-  }, [messages]);
+  }, [messages, isThreadOpen, messageListRef]);
 
   useEffect(() => {
     checkOverflow();

--- a/packages/react/src/views/FileMessage/FileMessage.js
+++ b/packages/react/src/views/FileMessage/FileMessage.js
@@ -2,8 +2,6 @@ import React, {
   useState,
   useCallback,
   memo,
-  useContext,
-  useEffect,
 } from 'react';
 import PropTypes from 'prop-types';
 import {
@@ -26,7 +24,7 @@ import FilePreviewHeader from './FilePreviewHeader';
 import { MessageBody as FileBody } from '../Message/MessageBody';
 import { FileMetrics } from './FileMetrics';
 import { useRCContext } from '../../context/RCInstance';
-import { useChannelStore, useMessageStore } from '../../store';
+import { useMessageStore } from '../../store';
 import { fileDisplayStyles as styles } from './Files.styles';
 
 const FileMessage = ({ fileMessage, onDeleteFile }) => {
@@ -34,10 +32,8 @@ const FileMessage = ({ fileMessage, onDeleteFile }) => {
   const dispatchToastMessage = useToastBarDispatch();
   const { RCInstance } = useRCContext();
   const messages = useMessageStore((state) => state.messages);
-  const [files, setFiles] = useState([]);
+  const removeMessage = useMessageStore((state) => state.removeMessage);
   const theme = useTheme();
-  const isChannelPrivate = useChannelStore((state) => state.isChannelPrivate);
-  const [isFetching, setIsFetching] = useState(true);
   const { mode } = theme;
   const messageStyles = styles.message;
 
@@ -63,39 +59,44 @@ const FileMessage = ({ fileMessage, onDeleteFile }) => {
 
   const deleteFile = useCallback(
     async (file) => {
-      messages.forEach(async (message) => {
-        if (message.file?._id === file._id) {
-          const res = await RCInstance.deleteMessage(message._id);
-          setFileToDelete({});
-          if (res.success) {
-            dispatchToastMessage({
-              type: 'success',
-              message: 'File deleted',
-            });
-          } else {
-            dispatchToastMessage({
-              type: 'error',
-              message: 'Error in deleting file',
-            });
-          }
-        }
-      });
-    },
-    [messages, RCInstance, dispatchToastMessage]
-  );
-  useEffect(() => {
-    const fetchAllFiles = async () => {
-      const res = await RCInstance.getAllFiles(isChannelPrivate, '');
-      if (res?.files) {
-        const sortedFiles = res.files.sort(
-          (a, b) => new Date(b.uploadedAt) - new Date(a.uploadedAt)
-        );
-        setFiles(sortedFiles);
-        setIsFetching(false);
+      const messageToDelete = messages.find(
+        (message) => message.file?._id === file._id
+      );
+
+      if (!messageToDelete) {
+        setFileToDelete({});
+        dispatchToastMessage({
+          type: 'error',
+          message: 'Unable to find the file message to delete',
+        });
+        return;
       }
-    };
-    fetchAllFiles();
-  }, [RCInstance, isChannelPrivate, messages, fileToDelete]);
+
+      const res = await RCInstance.deleteMessage(messageToDelete._id);
+      setFileToDelete({});
+
+      if (res?.success) {
+        removeMessage(messageToDelete._id);
+        onDeleteFile?.(file._id);
+        dispatchToastMessage({
+          type: 'success',
+          message: 'File deleted',
+        });
+      } else {
+        dispatchToastMessage({
+          type: 'error',
+          message: 'Error in deleting file',
+        });
+      }
+    },
+    [
+      messages,
+      RCInstance,
+      dispatchToastMessage,
+      removeMessage,
+      onDeleteFile,
+    ]
+  );
 
   const handleOnClose = () => {
     setFileToDelete({});

--- a/packages/react/src/views/MessageAggregators/FileGallery.js
+++ b/packages/react/src/views/MessageAggregators/FileGallery.js
@@ -1,4 +1,4 @@
-import React, { useState, useMemo, useEffect } from 'react';
+import React, { useState, useMemo, useEffect, useCallback } from 'react';
 import { useComponentOverrides } from '@embeddedchat/ui-elements';
 import { useChannelStore, useMessageStore } from '../../store';
 import { useRCContext } from '../../context/RCInstance';
@@ -68,6 +68,10 @@ const FileGallery = () => {
     }
   };
 
+  const handleFileDelete = useCallback((fileId) => {
+    setFiles((prevFiles) => prevFiles.filter((file) => file._id !== fileId));
+  }, []);
+
   return (
     <MessageAggregator
       title="Files"
@@ -89,6 +93,7 @@ const FileGallery = () => {
       type="file"
       searchFiltered={filteredFiles}
       viewType={viewType}
+      onDeleteFile={handleFileDelete}
     />
   );
 };

--- a/packages/react/src/views/MessageAggregators/common/MessageAggregator.js
+++ b/packages/react/src/views/MessageAggregators/common/MessageAggregator.js
@@ -33,6 +33,7 @@ export const MessageAggregator = ({
   fetching,
   type = 'message',
   viewType = 'Sidebar',
+  onDeleteFile,
 }) => {
   const { theme } = useTheme();
   const { mode } = useTheme();
@@ -185,6 +186,7 @@ export const MessageAggregator = ({
                     <FileDisplay
                       key={`${msg._id}-aggregated`}
                       fileMessage={msg}
+                      onDeleteFile={onDeleteFile}
                     />
                   ) : (
                     <Box


### PR DESCRIPTION
# Brief Title

## Acceptance Criteria fulfillment

- [x] Deleting a file from the File Gallery immediately removes it from the list without requiring a page reload.
- [x]  The delete confirmation modal closes correctly after deletion
- [x]  A success toast is shown on successful deletion; an error toast is shown on failure.
- [x]  The deleted message is also removed from the global message store.

Fixes #1208 

**Note**: The PR will be ready for live testing at https://rocketchat.github.io/EmbeddedChat/pulls/pr-<pr_number> after approval. Contributors are requested to replace `<pr_number>` with the actual PR number.
