### PR TITLE
fix: replace swiper/element/bundle import with swiper/element

### DIFF
--- a/packages/react/src/views/ImageGallery/Swiper.js
+++ b/packages/react/src/views/ImageGallery/Swiper.js
@@ -1,6 +1,6 @@
 import React, { useEffect, useRef } from 'react';
 /* eslint-disable import/no-unresolved */
-import { register } from 'swiper/element/bundle';
+import { register } from 'swiper/element';
 
 export function Swiper(props) {
   const swiperRef = useRef(null);


### PR DESCRIPTION
## Brief Description
This PR fixes an incorrect import path used in the ImageGallery Swiper component.

Previously the code imported:
import { register } from 'swiper/element/bundle';

This caused module resolution errors in Storybook and tests because the module could not be resolved properly.

The import has been updated to:
import { register } from 'swiper/element';

which works correctly with the installed Swiper dependency.

## Changes Made
- Updated import path in `packages/react/src/views/ImageGallery/Swiper.js`
- Replaced `swiper/element/bundle` with `swiper/element`

## Verification
- Ran Storybook locally using `yarn storybook`
- The project builds successfully without module resolution errors.

## Issue
Fixes #1191