### PR TITLE
fix(ui-kit): preserve falsy initial and state values

### DIFF
--- a/packages/ui-kit/src/hooks/useUiKitState.js
+++ b/packages/ui-kit/src/hooks/useUiKitState.js
@@ -6,8 +6,8 @@ import * as UiKit from '@rocket.chat/ui-kit';
 import { UiKitContext } from '../contexts/UiKitContext';
 import { getInitialValue } from '../utils/getInitialValue';
 
-const getElementValueFromState = (actionId, values, initialValue) =>
-  (values && (values[actionId]?.value || initialValue)) ?? initialValue;
+export const getElementValueFromState = (actionId, values, initialValue) =>
+  values?.[actionId]?.value ?? initialValue;
 
 export const useUiKitState = (element, context) => {
   const { blockId, actionId, appId, dispatchActionConfig } = element;

--- a/packages/ui-kit/src/hooks/useUiKitState.test.js
+++ b/packages/ui-kit/src/hooks/useUiKitState.test.js
@@ -1,0 +1,55 @@
+import React from 'react';
+import { render, screen } from '@testing-library/react';
+import { UiKitContext } from '../contexts/UiKitContext';
+import { useUiKitState } from './useUiKitState';
+
+const HookProbe = ({ element }) => {
+  const [{ value }] = useUiKitState(element);
+
+  return <span data-testid="value">{JSON.stringify(value)}</span>;
+};
+
+const renderProbe = (element, values) =>
+  render(
+    <UiKitContext.Provider value={{ values }}>
+      <HookProbe element={element} />
+    </UiKitContext.Provider>
+  );
+
+describe('useUiKitState', () => {
+  test('preserves zero values from context state', () => {
+    renderProbe(
+      {
+        type: 'linear_scale',
+        blockId: 'block-id',
+        actionId: 'score',
+        initialValue: 5,
+      },
+      {
+        score: {
+          value: 0,
+        },
+      }
+    );
+
+    expect(screen.getByTestId('value').textContent).toBe('0');
+  });
+
+  test('preserves empty string values from context state', () => {
+    renderProbe(
+      {
+        type: 'plain_text_input',
+        blockId: 'block-id',
+        actionId: 'message',
+        initialValue: 'prefilled',
+      },
+      {
+        message: {
+          value: '',
+        },
+      }
+    );
+
+    expect(screen.getByTestId('value').textContent).toBe('""');
+  });
+});

--- a/packages/ui-kit/src/utils/getInitialValue.js
+++ b/packages/ui-kit/src/utils/getInitialValue.js
@@ -11,10 +11,14 @@ const hasInitialOption = (element) => 'initialOption' in element;
 const hasInitialOptions = (element) => 'initialOptions' in element;
 
 export const getInitialValue = (element) =>
-  (hasInitialValue(element) && element.initialValue) ||
-  (hasInitialTime(element) && element.initialTime) ||
-  (hasInitialDate(element) && element.initialDate) ||
-  (hasInitialOption(element) && element.initialOption.value) ||
-  (hasInitialOptions(element) &&
-    element.initialOptions.map((option) => option.value)) ||
-  undefined;
+  hasInitialValue(element) && element.initialValue !== undefined
+    ? element.initialValue
+    : hasInitialTime(element) && element.initialTime !== undefined
+    ? element.initialTime
+    : hasInitialDate(element) && element.initialDate !== undefined
+    ? element.initialDate
+    : hasInitialOption(element) && element.initialOption?.value !== undefined
+    ? element.initialOption.value
+    : hasInitialOptions(element)
+    ? element.initialOptions.map((option) => option.value)
+    : undefined;

--- a/packages/ui-kit/src/utils/getInitialValue.test.js
+++ b/packages/ui-kit/src/utils/getInitialValue.test.js
@@ -1,0 +1,36 @@
+import { getInitialValue } from './getInitialValue';
+
+describe('getInitialValue', () => {
+  test('preserves empty string initial values', () => {
+    expect(
+      getInitialValue({
+        type: 'plain_text_input',
+        actionId: 'message',
+        initialValue: '',
+      })
+    ).toBe('');
+  });
+
+  test('preserves zero-valued initial values', () => {
+    expect(
+      getInitialValue({
+        type: 'linear_scale',
+        actionId: 'score',
+        initialValue: 0,
+      })
+    ).toBe(0);
+  });
+
+  test('preserves empty string option values', () => {
+    expect(
+      getInitialValue({
+        type: 'static_select',
+        actionId: 'status',
+        initialOption: {
+          text: { type: 'plain_text', text: 'None' },
+          value: '',
+        },
+      })
+    ).toBe('');
+  });
+});


### PR DESCRIPTION
## Acceptance Criteria fulfillment

- [x] Preserve valid falsy initial values such as `0` and `''` in UI Kit value resolution
- [x] Preserve valid falsy state values from `UiKitContext` instead of incorrectly falling back to initial values
- [x] Add regression tests covering falsy initial values and falsy context state values

Fixes #1235

## Video/Screenshots

N/A

## PR Test Details

- Added regression tests for `getInitialValue`
  - preserves empty string initial values
  - preserves zero-valued initial values
  - preserves empty string option values
- Added regression tests for `useUiKitState`
  - preserves zero values from context state
  - preserves empty string values from context state
- Targeted test result: `2 suites passed, 5 tests passed`
- File-scoped lint passed for:
  - `packages/ui-kit/src/utils/getInitialValue.js`
  - `packages/ui-kit/src/hooks/useUiKitState.js`
