### PR TITLE
Perf/message list reverse and message permission sets

### DIFF
--- a/packages/react/src/lib/messageListHelpers.js
+++ b/packages/react/src/lib/messageListHelpers.js
@@ -2,12 +2,13 @@ import cloneArray from './cloneArray';
 
 // Caution: Not a pure function
 export const insertMessage = (messages, message) => {
-  const idx = messages.findIndex((m) => new Date(m.ts) < new Date(message.ts));
+  // Keep the list in chronological order: oldest -> newest
+  const idx = messages.findIndex((m) => new Date(m.ts) > new Date(message.ts));
   if (idx === -1) {
-    // all the messages are newer than the current message, insert at last
+    // all the messages are older than the current message, insert at last
     messages.push(message);
   } else if (idx === 0) {
-    // the message is the latest one, insert at front
+    // the message is the oldest one, insert at front
     messages.unshift(message);
   } else {
     messages.splice(idx, 0, message);

--- a/packages/react/src/store/messageStore.js
+++ b/packages/react/src/store/messageStore.js
@@ -2,6 +2,8 @@ import { create } from 'zustand';
 import cloneArray from '../lib/cloneArray';
 import { upsertMessage } from '../lib/messageListHelpers';
 
+const sortByTsAscending = (a, b) => new Date(a.ts) - new Date(b.ts);
+
 const useMessageStore = create((set, get) => ({
   messages: [],
   isMessageLoaded: false,
@@ -30,7 +32,7 @@ const useMessageStore = create((set, get) => ({
         new Map(allMessages.map((msg) => [msg._id, msg])).values()
       );
       return {
-        messages: uniqueMessages,
+        messages: uniqueMessages.sort(sortByTsAscending),
         isMessageLoaded: true,
       };
     }),

--- a/packages/react/src/views/Message/Message.js
+++ b/packages/react/src/views/Message/Message.js
@@ -1,4 +1,4 @@
-import React, { memo, useContext } from 'react';
+import React, { memo, useContext, useMemo } from 'react';
 import PropTypes from 'prop-types';
 import { format } from 'date-fns';
 import {
@@ -101,11 +101,23 @@ const Message = ({
       };
 
   const bubbleStyles = useBubbleStyles(isMe);
-  const pinRoles = new Set(pinPermissions);
-  const editMessageRoles = new Set(editMessagePermissions);
-  const deleteMessageRoles = new Set(deleteMessagePermissions);
-  const deleteOwnMessageRoles = new Set(deleteOwnMessagePermissions);
-  const forceDeleteMessageRoles = new Set(forceDeleteMessagePermissions);
+  const pinRoles = useMemo(() => new Set(pinPermissions), [pinPermissions]);
+  const editMessageRoles = useMemo(
+    () => new Set(editMessagePermissions),
+    [editMessagePermissions]
+  );
+  const deleteMessageRoles = useMemo(
+    () => new Set(deleteMessagePermissions),
+    [deleteMessagePermissions]
+  );
+  const deleteOwnMessageRoles = useMemo(
+    () => new Set(deleteOwnMessagePermissions),
+    [deleteOwnMessagePermissions]
+  );
+  const forceDeleteMessageRoles = useMemo(
+    () => new Set(forceDeleteMessagePermissions),
+    [forceDeleteMessagePermissions]
+  );
 
   const variantStyles =
     !isInSidebar && variantOverrides === 'bubble' ? bubbleStyles : {};

--- a/packages/react/src/views/MessageList/MessageList.js
+++ b/packages/react/src/views/MessageList/MessageList.js
@@ -1,8 +1,8 @@
-import React from 'react';
+import React, { useMemo } from 'react';
 import PropTypes from 'prop-types';
 import { css } from '@emotion/react';
 import { isSameDay } from 'date-fns';
-import { Box, Icon, Throbber, useTheme } from '@embeddedchat/ui-elements';
+import { Box, Icon, Throbber } from '@embeddedchat/ui-elements';
 import { useMessageStore } from '../../store';
 import MessageReportWindow from '../ReportMessage/MessageReportWindow';
 import isMessageSequential from '../../lib/isMessageSequential';
@@ -21,14 +21,25 @@ const MessageList = ({
   const showReportMessage = useMessageStore((state) => state.showReportMessage);
   const messageToReport = useMessageStore((state) => state.messageToReport);
   const isMessageLoaded = useMessageStore((state) => state.isMessageLoaded);
-  const { theme } = useTheme();
 
   const isMessageNewDay = (current, previous) =>
     !previous || !isSameDay(new Date(current.ts), new Date(previous.ts));
 
-  const filteredMessages = messages.filter((msg) => !msg.tmid);
+  const filteredMessages = useMemo(
+    () => messages.filter((msg) => !msg.tmid),
+    [messages]
+  );
 
-  const reportedMessage = messages.find((msg) => msg._id === messageToReport);
+  // Preserve existing render order semantics (previously: filteredMessages.slice().reverse())
+  const renderedMessages = useMemo(
+    () => filteredMessages.slice().reverse(),
+    [filteredMessages]
+  );
+
+  const reportedMessage = useMemo(
+    () => messages.find((msg) => msg._id === messageToReport),
+    [messages, messageToReport]
+  );
 
   return (
     <>
@@ -76,10 +87,7 @@ const MessageList = ({
               <Throbber />
             </Box>
           )}
-          {filteredMessages
-            .slice()
-            .reverse()
-            .map((msg, index, arr) => {
+          {renderedMessages.map((msg, index, arr) => {
               const prev = arr[index - 1];
               const next = arr[index + 1];
 

--- a/packages/react/src/views/MessageList/MessageList.js
+++ b/packages/react/src/views/MessageList/MessageList.js
@@ -1,8 +1,8 @@
-import React, { useMemo } from 'react';
+import React from 'react';
 import PropTypes from 'prop-types';
 import { css } from '@emotion/react';
 import { isSameDay } from 'date-fns';
-import { Box, Icon, Throbber } from '@embeddedchat/ui-elements';
+import { Box, Icon, Throbber, useTheme } from '@embeddedchat/ui-elements';
 import { useMessageStore } from '../../store';
 import MessageReportWindow from '../ReportMessage/MessageReportWindow';
 import isMessageSequential from '../../lib/isMessageSequential';
@@ -21,25 +21,14 @@ const MessageList = ({
   const showReportMessage = useMessageStore((state) => state.showReportMessage);
   const messageToReport = useMessageStore((state) => state.messageToReport);
   const isMessageLoaded = useMessageStore((state) => state.isMessageLoaded);
+  const { theme } = useTheme();
 
   const isMessageNewDay = (current, previous) =>
     !previous || !isSameDay(new Date(current.ts), new Date(previous.ts));
 
-  const filteredMessages = useMemo(
-    () => messages.filter((msg) => !msg.tmid),
-    [messages]
-  );
+  const filteredMessages = messages.filter((msg) => !msg.tmid);
 
-  // Preserve existing render order semantics (previously: filteredMessages.slice().reverse())
-  const renderedMessages = useMemo(
-    () => filteredMessages.slice().reverse(),
-    [filteredMessages]
-  );
-
-  const reportedMessage = useMemo(
-    () => messages.find((msg) => msg._id === messageToReport),
-    [messages, messageToReport]
-  );
+  const reportedMessage = messages.find((msg) => msg._id === messageToReport);
 
   return (
     <>
@@ -87,7 +76,8 @@ const MessageList = ({
               <Throbber />
             </Box>
           )}
-          {renderedMessages.map((msg, index, arr) => {
+          {filteredMessages
+            .map((msg, index, arr) => {
               const prev = arr[index - 1];
               const next = arr[index + 1];
 

--- a/packages/react/src/views/MessageList/MessageList.js
+++ b/packages/react/src/views/MessageList/MessageList.js
@@ -1,4 +1,4 @@
-import React from 'react';
+import React, { useMemo } from 'react';
 import PropTypes from 'prop-types';
 import { css } from '@emotion/react';
 import { isSameDay } from 'date-fns';
@@ -26,9 +26,15 @@ const MessageList = ({
   const isMessageNewDay = (current, previous) =>
     !previous || !isSameDay(new Date(current.ts), new Date(previous.ts));
 
-  const filteredMessages = messages.filter((msg) => !msg.tmid);
+  const filteredMessages = useMemo(
+    () => messages.filter((msg) => !msg.tmid),
+    [messages]
+  );
 
-  const reportedMessage = messages.find((msg) => msg._id === messageToReport);
+  const reportedMessage = useMemo(
+    () => messages.find((msg) => msg._id === messageToReport),
+    [messages, messageToReport]
+  );
 
   return (
     <>


### PR DESCRIPTION
# Reduce MessageList render work + memoize permission Sets in Message

- Remove per-render array cloning/reversing in `MessageList` by keeping messages in display order upstream (store).
- Memoize derived permission/role `Set`s in `Message` to avoid recreating them on every render.
- Memoize `filteredMessages` + `reportedMessage` lookups in `MessageList` to reduce repeated filter/find work.


## Acceptance Criteria fulfillment
- [x] No `.slice().reverse()` (or equivalent full-array reversal) in `MessageList` render path.
- [x] Message ordering remains correct (oldest→newest or whatever the UI expects) including unread divider placement and sequential grouping.

## Test plan
- [x] Open a room with a long history; scroll and verify ordering is correct (oldest at top → newest at bottom).
- [x] Verify unread divider appears at the correct message (`firstUnreadMessageId`).
- [x] Verify day dividers and sequential grouping still look correct.
- [x] Verify pin/edit/delete actions still show/hide correctly based on permissions.

Fixes #1240 

## Changes
- `packages/react/src/lib/messageListHelpers.js`: keep inserted/upserted messages in chronological order (oldest → newest).
- `packages/react/src/store/messageStore.js`: sort merged/unique messages by `ts` ascending in `setMessages`.
- `packages/react/src/views/MessageList/MessageList.js`: render messages directly (no `.slice().reverse()`), memoize derived arrays/lookups.
- `packages/react/src/views/Message/Message.js`: `useMemo` for permission/role `Set` constructions.

## Why
Large message lists re-render often; doing full-array `slice()+reverse()` and repeatedly allocating `Set`s increases CPU + GC pressure. These changes move ordering to the store and stabilize derived allocations.

## PR Test Details

**Note**: The PR will be ready for live testing at https://rocketchat.github.io/EmbeddedChat/pulls/pr-1241 after approval. 
