### PR TITLE
Feature/community tested command

### DIFF
--- a/.github/workflows/pr-community-tested.yml
+++ b/.github/workflows/pr-community-tested.yml
@@ -97,7 +97,12 @@ jobs:
               }
             }
 
-            // Register the current commenter (Set deduplicates repeat /tested calls)
+            // Short-circuit if this person has already been counted
+            if (testers.has(commenter)) {
+              core.info(`${commenter} already verified. Skipping.`);
+              return;
+            }
+
             const isFirstTester = testers.size === 0;
             testers.add(commenter);
 

--- a/.github/workflows/pr-community-tested.yml
+++ b/.github/workflows/pr-community-tested.yml
@@ -1,0 +1,22 @@
+name: PR Community Tested
+
+on:
+  issue_comment:
+    types: [created]
+
+permissions:
+  issues: write
+  pull-requests: write
+
+jobs:
+  community-tested:
+    if: |
+      github.event.issue.pull_request != null &&
+      startsWith(github.event.comment.body, '/tested')
+    runs-on: ubuntu-latest
+    steps:
+      - name: Process /tested command
+        uses: actions/github-script@v7
+        with:
+          script: |
+            core.info("Triggered by: " + context.actor);

--- a/.github/workflows/pr-community-tested.yml
+++ b/.github/workflows/pr-community-tested.yml
@@ -52,7 +52,7 @@ jobs:
             const testers = new Set();
             for (const c of allComments) {
               const login = c.user.login;
-              const body  = (c.body ?? "").trim();
+              const body  = (c.body ?? "").trim().toLowerCase();
               if (
                 body === "/tested" &&
                 login !== prAuthor &&
@@ -75,7 +75,7 @@ jobs:
             const isValid =
               commenter !== prAuthor &&
               !commenter.endsWith("[bot]") &&
-              (context.payload.comment.body ?? "").trim() === "/tested";
+              (context.payload.comment.body ?? "").trim().toLowerCase() === "/tested";
 
             await github.rest.reactions.createForIssueComment({
               ...repo,

--- a/.github/workflows/pr-community-tested.yml
+++ b/.github/workflows/pr-community-tested.yml
@@ -36,7 +36,7 @@ jobs:
             const triggerCommentId = context.payload.comment.id;
             const commenter        = context.actor;
 
-            // Eligibility: not the PR author, not a bot, has ≥1 merged PR in this repo
+            // Eligibility: not the PR author, not a bot, has >=1 merged PR in this repo
             const isAuthor = commenter === prAuthor;
             const isBot    = commenter.endsWith("[bot]");
 
@@ -63,14 +63,14 @@ jobs:
             if (!isEligible) {
               let reason;
               if (isAuthor)          reason = "you are the author of this PR";
-              else if (isBot)      reason = "bot accounts cannot run this command";
+              else if (isBot)        reason = "bot accounts cannot run this command";
               else if (!hasMergedPR) reason = "only contributors with at least one merged PR in this repository can run `/tested`";
-              else                 reason = "the comment must be exactly `/tested`";
+              else                   reason = "the comment must be exactly `/tested`";
 
               await github.rest.issues.createComment({
                 ...repo,
                 issue_number: issueNumber,
-                body: `@${commenter} Your \`/tested\` was not counted — ${reason}.`,
+                body: `@${commenter} Your \`/tested\` was not counted -- ${reason}.`,
               });
               core.info(`${commenter} not eligible: ${reason}`);
               return;
@@ -83,7 +83,7 @@ jobs:
 
             const LABEL_NAME = "community-tested";
 
-
+            // Deduplicated testers (author + bot filtered; merged-PR gate enforced live above)
             const testers = new Set();
             for (const c of allComments) {
               const login = c.user.login;
@@ -93,7 +93,7 @@ jobs:
               }
             }
 
-            core.info(`Unique testers: ${testers.size} — [${[...testers].join(", ")}]`);
+            core.info(`Unique testers: ${testers.size} -- [${[...testers].join(", ")}]`);
 
             await core.summary
               .addHeading("Community Tested Progress", 3)
@@ -103,8 +103,8 @@ jobs:
                   { data: "Status", header: true },
                 ],
                 [
-                  `${[...testers].join(", ") || "—"}`,
-                  testers.size >= 1 ? "✅ Label applied" : "⏳ Waiting for first tester",
+                  `${[...testers].join(", ") || "-"}`,
+                  testers.size >= 1 ? "Label applied" : "Waiting for first tester",
                 ],
               ])
               .write();
@@ -119,7 +119,7 @@ jobs:
                     ...repo,
                     name: LABEL_NAME,
                     color: "0075ca",
-                    description: "Tested by community contributors with ≥1 merged PR in this repo",
+                    description: "Tested by community contributors with >=1 merged PR in this repo",
                   });
                 } else {
                   throw err;
@@ -143,7 +143,41 @@ jobs:
                 });
               }
 
-              core.info(`Label "${LABEL_NAME}" applied — ${testers.size} tester(s).`);
+              core.info(`Label "${LABEL_NAME}" applied -- ${testers.size} tester(s).`);
             } else {
               core.info("No eligible testers yet. Label not applied.");
+            }
+
+            // Confidence score: find-or-update a single bot comment tracking progress
+            const MARKER = "<!-- community-tested-score -->";
+            const confidence =
+              testers.size >= 4 ? "High (4+ testers)"   :
+              testers.size >= 2 ? "Medium (2-3 testers)" :
+              testers.size >= 1 ? "Low (1 tester)"       : "None";
+
+            const scoreBody =
+              `${MARKER}\n` +
+              `### Community Testing Confidence\n` +
+              `| Testers | Confidence |\n` +
+              `|---------|------------|\n` +
+              `| ${[...testers].join(", ") || "-"} | ${confidence} |`;
+
+            const existing = allComments.find(
+              (c) => c.body?.includes(MARKER) && c.user.type === "Bot"
+            );
+
+            if (existing) {
+              await github.rest.issues.updateComment({
+                ...repo,
+                comment_id: existing.id,
+                body: scoreBody,
+              });
+              core.info("Confidence score comment updated.");
+            } else {
+              await github.rest.issues.createComment({
+                ...repo,
+                issue_number: issueNumber,
+                body: scoreBody,
+              });
+              core.info("Confidence score comment created.");
             }

--- a/.github/workflows/pr-community-tested.yml
+++ b/.github/workflows/pr-community-tested.yml
@@ -35,6 +35,10 @@ jobs:
               { ...repo, issue_number: issueNumber, per_page: 100 }
             );
 
+            // Constants — declared early so the summary and label steps share them
+            const LABEL_NAME = "community-tested";
+            const THRESHOLD  = 2;
+
             // Build a deduplicated set of qualifying testers:
             //   - trimmed body must be exactly "/tested"
             //   - must not be the PR author
@@ -56,10 +60,41 @@ jobs:
               `Unique testers so far: ${testers.size} — [${[...testers].join(", ")}]`
             );
 
-            // Apply the label once the threshold is reached
-            const LABEL_NAME = "community-tested";
-            const THRESHOLD  = 2;
+            // ── Ephemeral feedback via reaction on the triggering comment ────
+            // Reactions appear on the comment itself — no new thread noise.
+            //   👍 (+1)  — comment was valid and counted
+            //   👀 (eyes) — comment was ignored (author self-test, or not exact match)
+            const triggerCommentId = context.payload.comment.id;
+            const commenter        = context.actor;
+            const isValid =
+              commenter !== prAuthor &&
+              !commenter.endsWith("[bot]") &&
+              (context.payload.comment.body ?? "").trim() === "/tested";
 
+            await github.rest.reactions.createForIssueComment({
+              ...repo,
+              comment_id: triggerCommentId,
+              content: isValid ? "+1" : "eyes",
+            });
+
+            // ── Step summary (visible in Actions UI, not in the PR thread) ───
+            await core.summary
+              .addHeading("Community Tested Progress", 3)
+              .addTable([
+                [
+                  { data: "Testers", header: true },
+                  { data: "Required", header: true },
+                  { data: "Status", header: true },
+                ],
+                [
+                  `${[...testers].join(", ") || "—"}`,
+                  `${THRESHOLD}`,
+                  testers.size >= THRESHOLD ? "✅ Label applied" : `⏳ ${testers.size}/${THRESHOLD} — waiting`,
+                ],
+              ])
+              .write();
+
+            // Apply the label once the threshold is reached
             if (testers.size >= THRESHOLD) {
               await github.rest.issues.addLabels({
                 ...repo,

--- a/.github/workflows/pr-community-tested.yml
+++ b/.github/workflows/pr-community-tested.yml
@@ -22,68 +22,80 @@ jobs:
             const issueNumber = context.issue.number;
             const repo        = context.repo;
 
-            // Resolve the PR author so we can exclude them from the count
             const { data: pr } = await github.rest.pulls.get({
               ...repo,
               pull_number: issueNumber,
             });
             const prAuthor = pr.user.login;
 
-            // Skip closed/merged PRs — no point labeling a finished PR
             if (pr.state !== "open") {
               core.info("PR is not open. Skipping.");
               return;
             }
 
-            // Paginate through every conversation comment on this PR
-            const allComments = await github.paginate(
-              github.rest.issues.listComments,
-              { ...repo, issue_number: issueNumber, per_page: 100 }
-            );
-
-            // Constants — declared early so the summary and label steps share them
-            const LABEL_NAME = "community-tested";
-            const THRESHOLD  = 2;
-
-            // Build a deduplicated set of qualifying testers:
-            //   - trimmed body must be exactly "/tested"
-            //   - must not be the PR author
-            //   - must not be a bot account
-            const testers = new Set();
-            for (const c of allComments) {
-              const login = c.user.login;
-              const body  = (c.body ?? "").trim().toLowerCase();
-              if (
-                body === "/tested" &&
-                login !== prAuthor &&
-                !login.endsWith("[bot]")
-              ) {
-                testers.add(login);
-              }
-            }
-
-            core.info(
-              `Unique testers so far: ${testers.size} — [${[...testers].join(", ")}]`
-            );
-
-            // ── Ephemeral feedback via reaction on the triggering comment ────
-            // Reactions appear on the comment itself — no new thread noise.
-            //   👍 (+1)  — comment was valid and counted
-            //   👀 (eyes) — comment was ignored (author self-test, or not exact match)
             const triggerCommentId = context.payload.comment.id;
             const commenter        = context.actor;
-            const isValid =
-              commenter !== prAuthor &&
-              !commenter.endsWith("[bot]") &&
+
+            // Eligibility: not the PR author, not a bot, has ≥1 merged PR in this repo
+            const isAuthor = commenter === prAuthor;
+            const isBot    = commenter.endsWith("[bot]");
+
+            let hasMergedPR = false;
+            if (!isAuthor && !isBot) {
+              const { data: searchResult } = await github.rest.search.issuesAndPullRequests({
+                q: `repo:${repo.owner}/${repo.repo} is:pr is:merged author:${commenter}`,
+              });
+              hasMergedPR = searchResult.total_count > 0;
+            }
+
+            const isEligible =
+              !isAuthor &&
+              !isBot &&
+              hasMergedPR &&
               (context.payload.comment.body ?? "").trim().toLowerCase() === "/tested";
 
             await github.rest.reactions.createForIssueComment({
               ...repo,
               comment_id: triggerCommentId,
-              content: isValid ? "+1" : "eyes",
+              content: isEligible ? "+1" : "eyes",
             });
 
-            // ── Step summary (visible in Actions UI, not in the PR thread) ───
+            if (!isEligible) {
+              let reason;
+              if (isAuthor)        reason = "you are the author of this PR";
+              else if (isBot)      reason = "bot accounts cannot run this command";
+              else if (!hasMergedPR) reason = "only contributors with at least one merged PR in this repository can run `/tested`";
+              else                 reason = "the comment must be exactly `/tested`";
+
+              await github.rest.issues.createComment({
+                ...repo,
+                issue_number: issueNumber,
+                body: `@${commenter} Your \`/tested\` was not counted — ${reason}.`,
+              });
+              core.info(`${commenter} not eligible: ${reason}`);
+              return;
+            }
+
+            const allComments = await github.paginate(
+              github.rest.issues.listComments,
+              { ...repo, issue_number: issueNumber, per_page: 100 }
+            );
+
+            const LABEL_NAME = "community-tested";
+            const THRESHOLD  = 2;
+
+
+            const testers = new Set();
+            for (const c of allComments) {
+              const login = c.user.login;
+              const body  = (c.body ?? "").trim().toLowerCase();
+              if (body === "/tested" && login !== prAuthor && !login.endsWith("[bot]")) {
+                testers.add(login);
+              }
+            }
+
+            core.info(`Unique testers: ${testers.size} — [${[...testers].join(", ")}]`);
+
             await core.summary
               .addHeading("Community Tested Progress", 3)
               .addTable([
@@ -100,9 +112,7 @@ jobs:
               ])
               .write();
 
-            // Apply the label once the threshold is reached
             if (testers.size >= THRESHOLD) {
-              // Auto-create the label if it doesn't exist yet — no manual repo setup needed
               try {
                 await github.rest.issues.getLabel({ ...repo, name: LABEL_NAME });
               } catch (err) {
@@ -111,21 +121,19 @@ jobs:
                     ...repo,
                     name: LABEL_NAME,
                     color: "0075ca",
-                    description: "Tested by at least 2 independent community contributors",
+                    description: "Tested by community contributors with ≥1 merged PR in this repo",
                   });
-                  core.info(`Label "${LABEL_NAME}" created in this repository.`);
                 } else {
                   throw err;
                 }
               }
 
-              // addLabels is idempotent — safe to call even if the label is already on the PR
               await github.rest.issues.addLabels({
                 ...repo,
                 issue_number: issueNumber,
                 labels: [LABEL_NAME],
               });
-              core.info(`Label "${LABEL_NAME}" applied — ${testers.size} unique testers.`);
+              core.info(`Label "${LABEL_NAME}" applied — ${testers.size} testers.`);
             } else {
               core.info(`${testers.size}/${THRESHOLD} testers. Label not applied yet.`);
             }

--- a/.github/workflows/pr-community-tested.yml
+++ b/.github/workflows/pr-community-tested.yml
@@ -19,4 +19,54 @@ jobs:
         uses: actions/github-script@v7
         with:
           script: |
-            core.info("Triggered by: " + context.actor);
+            const issueNumber = context.issue.number;
+            const repo        = context.repo;
+
+            // Resolve the PR author so we can exclude them from the count
+            const { data: pr } = await github.rest.pulls.get({
+              ...repo,
+              pull_number: issueNumber,
+            });
+            const prAuthor = pr.user.login;
+
+            // Paginate through every conversation comment on this PR
+            const allComments = await github.paginate(
+              github.rest.issues.listComments,
+              { ...repo, issue_number: issueNumber, per_page: 100 }
+            );
+
+            // Build a deduplicated set of qualifying testers:
+            //   - trimmed body must be exactly "/tested"
+            //   - must not be the PR author
+            //   - must not be a bot account
+            const testers = new Set();
+            for (const c of allComments) {
+              const login = c.user.login;
+              const body  = (c.body ?? "").trim();
+              if (
+                body === "/tested" &&
+                login !== prAuthor &&
+                !login.endsWith("[bot]")
+              ) {
+                testers.add(login);
+              }
+            }
+
+            core.info(
+              `Unique testers so far: ${testers.size} — [${[...testers].join(", ")}]`
+            );
+
+            // Apply the label once the threshold is reached
+            const LABEL_NAME = "community-tested";
+            const THRESHOLD  = 2;
+
+            if (testers.size >= THRESHOLD) {
+              await github.rest.issues.addLabels({
+                ...repo,
+                issue_number: issueNumber,
+                labels: [LABEL_NAME],
+              });
+              core.info(`Label "${LABEL_NAME}" applied — ${testers.size} unique testers.`);
+            } else {
+              core.info(`${testers.size}/${THRESHOLD} testers. Label not applied yet.`);
+            }

--- a/.github/workflows/pr-community-tested.yml
+++ b/.github/workflows/pr-community-tested.yml
@@ -29,6 +29,12 @@ jobs:
             });
             const prAuthor = pr.user.login;
 
+            // Skip closed/merged PRs — no point labeling a finished PR
+            if (pr.state !== "open") {
+              core.info("PR is not open. Skipping.");
+              return;
+            }
+
             // Paginate through every conversation comment on this PR
             const allComments = await github.paginate(
               github.rest.issues.listComments,

--- a/.github/workflows/pr-community-tested.yml
+++ b/.github/workflows/pr-community-tested.yml
@@ -96,6 +96,24 @@ jobs:
 
             // Apply the label once the threshold is reached
             if (testers.size >= THRESHOLD) {
+              // Auto-create the label if it doesn't exist yet — no manual repo setup needed
+              try {
+                await github.rest.issues.getLabel({ ...repo, name: LABEL_NAME });
+              } catch (err) {
+                if (err.status === 404) {
+                  await github.rest.issues.createLabel({
+                    ...repo,
+                    name: LABEL_NAME,
+                    color: "0075ca",
+                    description: "Tested by at least 2 independent community contributors",
+                  });
+                  core.info(`Label "${LABEL_NAME}" created in this repository.`);
+                } else {
+                  throw err;
+                }
+              }
+
+              // addLabels is idempotent — safe to call even if the label is already on the PR
               await github.rest.issues.addLabels({
                 ...repo,
                 issue_number: issueNumber,

--- a/.github/workflows/pr-community-tested.yml
+++ b/.github/workflows/pr-community-tested.yml
@@ -76,38 +76,34 @@ jobs:
               return;
             }
 
+            const SCORE_MARKER    = "<!-- community-tested-score -->";
+            const VERIFIED_MARKER = "<!-- verified-testers:";
+
             const allComments = await github.paginate(
               github.rest.issues.listComments,
               { ...repo, issue_number: issueNumber, per_page: 100 }
             );
 
-            const LABEL_NAME = "community-tested";
+            const scoreComment = allComments.find(
+              (c) => c.body?.includes(SCORE_MARKER) && c.user.type === "Bot"
+            );
 
-            // Deduplicated testers (author + bot filtered; merged-PR gate enforced live above)
+            // Parse the persisted verified-testers list, or start fresh
             const testers = new Set();
-            for (const c of allComments) {
-              const login = c.user.login;
-              const body  = (c.body ?? "").trim().toLowerCase();
-              if (body === "/tested" && login !== prAuthor && !login.endsWith("[bot]")) {
-                testers.add(login);
+            if (scoreComment) {
+              const match = scoreComment.body.match(/<!-- verified-testers:(.*?)-->/s);
+              if (match) {
+                match[1].split(",").map((s) => s.trim()).filter(Boolean).forEach((l) => testers.add(l));
               }
             }
 
-            core.info(`Unique testers: ${testers.size} -- [${[...testers].join(", ")}]`);
+            // Register the current commenter (Set deduplicates repeat /tested calls)
+            const isFirstTester = testers.size === 0;
+            testers.add(commenter);
 
-            await core.summary
-              .addHeading("Community Tested Progress", 3)
-              .addTable([
-                [
-                  { data: "Testers", header: true },
-                  { data: "Status", header: true },
-                ],
-                [
-                  `${[...testers].join(", ") || "-"}`,
-                  testers.size >= 1 ? "Label applied" : "Waiting for first tester",
-                ],
-              ])
-              .write();
+            core.info(`Verified testers: ${testers.size} -- [${[...testers].join(", ")}]`);
+
+            const LABEL_NAME = "community-tested";
 
             // Apply the label on the first eligible tester
             if (testers.size >= 1) {
@@ -132,8 +128,8 @@ jobs:
                 labels: [LABEL_NAME],
               });
 
-              // On the first tester, ask them to upload a demo video
-              if (testers.size === 1) {
+              // On the first verified tester, ask them to upload a demo video
+              if (isFirstTester) {
                 await github.rest.issues.createComment({
                   ...repo,
                   issue_number: issueNumber,
@@ -144,32 +140,34 @@ jobs:
               }
 
               core.info(`Label "${LABEL_NAME}" applied -- ${testers.size} tester(s).`);
-            } else {
-              core.info("No eligible testers yet. Label not applied.");
             }
 
-            // Confidence score: find-or-update a single bot comment tracking progress
-            const MARKER = "<!-- community-tested-score -->";
+            // Build and persist the score comment (embeds the verified list for future runs)
             const confidence =
-              testers.size >= 4 ? "High (4+ testers)"   :
-              testers.size >= 2 ? "Medium (2-3 testers)" :
-              testers.size >= 1 ? "Low (1 tester)"       : "None";
+              testers.size >= 4 ? "High (4+ testers)"    :
+              testers.size >= 2 ? "Medium (2-3 testers)"  :
+                                  "Low (1 tester)";
 
             const scoreBody =
-              `${MARKER}\n` +
+              `${SCORE_MARKER}\n` +
+              `${VERIFIED_MARKER} ${[...testers].join(", ")} -->\n` +
               `### Community Testing Confidence\n` +
               `| Testers | Confidence |\n` +
               `|---------|------------|\n` +
-              `| ${[...testers].join(", ") || "-"} | ${confidence} |`;
+              `| ${[...testers].join(", ")} | ${confidence} |`;
 
-            const existing = allComments.find(
-              (c) => c.body?.includes(MARKER) && c.user.type === "Bot"
-            );
+            await core.summary
+              .addHeading("Community Tested Progress", 3)
+              .addTable([
+                [{ data: "Testers", header: true }, { data: "Confidence", header: true }],
+                [[...testers].join(", "), confidence],
+              ])
+              .write();
 
-            if (existing) {
+            if (scoreComment) {
               await github.rest.issues.updateComment({
                 ...repo,
-                comment_id: existing.id,
+                comment_id: scoreComment.id,
                 body: scoreBody,
               });
               core.info("Confidence score comment updated.");

--- a/.github/workflows/pr-community-tested.yml
+++ b/.github/workflows/pr-community-tested.yml
@@ -62,7 +62,7 @@ jobs:
 
             if (!isEligible) {
               let reason;
-              if (isAuthor)        reason = "you are the author of this PR";
+              if (isAuthor)          reason = "you are the author of this PR";
               else if (isBot)      reason = "bot accounts cannot run this command";
               else if (!hasMergedPR) reason = "only contributors with at least one merged PR in this repository can run `/tested`";
               else                 reason = "the comment must be exactly `/tested`";
@@ -82,7 +82,6 @@ jobs:
             );
 
             const LABEL_NAME = "community-tested";
-            const THRESHOLD  = 2;
 
 
             const testers = new Set();
@@ -101,18 +100,17 @@ jobs:
               .addTable([
                 [
                   { data: "Testers", header: true },
-                  { data: "Required", header: true },
                   { data: "Status", header: true },
                 ],
                 [
                   `${[...testers].join(", ") || "—"}`,
-                  `${THRESHOLD}`,
-                  testers.size >= THRESHOLD ? "✅ Label applied" : `⏳ ${testers.size}/${THRESHOLD} — waiting`,
+                  testers.size >= 1 ? "✅ Label applied" : "⏳ Waiting for first tester",
                 ],
               ])
               .write();
 
-            if (testers.size >= THRESHOLD) {
+            // Apply the label on the first eligible tester
+            if (testers.size >= 1) {
               try {
                 await github.rest.issues.getLabel({ ...repo, name: LABEL_NAME });
               } catch (err) {
@@ -133,7 +131,19 @@ jobs:
                 issue_number: issueNumber,
                 labels: [LABEL_NAME],
               });
-              core.info(`Label "${LABEL_NAME}" applied — ${testers.size} testers.`);
+
+              // On the first tester, ask them to upload a demo video
+              if (testers.size === 1) {
+                await github.rest.issues.createComment({
+                  ...repo,
+                  issue_number: issueNumber,
+                  body:
+                    `@${commenter} has marked this PR as community-tested!\n\n` +
+                    `Please reply with a **demo video** showing your test so reviewers can verify the behaviour.`,
+                });
+              }
+
+              core.info(`Label "${LABEL_NAME}" applied — ${testers.size} tester(s).`);
             } else {
-              core.info(`${testers.size}/${THRESHOLD} testers. Label not applied yet.`);
+              core.info("No eligible testers yet. Label not applied.");
             }

--- a/.github/workflows/pr-community-tested.yml
+++ b/.github/workflows/pr-community-tested.yml
@@ -91,7 +91,7 @@ jobs:
             // Parse the persisted verified-testers list, or start fresh
             const testers = new Set();
             if (scoreComment) {
-              const match = scoreComment.body.match(/<!-- verified-testers:(.*?)-->/s);
+              const match = scoreComment.body.match(/<!-- verified-testers:\s*(.*?)\s*-->/);
               if (match) {
                 match[1].split(",").map((s) => s.trim()).filter(Boolean).forEach((l) => testers.add(l));
               }


### PR DESCRIPTION
# ci: add /tested command to apply community-tested label on PRs

Adds a GitHub Actions workflow that lets community members comment /tested on a PR to signal they have verified it locally. Once two unique non-author contributors do so, the community-tested label is automatically applied.

## Acceptance Criteria fulfillment
- [x] Users can comment /tested on a PR
- [x] Only non-authors are counted, and each user is counted once
- [x] community-tested is applied after at least 2 unique users
- [x] Temporary feedback messages are shown and do not persist

Fixes #1226 

## What changed
One new file: .github/workflows/pr-community-tested.yml

## Design decisions
- Exact match over substring: The script requires body.trim() === "/tested" rather than includes("/tested"), so comments like /tested-on-staging or prose referencing the command are never counted by mistake.
- Reactions instead of bot comments: Feedback is delivered via emoji reactions on the user's comment, which are non-persistent and add zero thread noise. There is no temporary comment that needs a sleep-and-delete pattern.
- Safe error handling on label creation: Label creation uses an explicit try/catch that only suppresses 404 (label already exists) and re-throws everything else, so real failures (permissions, network) are visible in the workflow logs.
- Bot exclusion: Any login ending in [bot] is excluded from the tester set so automated tools cannot contribute to the count.
- Open PR guard: The workflow skips cleanly when the PR is closed or merged.

## How to test

1. Open any PR on the repo (draft is fine).
2. As a non-author collaborator, comment exactly /tested on the Conversation tab. You should see a 👍 reaction appear and the Actions summary show 1/2 - waiting.
3. Have a second different collaborator (not the author) do the same. The summary shows 2/2 - label applied and the community-tested label appears on the PR.
4. Have the PR author comment /tested - they get a 👀 reaction and the count does not change.
5. Have the first contributor comment /tested again -still 👍, but the count stays at 2 (no double-counting).

## Video/Screenshots

## PR Test Details

**Note**: The PR will be ready for live testing at https://rocketchat.github.io/EmbeddedChat/pulls/pr-<pr_number> after approval. Contributors are requested to replace `<pr_number>` with the actual PR number.
