### PR TITLE
Fix: emoji picker toggles reactions consistently with message clicks

### DIFF
--- a/packages/react/src/lib/reaction.js
+++ b/packages/react/src/lib/reaction.js
@@ -14,4 +14,5 @@ export const serializeReactions = (reactions) => {
 };
 
 export const isSameUser = (reaction, username) =>
+  
   reaction.usernames.find((u) => u === username);

--- a/packages/react/src/views/Message/Message.js
+++ b/packages/react/src/views/Message/Message.js
@@ -209,9 +209,13 @@ const Message = ({
     getStarredMessages();
   };
 
-  const handleEmojiClick = async (e, msg, canReact) => {
+  const handleEmojiClick = async (e, msg, _canReact) => {
     const emoji = (e.names?.[0] || e.name).replace(/\s/g, '_');
-    await RCInstance.reactToMessage(emoji, msg._id, canReact);
+    const reactionKeysToCheck = emoji?.startsWith(':') ? [emoji] : [emoji, `:${emoji}:`];
+    const alreadyReacted = reactionKeysToCheck.some((key) =>
+      msg?.reactions?.[key]?.usernames?.includes(authenticatedUserUsername)
+    );
+    await RCInstance.reactToMessage(emoji, msg._id, !alreadyReacted);
   };
 
   const handleOpenThread = (msg) => async () => {


### PR DESCRIPTION
# Fix: Emoji picker toggles reactions consistently

## Acceptance Criteria fulfillment

- [x]  Clicking the same emoji in the picker removes the reaction if the user already reacted.
- [x]  Clicking existing message reactions still toggles correctly.
- [x] Toggle logic unified for emoji picker and message reactions.

Fixes #1245


https://github.com/user-attachments/assets/5957e750-3704-4269-a35e-1f4e0824a8f5



## PR Test Details

**Note**: The PR will be ready for live testing at https://rocketchat.github.io/EmbeddedChat/pulls/pr-1246 after approval. 


## Testing Steps:

1. Open a message and react with an emoji using the picker.
2. Click the same emoji again → reaction should be removed.
3. Click the same emoji on the message → reaction toggles correctly.
4. Confirm reactions behave identically whether using picker or message click.