### PR TITLE
fix(login): gracefully handle network drop crash during authentication

### DIFF
--- a/packages/react/src/hooks/useRCAuth.js
+++ b/packages/react/src/hooks/useRCAuth.js
@@ -25,6 +25,14 @@ export const useRCAuth = () => {
   const handleLogin = async (userOrEmail, password, code) => {
     try {
       const res = await RCInstance.login(userOrEmail, password, code);
+      if (!res) {
+        dispatchToastMessage({
+          type: 'error',
+          message:
+            'A network or connection error occurred. Please check your connection and try again.',
+        });
+        return;
+      }
       if (res.error === 'Unauthorized' || res.error === 403) {
         dispatchToastMessage({
           type: 'error',


### PR DESCRIPTION
Handle undefined response in login hook

When a user attempts to log in but encounters a network error (e.g. `net::ERR_NETWORK_CHANGED`), the fetch call in `EmbeddedChatApi.login` throws an error. The catch block logs the error but implicitly returns `undefined`. Subsequently, `useRCAuth.js` attempts to read `res.error`, leading to an uncaught `TypeError: Cannot read properties of undefined (reading 'error')` which completely breaks the login flow.

This adds a falsy check for the response object and dispatches a user-friendly toast message informing them of the network connection issue instead of crashing.

Fixes #1210