### PR TITLE
fix: restore message history loading

### DIFF
--- a/packages/api/src/EmbeddedChatApi.ts
+++ b/packages/api/src/EmbeddedChatApi.ts
@@ -13,6 +13,7 @@ export default class EmbeddedChatApi {
   host: string;
   rid: string;
   rcClient: Rocketchat;
+  roomRoute: "channels" | "groups" | null;
   onMessageCallbacks: ((message: any) => void)[];
   onMessageDeleteCallbacks: ((messageId: string) => void)[];
   onTypingStatusCallbacks: ((users: string[]) => void)[];
@@ -34,6 +35,7 @@ export default class EmbeddedChatApi {
       useSsl: !/http:\/\//.test(host),
       reopen: 20000,
     });
+    this.roomRoute = null;
     this.onMessageCallbacks = [];
     this.onMessageDeleteCallbacks = [];
     this.onTypingStatusCallbacks = [];
@@ -485,7 +487,13 @@ export default class EmbeddedChatApi {
           method: "GET",
         }
       );
-      return await response.json();
+      const roomInfo = await response.json();
+
+      if (roomInfo?.success && roomInfo?.room?.t) {
+        this.roomRoute = this.getRoomRoute(roomInfo.room.t);
+      }
+
+      return roomInfo;
     } catch (err) {
       console.error(err);
     }
@@ -521,6 +529,28 @@ export default class EmbeddedChatApi {
     await this.rcClient.disconnect();
   }
 
+  getRoomRoute(roomType: string) {
+    return roomType === "p" ? "groups" : "channels";
+  }
+
+  async resolveRoomRoute(isChannelPrivate = false) {
+    if (this.roomRoute) {
+      return this.roomRoute;
+    }
+
+    try {
+      const roomInfo = await this.channelInfo();
+
+      if (roomInfo?.success && roomInfo?.room?.t) {
+        return this.getRoomRoute(roomInfo.room.t);
+      }
+    } catch (err) {
+      console.error(err);
+    }
+
+    return isChannelPrivate ? "groups" : "channels";
+  }
+
   /**
    * @param {boolean} anonymousMode
    * @param {Object} options This object should include query or fields.
@@ -539,7 +569,7 @@ export default class EmbeddedChatApi {
     },
     isChannelPrivate = false
   ) {
-    const roomType = isChannelPrivate ? "groups" : "channels";
+    const roomType = await this.resolveRoomRoute(isChannelPrivate);
     const endp = anonymousMode ? "anonymousread" : "messages";
     const query = options?.query
       ? `&query=${JSON.stringify(options.query)}`
@@ -579,7 +609,7 @@ export default class EmbeddedChatApi {
     },
     isChannelPrivate = false
   ) {
-    const roomType = isChannelPrivate ? "groups" : "channels";
+    const roomType = await this.resolveRoomRoute(isChannelPrivate);
     const endp = anonymousMode ? "anonymousread" : "messages";
     const query = options?.query
       ? `&query=${JSON.stringify(options.query)}`
@@ -628,7 +658,7 @@ export default class EmbeddedChatApi {
   }
 
   async getChannelRoles(isChannelPrivate = false) {
-    const roomType = isChannelPrivate ? "groups" : "channels";
+    const roomType = await this.resolveRoomRoute(isChannelPrivate);
     try {
       const { userId, authToken } = (await this.auth.getCurrentUser()) || {};
       const roles = await fetch(
@@ -766,7 +796,7 @@ export default class EmbeddedChatApi {
   }
 
   async getAllFiles(isChannelPrivate = false, typeGroup: string) {
-    const roomType = isChannelPrivate ? "groups" : "channels";
+    const roomType = await this.resolveRoomRoute(isChannelPrivate);
     try {
       const { userId, authToken } = (await this.auth.getCurrentUser()) || {};
       const url =
@@ -1075,7 +1105,7 @@ export default class EmbeddedChatApi {
   }
 
   async getChannelMembers(isChannelPrivate = false) {
-    const roomType = isChannelPrivate ? "groups" : "channels";
+    const roomType = await this.resolveRoomRoute(isChannelPrivate);
     try {
       const { userId, authToken } = (await this.auth.getCurrentUser()) || {};
       const response = await fetch(

--- a/packages/react/src/views/ChatHeader/ChatHeader.js
+++ b/packages/react/src/views/ChatHeader/ChatHeader.js
@@ -146,7 +146,14 @@ const ChatHeader = ({
     } finally {
       setIsUserAuthenticated(false);
     }
-  }, [RCInstance, setIsUserAuthenticated]);
+  }, [
+    RCInstance,
+    setChannelInfo,
+    setIsUserAuthenticated,
+    setMessages,
+    setShowSidebar,
+    setUserAvatarUrl,
+  ]);
 
   useEffect(() => {
     const getMessageLimit = async () => {
@@ -182,10 +189,11 @@ const ChatHeader = ({
       const res = await RCInstance.channelInfo();
       if (res.success) {
         setChannelInfo(res.room);
-        if (res.room.t === 'p') setIsChannelPrivate(true);
-        if (res.room?.teamMain) setIsRoomTeam(true);
+        setIsChannelPrivate(res.room.t === 'p');
+        setIsRoomTeam(Boolean(res.room?.teamMain));
+        setIsChannelArchived(false);
+        setIsChannelReadOnly(Boolean(res.room.ro));
         if (res.room.ro) {
-          setIsChannelReadOnly(true);
           setMessageAllowed();
         }
       } else if (
@@ -205,6 +213,9 @@ const ChatHeader = ({
         const roomInfo = await RCInstance.getRoomInfo();
         const roomData = roomInfo.result[roomInfo.result.length - 1];
         setChannelInfo(roomData);
+        setIsChannelPrivate(roomData?.t === 'p');
+        setIsRoomTeam(Boolean(roomData?.teamMain));
+        setIsChannelReadOnly(Boolean(roomData?.ro));
       } else if ('errorType' in res && res.errorType === 'Not Allowed') {
         dispatchToastMessage({
           type: 'error',
@@ -230,7 +241,9 @@ const ChatHeader = ({
     authenticatedUserId,
     setMessageLimit,
     workspaceLevelRoles,
+    setIsChannelArchived,
     setIsChannelReadOnly,
+    setIsRoomTeam,
   ]);
 
   const options = useMemo(


### PR DESCRIPTION
# fix: resolve 400 Bad Request and restore message loading for public channels


## Acceptance Criteria fulfillment

- [x] Room-scoped state flags (`isChannelPrivate`, `isRoomTeam`, `isChannelReadOnly`, `isChannelArchived`) correctly reset when switching between channels.
- [x] API class dynamically resolves the correct REST endpoint (`channels.messages` vs `groups.messages`) based on actual room data.
- [x] Message history successfully loads for public channels (e.g., `#general`) even after opening a private room.

Fixes #1232

## Description

**Root Cause:**
Previously, room state flags like `isChannelPrivate` in the Zustand store were only conditionally updated to `true` when encountering a private room (`t === 'p'`). Because they were never explicitly reset to `false`, switching to a public room later would falsely preserve the private state. This caused the EmbeddedChatApi to call the `groups.*` REST endpoints instead of `channels.*` for public rooms, resulting in a `400 Bad Request` and failing to load message history.

**Solution:**
1. **Frontend State Fix:** We now derive and explicitly set `isChannelPrivate` and other boolean flags dynamically (`setIsChannelPrivate(res.room.t === 'p')`) upon every room switch in ChatHeader.js

2. **API Layer Hardening:** added a resolveRoomRoute() mechanism to EmbeddedChatApi.ts, which enforces resolution of the correct endpoint (`"groups"` vs `"channels"`) based on API-level `roomInfo` caching rather than blindly trusting frontend booleans.

## PR Test Details

**Note**: The PR will be ready for live testing at https://rocketchat.github.io/EmbeddedChat/pulls/pr-1234 after approval. Contributors are requested to replace `<pr_number>` with the actual PR number.
