### PR TITLE
fix(audio): resolve recorded audio playback and download filename handling

### DIFF
--- a/packages/react/src/hooks/useMediaRecorder.js
+++ b/packages/react/src/hooks/useMediaRecorder.js
@@ -24,10 +24,32 @@ export function useMediaRecorder({ constraints, onStop, videoRef }) {
   const { getStream } = useUserMedia(constraints, videoRef);
   const chunks = useRef([]);
 
+  function getPreferredAudioMimeType() {
+    if (typeof MediaRecorder === 'undefined' || !MediaRecorder.isTypeSupported) {
+      return '';
+    }
+
+    const candidates = [
+      'audio/mpeg',
+      'audio/webm;codecs=opus',
+      'audio/ogg;codecs=opus',
+      'audio/webm',
+      'audio/ogg',
+    ];
+
+    return candidates.find((type) => MediaRecorder.isTypeSupported(type)) || '';
+  }
+
   async function start() {
     const stream = await getStream(constraints, true);
     chunks.current = [];
-    const _recorder = new MediaRecorder(stream);
+    const shouldUseAudioMimeType = constraints?.audio && !constraints?.video;
+    const preferredMimeType = shouldUseAudioMimeType
+      ? getPreferredAudioMimeType()
+      : '';
+    const _recorder = preferredMimeType
+      ? new MediaRecorder(stream, { mimeType: preferredMimeType })
+      : new MediaRecorder(stream);
 
     const handleDataAvailable = (event) => {
       chunks.current.push(event.data);

--- a/packages/react/src/lib/reaction.js
+++ b/packages/react/src/lib/reaction.js
@@ -14,4 +14,5 @@ export const serializeReactions = (reactions) => {
 };
 
 export const isSameUser = (reaction, username) =>
+  
   reaction.usernames.find((u) => u === username);

--- a/packages/react/src/views/AttachmentHandler/AttachmentMetadata.js
+++ b/packages/react/src/views/AttachmentHandler/AttachmentMetadata.js
@@ -1,7 +1,8 @@
-import React from 'react';
+import React, { useContext } from 'react';
 import { css } from '@emotion/react';
 import { ActionButton, Box, Tooltip } from '@embeddedchat/ui-elements';
 import { Markdown } from '../Markdown';
+import RCContext from '../../context/RCInstance';
 
 const AttachmentMetadata = ({
   attachment,
@@ -11,19 +12,77 @@ const AttachmentMetadata = ({
   onExpandCollapseClick,
   isExpanded,
 }) => {
+  const { RCInstance } = useContext(RCContext);
+  const [downloadUrl, setDownloadUrl] = React.useState(url);
+
+  React.useEffect(() => {
+    let isMounted = true;
+
+    const prepareDownloadUrl = async () => {
+      const { userId, authToken } = (await RCInstance.auth.getCurrentUser()) || {};
+      if (!isMounted) return;
+      if (userId && authToken) {
+        const separator = url.includes('?') ? '&' : '?';
+        setDownloadUrl(
+          `${url}${separator}rc_uid=${encodeURIComponent(userId)}&rc_token=${encodeURIComponent(authToken)}`
+        );
+      } else {
+        setDownloadUrl(url);
+      }
+    };
+
+    prepareDownloadUrl();
+    return () => {
+      isMounted = false;
+    };
+  }, [RCInstance, url]);
+  const getExtensionFromMimeType = (mimeType = '') => {
+    if (!mimeType.includes('/')) return '';
+    const rawExt = mimeType.split('/')[1].toLowerCase();
+    if (rawExt === 'mpeg') return 'mp3';
+    if (rawExt === 'jpeg') return 'jpg';
+    return rawExt;
+  };
+
+  const getDownloadFileName = (blobType = '') => {
+    const baseName = (attachment?.title || 'download').trim();
+    const hasExtension = /\.[a-z0-9]+$/i.test(baseName);
+    const extensionFromBlob = getExtensionFromMimeType(blobType);
+
+    const isMediaAttachment = Boolean(
+      attachment?.audio_url || attachment?.video_url || attachment?.image_url
+    );
+
+    if (!isMediaAttachment) {
+      return baseName;
+    }
+
+    if (!hasExtension && extensionFromBlob) {
+      return `${baseName}.${extensionFromBlob}`;
+    }
+
+    if (hasExtension && extensionFromBlob) {
+      const currentExtension = baseName.split('.').pop().toLowerCase();
+      if (
+        (attachment?.audio_url || attachment?.video_url || attachment?.image_url) &&
+        ['txt', 'text'].includes(currentExtension)
+      ) {
+        return `${baseName.replace(/\.[^.]+$/, '')}.${extensionFromBlob}`;
+      }
+    }
+
+    return baseName;
+  };
+
   const handleDownload = async () => {
     try {
-      const response = await fetch(url);
-      const data = await response.blob();
-      const downloadUrl = URL.createObjectURL(data);
       const anchor = document.createElement('a');
       anchor.href = downloadUrl;
-      anchor.download = attachment?.title || 'download';
+      anchor.download = getDownloadFileName(attachment?.audio_type || attachment?.video_type || attachment?.image_type || '');
 
       document.body.appendChild(anchor);
       anchor.click();
       document.body.removeChild(anchor);
-      URL.revokeObjectURL(downloadUrl);
     } catch (error) {
       console.error('Error downloading the file:', error);
     }

--- a/packages/react/src/views/AttachmentHandler/AudioAttachment.js
+++ b/packages/react/src/views/AttachmentHandler/AudioAttachment.js
@@ -1,4 +1,4 @@
-import React, { useState, useContext } from 'react';
+import React, { useState, useContext, useEffect } from 'react';
 import PropTypes from 'prop-types';
 import { css } from '@emotion/react';
 import { Box, Avatar, useTheme } from '@embeddedchat/ui-elements';
@@ -23,9 +23,68 @@ const AudioAttachment = ({
   const { authorIcon, authorName } = author;
 
   const [isExpanded, setIsExpanded] = useState(true);
+  const [audioSrc, setAudioSrc] = useState('');
+  const [nestedAudioSrcMap, setNestedAudioSrcMap] = useState({});
   const toggleExpanded = () => {
     setIsExpanded((prevState) => !prevState);
   };
+
+  useEffect(() => {
+    let isMounted = true;
+    const loadAudioWithAuth = async () => {
+      const { userId, authToken } = (await RCInstance.auth.getCurrentUser()) || {};
+      const sourceUrl = host + attachment.audio_url;
+      if (!isMounted) return;
+      if (userId && authToken) {
+        const separator = sourceUrl.includes('?') ? '&' : '?';
+        setAudioSrc(
+          `${sourceUrl}${separator}rc_uid=${encodeURIComponent(userId)}&rc_token=${encodeURIComponent(authToken)}`
+        );
+      } else {
+        setAudioSrc(sourceUrl);
+      }
+    };
+
+    if (attachment?.audio_url) {
+      loadAudioWithAuth();
+    }
+
+    return () => {
+      isMounted = false;
+    };
+  }, [RCInstance, attachment?.audio_url, host]);
+
+  useEffect(() => {
+    let isMounted = true;
+
+    const loadNestedAudio = async () => {
+      if (!attachment?.attachments?.length) return;
+
+      const { userId, authToken } = (await RCInstance.auth.getCurrentUser()) || {};
+      const nextMap = {};
+
+      attachment.attachments.forEach((nestedAttachment, index) => {
+        if (!nestedAttachment?.audio_url) return;
+        const sourceUrl = host + nestedAttachment.audio_url;
+        if (userId && authToken) {
+          const separator = sourceUrl.includes('?') ? '&' : '?';
+          nextMap[index] = `${sourceUrl}${separator}rc_uid=${encodeURIComponent(userId)}&rc_token=${encodeURIComponent(authToken)}`;
+        } else {
+          nextMap[index] = sourceUrl;
+        }
+      });
+
+      if (isMounted) {
+        setNestedAudioSrcMap(nextMap);
+      }
+    };
+
+    loadNestedAudio();
+
+    return () => {
+      isMounted = false;
+    };
+  }, [RCInstance, attachment?.attachments, host]);
 
   return (
     <Box>
@@ -76,7 +135,7 @@ const AudioAttachment = ({
         >
           <AttachmentMetadata
             attachment={attachment}
-            url={host + (attachment.title_url || attachment.audio_url)}
+            url={host + (attachment.audio_url || attachment.title_url)}
             variantStyles={variantStyles}
             msg={msg}
             onExpandCollapseClick={toggleExpanded}
@@ -85,7 +144,7 @@ const AudioAttachment = ({
         </Box>
         {isExpanded && (
           <audio
-            src={host + attachment.audio_url}
+            src={audioSrc || host + attachment.audio_url}
             style={{ maxHeight: '100%', maxWidth: '100%' }}
             controls
           />
@@ -138,12 +197,14 @@ const AudioAttachment = ({
                   attachment={nestedAttachment}
                   url={
                     host +
-                    (nestedAttachment.title_url || nestedAttachment.audio_url)
+                    (nestedAttachment.audio_url || nestedAttachment.title_url)
                   }
                   variantStyles={variantStyles}
                 />
                 <audio
-                  src={host + nestedAttachment.audio_url}
+                  src={
+                    nestedAudioSrcMap[index] || host + nestedAttachment.audio_url
+                  }
                   width="100%"
                   controls
                 />

--- a/packages/react/src/views/AttachmentPreview/AttachmentPreview.js
+++ b/packages/react/src/views/AttachmentPreview/AttachmentPreview.js
@@ -29,6 +29,7 @@ const AttachmentPreview = () => {
   const setData = useAttachmentWindowStore((state) => state.setData);
 
   const [isPending, setIsPending] = useState(false);
+  const isMountedRef = useRef(true);
   const messageRef = useRef(null);
   const [showMembersList, setShowMembersList] = useState(false);
   const [filteredMembers, setFilteredMembers] = useState([]);
@@ -37,6 +38,12 @@ const AttachmentPreview = () => {
 
   const [fileName, setFileName] = useState(data?.name ?? '');
   useEffect(() => setFileName(data?.name ?? ''), [data?.name]);
+  useEffect(
+    () => () => {
+      isMountedRef.current = false;
+    },
+    []
+  );
 
   const [description, setDescription] = useState('');
   const charCount = description.length;
@@ -68,22 +75,61 @@ const AttachmentPreview = () => {
     searchMentionUser(raw);
   };
 
+  const getExtensionFromMimeType = (mimeType = '') => {
+    if (!mimeType.includes('/')) return '';
+    const ext = mimeType.split('/')[1].toLowerCase();
+    if (ext === 'mpeg') return 'mp3';
+    if (ext === 'jpeg') return 'jpg';
+    return ext;
+  };
+
+  const getNormalizedUploadFileName = () => {
+    const originalName = (data?.name || '').trim();
+    const desiredName = (fileName || '').trim();
+
+    if (!desiredName) return originalName || 'upload';
+
+    const originalExtension = originalName.includes('.')
+      ? originalName.split('.').pop().toLowerCase()
+      : getExtensionFromMimeType(data?.type || '');
+    const hasDesiredExtension = /\.[a-z0-9]+$/i.test(desiredName);
+
+    // Keep media files downloadable/playable even after rename.
+    if ((data?.type || '').startsWith('audio/')) {
+      if (!hasDesiredExtension && originalExtension) {
+        return `${desiredName}.${originalExtension}`;
+      }
+
+      if (hasDesiredExtension) {
+        const desiredExtension = desiredName.split('.').pop().toLowerCase();
+        if (['txt', 'text'].includes(desiredExtension) && originalExtension) {
+          return `${desiredName.replace(/\.[^.]+$/, '')}.${originalExtension}`;
+        }
+      }
+    }
+
+    return desiredName;
+  };
+
   const submit = async () => {
     if (isPending) return;
     if (msgMaxLength && description.length > msgMaxLength) return;
 
     setIsPending(true);
     try {
+      const normalizedFileName = getNormalizedUploadFileName();
       await RCInstance.sendAttachment(
         data,
-        fileName,
+        normalizedFileName,
         parseEmoji(description),
         ECOptions?.enableThreads ? threadId : undefined
       );
       toggle();
       setData(null);
     } finally {
-      setIsPending(false);
+      if (isMountedRef.current) {
+        setIsPending(false);
+      }
     }
   };
 

--- a/packages/react/src/views/AttachmentPreview/CheckPreviewType.js
+++ b/packages/react/src/views/AttachmentPreview/CheckPreviewType.js
@@ -24,11 +24,14 @@ const CheckPreviewType = ({ data }) => {
     return null;
   }
 
-  const reader = new FileReader();
-  reader.onload = (e) => {
-    setPreviewURL(e.target.result);
-  };
-  reader.readAsDataURL(data);
+  useEffect(() => {
+    const url = URL.createObjectURL(data);
+    setPreviewURL(url);
+
+    return () => {
+      URL.revokeObjectURL(url);
+    };
+  }, [data]);
 
   switch (type) {
     case 'image': {

--- a/packages/react/src/views/ChatInput/AudioMessageRecorder.js
+++ b/packages/react/src/views/ChatInput/AudioMessageRecorder.js
@@ -32,9 +32,17 @@ const AudioMessageRecorder = (props) => {
   const [isRecorded, setIsRecorded] = useState(false);
 
   const onStop = (audioChunks) => {
-    const audioBlob = new Blob(audioChunks, { type: 'audio/mpeg' });
-    const fileName = 'Audio record.mp3';
-    setFile(new File([audioBlob], fileName, { type: 'audio/mpeg' }));
+    const detectedMimeType = audioChunks?.[0]?.type || 'audio/webm';
+    const extension = detectedMimeType.includes('mpeg')
+      ? 'mp3'
+      : detectedMimeType.includes('ogg')
+      ? 'ogg'
+      : detectedMimeType.includes('wav')
+      ? 'wav'
+      : 'webm';
+    const audioBlob = new Blob(audioChunks, { type: detectedMimeType });
+    const fileName = `Audio record.${extension}`;
+    setFile(new File([audioBlob], fileName, { type: detectedMimeType }));
   };
 
   const [start, stop] = useMediaRecorder({

--- a/packages/react/src/views/Message/Message.js
+++ b/packages/react/src/views/Message/Message.js
@@ -209,9 +209,13 @@ const Message = ({
     getStarredMessages();
   };
 
-  const handleEmojiClick = async (e, msg, canReact) => {
+  const handleEmojiClick = async (e, msg, _canReact) => {
     const emoji = (e.names?.[0] || e.name).replace(/\s/g, '_');
-    await RCInstance.reactToMessage(emoji, msg._id, canReact);
+    const reactionKeysToCheck = emoji?.startsWith(':') ? [emoji] : [emoji, `:${emoji}:`];
+    const alreadyReacted = reactionKeysToCheck.some((key) =>
+      msg?.reactions?.[key]?.usernames?.includes(authenticatedUserUsername)
+    );
+    await RCInstance.reactToMessage(emoji, msg._id, !alreadyReacted);
   };
 
   const handleOpenThread = (msg) => async () => {

--- a/packages/ui-elements/src/components/Tooltip/Tooltip.js
+++ b/packages/ui-elements/src/components/Tooltip/Tooltip.js
@@ -32,6 +32,7 @@ const Tooltip = ({ children, text, position }) => {
 
   return (
     <Box
+      is="span"
       onMouseEnter={handleMouseEnter}
       onMouseLeave={handleMouseLeave}
       onTouchStart={handleTouchStart}
@@ -43,9 +44,9 @@ const Tooltip = ({ children, text, position }) => {
     >
       {children}
       {isTooltipVisible && (
-        <Box css={styles.tooltip}>
+        <Box is="span" css={styles.tooltip}>
           {text.charAt(0).toUpperCase() + text.slice(1)}
-          <Box css={styles.tooltipArrow} />
+          <Box is="span" css={styles.tooltipArrow} />
         </Box>
       )}
     </Box>


### PR DESCRIPTION
# Fix recorded audio playback and download format handling

## Acceptance Criteria fulfillment

- [x] Audio recording playback is functional for newly recorded messages (play button and seek bar work when media URL is accessible).
- [x] Renamed audio attachments preserve a valid audio extension (no unintended.txt fallback for audio flows).
- [x] Recorder MIME selection now prefers supported audio formats and falls back safely (mp3 when supported, otherwise webm/ogg .

Fixes #1247 


https://github.com/user-attachments/assets/faff0a12-a175-4102-b2e8-b73567225093



## PR Test Details

**Note**: The PR will be ready for live testing at https://rocketchat.github.io/EmbeddedChat/pulls/pr-1248 after approval. 
