### PR TITLE
feat: add multi-message selection and bulk delete in chat

### DIFF
--- a/packages/react/src/hooks/useMediaRecorder.js
+++ b/packages/react/src/hooks/useMediaRecorder.js
@@ -24,10 +24,32 @@ export function useMediaRecorder({ constraints, onStop, videoRef }) {
   const { getStream } = useUserMedia(constraints, videoRef);
   const chunks = useRef([]);
 
+  function getPreferredAudioMimeType() {
+    if (typeof MediaRecorder === 'undefined' || !MediaRecorder.isTypeSupported) {
+      return '';
+    }
+
+    const candidates = [
+      'audio/mpeg',
+      'audio/webm;codecs=opus',
+      'audio/ogg;codecs=opus',
+      'audio/webm',
+      'audio/ogg',
+    ];
+
+    return candidates.find((type) => MediaRecorder.isTypeSupported(type)) || '';
+  }
+
   async function start() {
     const stream = await getStream(constraints, true);
     chunks.current = [];
-    const _recorder = new MediaRecorder(stream);
+    const shouldUseAudioMimeType = constraints?.audio && !constraints?.video;
+    const preferredMimeType = shouldUseAudioMimeType
+      ? getPreferredAudioMimeType()
+      : '';
+    const _recorder = preferredMimeType
+      ? new MediaRecorder(stream, { mimeType: preferredMimeType })
+      : new MediaRecorder(stream);
 
     const handleDataAvailable = (event) => {
       chunks.current.push(event.data);

--- a/packages/react/src/lib/reaction.js
+++ b/packages/react/src/lib/reaction.js
@@ -14,4 +14,5 @@ export const serializeReactions = (reactions) => {
 };
 
 export const isSameUser = (reaction, username) =>
+  
   reaction.usernames.find((u) => u === username);

--- a/packages/react/src/store/messageStore.js
+++ b/packages/react/src/store/messageStore.js
@@ -20,6 +20,8 @@ const useMessageStore = create((set, get) => ({
   isThreadOpen: false,
   threadMainMessage: null,
   headerTitle: null,
+  isBulkSelectMode: false,
+  selectedMessageIds: [],
   setFilter: (filter) => set(() => ({ filtered: filter })),
   setMessages: (newMessages, append = false) =>
     set((state) => {
@@ -135,6 +137,34 @@ const useMessageStore = create((set, get) => ({
     set((state) => ({ ...state, forceDeleteMessageRoles })),
   setThreadMessages: (messages) => set(() => ({ threadMessages: messages })),
   setHeaderTitle: (title) => set(() => ({ headerTitle: title })),
+  setBulkSelectMode: (isBulkSelectMode) =>
+    set(() => ({
+      isBulkSelectMode,
+      selectedMessageIds: isBulkSelectMode ? get().selectedMessageIds : [],
+    })),
+  clearBulkSelection: () =>
+    set(() => ({
+      isBulkSelectMode: false,
+      selectedMessageIds: [],
+    })),
+  toggleSelectedMessageId: (messageId) =>
+    set((state) => {
+      const isSelected = state.selectedMessageIds.includes(messageId);
+      const selectedMessageIds = isSelected
+        ? state.selectedMessageIds.filter((id) => id !== messageId)
+        : [...state.selectedMessageIds, messageId];
+      return {
+        selectedMessageIds,
+        isBulkSelectMode: selectedMessageIds.length
+          ? true
+          : state.isBulkSelectMode,
+      };
+    }),
+  setSelectedMessageIds: (selectedMessageIds) =>
+    set(() => ({
+      selectedMessageIds,
+      isBulkSelectMode: selectedMessageIds.length ? true : get().isBulkSelectMode,
+    })),
 }));
 
 export default useMessageStore;

--- a/packages/react/src/views/AttachmentHandler/AttachmentMetadata.js
+++ b/packages/react/src/views/AttachmentHandler/AttachmentMetadata.js
@@ -1,7 +1,8 @@
-import React from 'react';
+import React, { useContext } from 'react';
 import { css } from '@emotion/react';
 import { ActionButton, Box, Tooltip } from '@embeddedchat/ui-elements';
 import { Markdown } from '../Markdown';
+import RCContext from '../../context/RCInstance';
 
 const AttachmentMetadata = ({
   attachment,
@@ -11,19 +12,77 @@ const AttachmentMetadata = ({
   onExpandCollapseClick,
   isExpanded,
 }) => {
+  const { RCInstance } = useContext(RCContext);
+  const [downloadUrl, setDownloadUrl] = React.useState(url);
+
+  React.useEffect(() => {
+    let isMounted = true;
+
+    const prepareDownloadUrl = async () => {
+      const { userId, authToken } = (await RCInstance.auth.getCurrentUser()) || {};
+      if (!isMounted) return;
+      if (userId && authToken) {
+        const separator = url.includes('?') ? '&' : '?';
+        setDownloadUrl(
+          `${url}${separator}rc_uid=${encodeURIComponent(userId)}&rc_token=${encodeURIComponent(authToken)}`
+        );
+      } else {
+        setDownloadUrl(url);
+      }
+    };
+
+    prepareDownloadUrl();
+    return () => {
+      isMounted = false;
+    };
+  }, [RCInstance, url]);
+  const getExtensionFromMimeType = (mimeType = '') => {
+    if (!mimeType.includes('/')) return '';
+    const rawExt = mimeType.split('/')[1].toLowerCase();
+    if (rawExt === 'mpeg') return 'mp3';
+    if (rawExt === 'jpeg') return 'jpg';
+    return rawExt;
+  };
+
+  const getDownloadFileName = (blobType = '') => {
+    const baseName = (attachment?.title || 'download').trim();
+    const hasExtension = /\.[a-z0-9]+$/i.test(baseName);
+    const extensionFromBlob = getExtensionFromMimeType(blobType);
+
+    const isMediaAttachment = Boolean(
+      attachment?.audio_url || attachment?.video_url || attachment?.image_url
+    );
+
+    if (!isMediaAttachment) {
+      return baseName;
+    }
+
+    if (!hasExtension && extensionFromBlob) {
+      return `${baseName}.${extensionFromBlob}`;
+    }
+
+    if (hasExtension && extensionFromBlob) {
+      const currentExtension = baseName.split('.').pop().toLowerCase();
+      if (
+        (attachment?.audio_url || attachment?.video_url || attachment?.image_url) &&
+        ['txt', 'text'].includes(currentExtension)
+      ) {
+        return `${baseName.replace(/\.[^.]+$/, '')}.${extensionFromBlob}`;
+      }
+    }
+
+    return baseName;
+  };
+
   const handleDownload = async () => {
     try {
-      const response = await fetch(url);
-      const data = await response.blob();
-      const downloadUrl = URL.createObjectURL(data);
       const anchor = document.createElement('a');
       anchor.href = downloadUrl;
-      anchor.download = attachment?.title || 'download';
+      anchor.download = getDownloadFileName(attachment?.audio_type || attachment?.video_type || attachment?.image_type || '');
 
       document.body.appendChild(anchor);
       anchor.click();
       document.body.removeChild(anchor);
-      URL.revokeObjectURL(downloadUrl);
     } catch (error) {
       console.error('Error downloading the file:', error);
     }

--- a/packages/react/src/views/AttachmentHandler/AudioAttachment.js
+++ b/packages/react/src/views/AttachmentHandler/AudioAttachment.js
@@ -1,4 +1,4 @@
-import React, { useState, useContext } from 'react';
+import React, { useState, useContext, useEffect } from 'react';
 import PropTypes from 'prop-types';
 import { css } from '@emotion/react';
 import { Box, Avatar, useTheme } from '@embeddedchat/ui-elements';
@@ -23,9 +23,68 @@ const AudioAttachment = ({
   const { authorIcon, authorName } = author;
 
   const [isExpanded, setIsExpanded] = useState(true);
+  const [audioSrc, setAudioSrc] = useState('');
+  const [nestedAudioSrcMap, setNestedAudioSrcMap] = useState({});
   const toggleExpanded = () => {
     setIsExpanded((prevState) => !prevState);
   };
+
+  useEffect(() => {
+    let isMounted = true;
+    const loadAudioWithAuth = async () => {
+      const { userId, authToken } = (await RCInstance.auth.getCurrentUser()) || {};
+      const sourceUrl = host + attachment.audio_url;
+      if (!isMounted) return;
+      if (userId && authToken) {
+        const separator = sourceUrl.includes('?') ? '&' : '?';
+        setAudioSrc(
+          `${sourceUrl}${separator}rc_uid=${encodeURIComponent(userId)}&rc_token=${encodeURIComponent(authToken)}`
+        );
+      } else {
+        setAudioSrc(sourceUrl);
+      }
+    };
+
+    if (attachment?.audio_url) {
+      loadAudioWithAuth();
+    }
+
+    return () => {
+      isMounted = false;
+    };
+  }, [RCInstance, attachment?.audio_url, host]);
+
+  useEffect(() => {
+    let isMounted = true;
+
+    const loadNestedAudio = async () => {
+      if (!attachment?.attachments?.length) return;
+
+      const { userId, authToken } = (await RCInstance.auth.getCurrentUser()) || {};
+      const nextMap = {};
+
+      attachment.attachments.forEach((nestedAttachment, index) => {
+        if (!nestedAttachment?.audio_url) return;
+        const sourceUrl = host + nestedAttachment.audio_url;
+        if (userId && authToken) {
+          const separator = sourceUrl.includes('?') ? '&' : '?';
+          nextMap[index] = `${sourceUrl}${separator}rc_uid=${encodeURIComponent(userId)}&rc_token=${encodeURIComponent(authToken)}`;
+        } else {
+          nextMap[index] = sourceUrl;
+        }
+      });
+
+      if (isMounted) {
+        setNestedAudioSrcMap(nextMap);
+      }
+    };
+
+    loadNestedAudio();
+
+    return () => {
+      isMounted = false;
+    };
+  }, [RCInstance, attachment?.attachments, host]);
 
   return (
     <Box>
@@ -76,7 +135,7 @@ const AudioAttachment = ({
         >
           <AttachmentMetadata
             attachment={attachment}
-            url={host + (attachment.title_url || attachment.audio_url)}
+            url={host + (attachment.audio_url || attachment.title_url)}
             variantStyles={variantStyles}
             msg={msg}
             onExpandCollapseClick={toggleExpanded}
@@ -85,7 +144,7 @@ const AudioAttachment = ({
         </Box>
         {isExpanded && (
           <audio
-            src={host + attachment.audio_url}
+            src={audioSrc || host + attachment.audio_url}
             style={{ maxHeight: '100%', maxWidth: '100%' }}
             controls
           />
@@ -138,12 +197,14 @@ const AudioAttachment = ({
                   attachment={nestedAttachment}
                   url={
                     host +
-                    (nestedAttachment.title_url || nestedAttachment.audio_url)
+                    (nestedAttachment.audio_url || nestedAttachment.title_url)
                   }
                   variantStyles={variantStyles}
                 />
                 <audio
-                  src={host + nestedAttachment.audio_url}
+                  src={
+                    nestedAudioSrcMap[index] || host + nestedAttachment.audio_url
+                  }
                   width="100%"
                   controls
                 />

--- a/packages/react/src/views/AttachmentPreview/AttachmentPreview.js
+++ b/packages/react/src/views/AttachmentPreview/AttachmentPreview.js
@@ -29,6 +29,7 @@ const AttachmentPreview = () => {
   const setData = useAttachmentWindowStore((state) => state.setData);
 
   const [isPending, setIsPending] = useState(false);
+  const isMountedRef = useRef(true);
   const messageRef = useRef(null);
   const [showMembersList, setShowMembersList] = useState(false);
   const [filteredMembers, setFilteredMembers] = useState([]);
@@ -37,6 +38,12 @@ const AttachmentPreview = () => {
 
   const [fileName, setFileName] = useState(data?.name ?? '');
   useEffect(() => setFileName(data?.name ?? ''), [data?.name]);
+  useEffect(
+    () => () => {
+      isMountedRef.current = false;
+    },
+    []
+  );
 
   const [description, setDescription] = useState('');
   const charCount = description.length;
@@ -68,22 +75,61 @@ const AttachmentPreview = () => {
     searchMentionUser(raw);
   };
 
+  const getExtensionFromMimeType = (mimeType = '') => {
+    if (!mimeType.includes('/')) return '';
+    const ext = mimeType.split('/')[1].toLowerCase();
+    if (ext === 'mpeg') return 'mp3';
+    if (ext === 'jpeg') return 'jpg';
+    return ext;
+  };
+
+  const getNormalizedUploadFileName = () => {
+    const originalName = (data?.name || '').trim();
+    const desiredName = (fileName || '').trim();
+
+    if (!desiredName) return originalName || 'upload';
+
+    const originalExtension = originalName.includes('.')
+      ? originalName.split('.').pop().toLowerCase()
+      : getExtensionFromMimeType(data?.type || '');
+    const hasDesiredExtension = /\.[a-z0-9]+$/i.test(desiredName);
+
+    // Keep media files downloadable/playable even after rename.
+    if ((data?.type || '').startsWith('audio/')) {
+      if (!hasDesiredExtension && originalExtension) {
+        return `${desiredName}.${originalExtension}`;
+      }
+
+      if (hasDesiredExtension) {
+        const desiredExtension = desiredName.split('.').pop().toLowerCase();
+        if (['txt', 'text'].includes(desiredExtension) && originalExtension) {
+          return `${desiredName.replace(/\.[^.]+$/, '')}.${originalExtension}`;
+        }
+      }
+    }
+
+    return desiredName;
+  };
+
   const submit = async () => {
     if (isPending) return;
     if (msgMaxLength && description.length > msgMaxLength) return;
 
     setIsPending(true);
     try {
+      const normalizedFileName = getNormalizedUploadFileName();
       await RCInstance.sendAttachment(
         data,
-        fileName,
+        normalizedFileName,
         parseEmoji(description),
         ECOptions?.enableThreads ? threadId : undefined
       );
       toggle();
       setData(null);
     } finally {
-      setIsPending(false);
+      if (isMountedRef.current) {
+        setIsPending(false);
+      }
     }
   };
 

--- a/packages/react/src/views/AttachmentPreview/CheckPreviewType.js
+++ b/packages/react/src/views/AttachmentPreview/CheckPreviewType.js
@@ -24,11 +24,14 @@ const CheckPreviewType = ({ data }) => {
     return null;
   }
 
-  const reader = new FileReader();
-  reader.onload = (e) => {
-    setPreviewURL(e.target.result);
-  };
-  reader.readAsDataURL(data);
+  useEffect(() => {
+    const url = URL.createObjectURL(data);
+    setPreviewURL(url);
+
+    return () => {
+      URL.revokeObjectURL(url);
+    };
+  }, [data]);
 
   switch (type) {
     case 'image': {

--- a/packages/react/src/views/ChatInput/AudioMessageRecorder.js
+++ b/packages/react/src/views/ChatInput/AudioMessageRecorder.js
@@ -32,9 +32,17 @@ const AudioMessageRecorder = (props) => {
   const [isRecorded, setIsRecorded] = useState(false);
 
   const onStop = (audioChunks) => {
-    const audioBlob = new Blob(audioChunks, { type: 'audio/mpeg' });
-    const fileName = 'Audio record.mp3';
-    setFile(new File([audioBlob], fileName, { type: 'audio/mpeg' }));
+    const detectedMimeType = audioChunks?.[0]?.type || 'audio/webm';
+    const extension = detectedMimeType.includes('mpeg')
+      ? 'mp3'
+      : detectedMimeType.includes('ogg')
+      ? 'ogg'
+      : detectedMimeType.includes('wav')
+      ? 'wav'
+      : 'webm';
+    const audioBlob = new Blob(audioChunks, { type: detectedMimeType });
+    const fileName = `Audio record.${extension}`;
+    setFile(new File([audioBlob], fileName, { type: detectedMimeType }));
   };
 
   const [start, stop] = useMediaRecorder({

--- a/packages/react/src/views/Message/Message.js
+++ b/packages/react/src/views/Message/Message.js
@@ -68,9 +68,16 @@ const Message = ({
   const openThread = useMessageStore((state) => state.openThread);
   const { getStarredMessages } = useFetchChatData();
   const dispatchToastMessage = useToastBarDispatch();
-  const { editMessage, setEditMessage } = useMessageStore((state) => ({
+  const {
+    editMessage,
+    setEditMessage,
+    setBulkSelectMode,
+    toggleSelectedMessageId,
+  } = useMessageStore((state) => ({
     editMessage: state.editMessage,
     setEditMessage: state.setEditMessage,
+    setBulkSelectMode: state.setBulkSelectMode,
+    toggleSelectedMessageId: state.toggleSelectedMessageId,
   }));
   const deleteMessagePermissions = useMessageStore(
     (state) => state.deleteMessageRoles.roles
@@ -325,6 +332,10 @@ const Message = ({
                       }
                     }}
                     handleQuoteMessage={() => addQuoteMessage(message)}
+                    handleSelectMessages={(msg) => {
+                      setBulkSelectMode(true);
+                      toggleSelectedMessageId(msg._id);
+                    }}
                     handleEmojiClick={handleEmojiClick}
                     handlerReportMessage={() => {
                       setMessageToReport(message._id);

--- a/packages/react/src/views/Message/Message.js
+++ b/packages/react/src/views/Message/Message.js
@@ -209,9 +209,13 @@ const Message = ({
     getStarredMessages();
   };
 
-  const handleEmojiClick = async (e, msg, canReact) => {
+  const handleEmojiClick = async (e, msg, _canReact) => {
     const emoji = (e.names?.[0] || e.name).replace(/\s/g, '_');
-    await RCInstance.reactToMessage(emoji, msg._id, canReact);
+    const reactionKeysToCheck = emoji?.startsWith(':') ? [emoji] : [emoji, `:${emoji}:`];
+    const alreadyReacted = reactionKeysToCheck.some((key) =>
+      msg?.reactions?.[key]?.usernames?.includes(authenticatedUserUsername)
+    );
+    await RCInstance.reactToMessage(emoji, msg._id, !alreadyReacted);
   };
 
   const handleOpenThread = (msg) => async () => {

--- a/packages/react/src/views/Message/MessageToolbox.js
+++ b/packages/react/src/views/Message/MessageToolbox.js
@@ -39,6 +39,7 @@ export const MessageToolbox = ({
   handleCopyMessageLink,
   handleEditMessage,
   handleQuoteMessage,
+  handleSelectMessages,
   isEditing = false,
   optionConfig = {
     surfaceItems: [
@@ -50,6 +51,7 @@ export const MessageToolbox = ({
       'link',
       'pin',
       'edit',
+      'select',
       'delete',
       'report',
     ],
@@ -115,6 +117,13 @@ export const MessageToolbox = ({
 
   const options = useMemo(
     () => ({
+      select: {
+        label: 'Select message',
+        id: 'select',
+        onClick: () => handleSelectMessages(message),
+        iconName: 'check',
+        visible: true,
+      },
       reply: {
         label: 'Reply in thread',
         id: 'reply',
@@ -204,6 +213,7 @@ export const MessageToolbox = ({
       isThreadMessage,
       authenticatedUserId,
       isEditing,
+      handleSelectMessages,
       handleQuoteMessage,
       handleStarMessage,
       handlePinMessage,
@@ -243,6 +253,29 @@ export const MessageToolbox = ({
     })
     .filter((option) => option !== null);
 
+  const hasSelectAction = surfaceOptions?.some((option) => option.id === 'select');
+  const mergedSurfaceOptions = hasSelectAction
+    ? surfaceOptions
+    : (() => {
+        const fallbackOptions = [...(surfaceOptions || [])];
+        const editIndex = fallbackOptions.findIndex((option) => option.id === 'edit');
+        const selectOption = {
+          id: options.select.id,
+          onClick: options.select.onClick,
+          label: options.select.label,
+          iconName: options.select.iconName,
+          type: options.select.type,
+        };
+
+        if (editIndex >= 0) {
+          fallbackOptions.splice(editIndex + 1, 0, selectOption);
+        } else {
+          fallbackOptions.push(selectOption);
+        }
+
+        return fallbackOptions;
+      })();
+
   return (
     <>
       <Box css={variantStyles.toolboxContainer || styles.toolboxContainer}>
@@ -252,8 +285,8 @@ export const MessageToolbox = ({
           style={styleOverrides}
           {...props}
         >
-          {surfaceOptions?.length > 0 && (
-            <SurfaceMenu options={surfaceOptions} size="small" />
+          {mergedSurfaceOptions?.length > 0 && (
+            <SurfaceMenu options={mergedSurfaceOptions} size="small" />
           )}
           {menuOptions?.length > 0 && (
             <Menu

--- a/packages/react/src/views/MessageList/MessageList.js
+++ b/packages/react/src/views/MessageList/MessageList.js
@@ -1,9 +1,19 @@
-import React from 'react';
+import React, { useContext, useMemo, useState } from 'react';
 import PropTypes from 'prop-types';
 import { css } from '@emotion/react';
 import { isSameDay } from 'date-fns';
-import { Box, Icon, Throbber, useTheme } from '@embeddedchat/ui-elements';
-import { useMessageStore } from '../../store';
+import {
+  Box,
+  Icon,
+  Throbber,
+  useTheme,
+  Button,
+  Modal,
+  Input,
+  useToastBarDispatch,
+} from '@embeddedchat/ui-elements';
+import RCContext from '../../context/RCInstance';
+import { useMessageStore, useUserStore } from '../../store';
 import MessageReportWindow from '../ReportMessage/MessageReportWindow';
 import isMessageSequential from '../../lib/isMessageSequential';
 import { Message } from '../Message';
@@ -18,15 +28,129 @@ const MessageList = ({
   hasMoreMessages,
   firstUnreadMessageId,
 }) => {
+  const { RCInstance } = useContext(RCContext);
   const showReportMessage = useMessageStore((state) => state.showReportMessage);
   const messageToReport = useMessageStore((state) => state.messageToReport);
   const isMessageLoaded = useMessageStore((state) => state.isMessageLoaded);
+  const removeMessage = useMessageStore((state) => state.removeMessage);
+  const deleteMessageRoles = useMessageStore((state) => state.deleteMessageRoles.roles);
+  const deleteOwnMessageRoles = useMessageStore(
+    (state) => state.deleteOwnMessageRoles.roles
+  );
+  const forceDeleteMessageRoles = useMessageStore(
+    (state) => state.forceDeleteMessageRoles.roles
+  );
+  const userId = useUserStore((state) => state.userId);
+  const userRoles = useUserStore((state) => state.roles);
+  const dispatchToastMessage = useToastBarDispatch();
   const { theme } = useTheme();
+  const selectionMode = useMessageStore((state) => state.isBulkSelectMode);
+  const selectedMessageIds = useMessageStore((state) => state.selectedMessageIds);
+  const setSelectionMode = useMessageStore((state) => state.setBulkSelectMode);
+  const clearBulkSelection = useMessageStore((state) => state.clearBulkSelection);
+  const toggleSelectedMessageId = useMessageStore(
+    (state) => state.toggleSelectedMessageId
+  );
+  const setSelectedMessageIds = useMessageStore(
+    (state) => state.setSelectedMessageIds
+  );
+  const [showBulkDeleteModal, setShowBulkDeleteModal] = useState(false);
 
   const isMessageNewDay = (current, previous) =>
     !previous || !isSameDay(new Date(current.ts), new Date(previous.ts));
 
   const filteredMessages = messages.filter((msg) => !msg.tmid);
+  const selectedMessages = filteredMessages.filter((msg) =>
+    selectedMessageIds.includes(msg._id)
+  );
+
+  const deleteRolesSet = useMemo(() => new Set(deleteMessageRoles || []), [
+    deleteMessageRoles,
+  ]);
+  const deleteOwnRolesSet = useMemo(() => new Set(deleteOwnMessageRoles || []), [
+    deleteOwnMessageRoles,
+  ]);
+  const forceDeleteRolesSet = useMemo(
+    () => new Set(forceDeleteMessageRoles || []),
+    [forceDeleteMessageRoles]
+  );
+
+  const canDeleteMessage = (msg) => {
+    const isAllowedToForceDelete = (userRoles || []).some((role) =>
+      forceDeleteRolesSet.has(role)
+    );
+    if (isAllowedToForceDelete) return true;
+
+    const isAllowedToDelete = (userRoles || []).some((role) =>
+      deleteRolesSet.has(role)
+    );
+    if (isAllowedToDelete) return true;
+
+    const isAllowedToDeleteOwn = (userRoles || []).some((role) =>
+      deleteOwnRolesSet.has(role)
+    );
+    return isAllowedToDeleteOwn && msg?.u?._id === userId;
+  };
+
+  const selectableMessageIds = filteredMessages
+    .filter((msg) => canDeleteMessage(msg))
+    .map((msg) => msg._id);
+  const areAllDeletableSelected =
+    selectableMessageIds.length > 0 &&
+    selectableMessageIds.every((id) => selectedMessageIds.includes(id));
+
+  const handleToggleSelectionMode = (nextState = null) => {
+    const isNextState =
+      typeof nextState === 'boolean' ? nextState : !selectionMode;
+    if (isNextState) {
+      setSelectionMode(true);
+      return;
+    }
+    clearBulkSelection();
+  };
+
+  const handleToggleMessageSelect = (messageId, checked) => {
+    if (checked && !selectionMode) {
+      setSelectionMode(true);
+    }
+    toggleSelectedMessageId(messageId);
+  };
+
+  const handleBulkDelete = async () => {
+    const allowedMessages = selectedMessages.filter((msg) => canDeleteMessage(msg));
+    if (!allowedMessages.length) {
+      dispatchToastMessage({
+        type: 'error',
+        message: 'No selected messages can be deleted',
+      });
+      return;
+    }
+
+    const results = await Promise.allSettled(
+      allowedMessages.map((msg) => RCInstance.deleteMessage(msg._id))
+    );
+
+    let deletedCount = 0;
+    let failedCount = 0;
+    results.forEach((result, index) => {
+      if (result.status === 'fulfilled' && result.value?.success) {
+        deletedCount += 1;
+        removeMessage(allowedMessages[index]._id);
+      } else {
+        failedCount += 1;
+      }
+    });
+
+    setShowBulkDeleteModal(false);
+    clearBulkSelection();
+
+    dispatchToastMessage({
+      type: failedCount ? 'warning' : 'success',
+      message: failedCount
+        ? `Deleted ${deletedCount} message(s), failed ${failedCount}`
+        : `Deleted ${deletedCount} message(s)`,
+    });
+  };
 
   const reportedMessage = messages.find((msg) => msg._id === messageToReport);
 
@@ -96,14 +220,81 @@ const MessageList = ({
                   {showUnreadDivider && (
                     <MessageDivider unread>Unread Messages</MessageDivider>
                   )}
-                  <Message
-                    message={msg}
-                    newDay={newDay}
-                    sequential={sequential}
-                    lastSequential={lastSequential}
-                    type="default"
-                    showAvatar
-                  />
+                  <Box
+                    css={css`
+                      display: flex;
+                      align-items: flex-start;
+                      gap: 0.25rem;
+                      position: relative;
+                    `}
+                  >
+                    {selectionMode && (
+                      <Box
+                        css={css`
+                          padding-top: 0.4rem;
+                          min-width: 1.5rem;
+                        `}
+                      >
+                        <Input
+                          type="checkbox"
+                          checked={selectedMessageIds.includes(msg._id)}
+                          disabled={!canDeleteMessage(msg)}
+                          onChange={(e) =>
+                            handleToggleMessageSelect(msg._id, e.target.checked)
+                          }
+                          css={css`
+                            width: 16px;
+                            height: 16px;
+                            min-width: 16px;
+                            border: 1.5px solid ${theme.colors.border};
+                            border-radius: 3px;
+                            appearance: none;
+                            background: transparent;
+                            cursor: pointer;
+                            margin: 0;
+
+                            &:checked {
+                              background: ${theme.colors.primary};
+                              border-color: ${theme.colors.primary};
+                              position: relative;
+                            }
+
+                            &:checked::after {
+                              content: '';
+                              position: absolute;
+                              left: 4px;
+                              top: 1px;
+                              width: 4px;
+                              height: 8px;
+                              border: solid ${theme.colors.background};
+                              border-width: 0 2px 2px 0;
+                              transform: rotate(45deg);
+                            }
+
+                            &:disabled {
+                              opacity: 0.4;
+                              cursor: not-allowed;
+                            }
+                          `}
+                        />
+                      </Box>
+                    )}
+                    <Box
+                      css={css`
+                        width: 100%;
+                      `}
+                    >
+                      <Message
+                        message={msg}
+                        newDay={newDay}
+                        sequential={sequential}
+                        lastSequential={lastSequential}
+                        type="default"
+                        showAvatar
+                        showToolbox={!selectionMode}
+                      />
+                    </Box>
+                  </Box>
                 </React.Fragment>
               );
             })}
@@ -114,6 +305,82 @@ const MessageList = ({
             />
           )}
         </>
+      )}
+      {showBulkDeleteModal && (
+        <Modal onClose={() => setShowBulkDeleteModal(false)}>
+          <Modal.Header>
+            <Modal.Title>Delete selected messages?</Modal.Title>
+            <Modal.Close onClick={() => setShowBulkDeleteModal(false)} />
+          </Modal.Header>
+          <Modal.Content>
+            You are about to delete {selectedMessageIds.length} selected message(s).
+            This action cannot be undone.
+          </Modal.Content>
+          <Modal.Footer>
+            <Button type="secondary" onClick={() => setShowBulkDeleteModal(false)}>
+              Cancel
+            </Button>
+            <Button type="destructive" onClick={handleBulkDelete}>
+              Delete
+            </Button>
+          </Modal.Footer>
+        </Modal>
+      )}
+      {selectionMode && (
+        <Box
+          css={css`
+            position: sticky;
+            bottom: 0;
+            z-index: 20;
+            width: 100%;
+            padding: 0.5rem 0.75rem;
+            border-top: 1px solid ${theme.colors.border};
+            background: ${theme.colors.background};
+            display: flex;
+            align-items: center;
+            justify-content: space-between;
+            gap: 0.5rem;
+          `}
+        >
+          <Box
+            css={css`
+              font-size: 0.875rem;
+              opacity: 0.85;
+            `}
+          >
+            {selectedMessageIds.length} selected
+          </Box>
+          <Box
+            css={css`
+              display: flex;
+              gap: 0.5rem;
+            `}
+          >
+            <Button
+              type="secondary"
+              small
+              onClick={() => {
+                setSelectionMode(true);
+                setSelectedMessageIds(
+                  areAllDeletableSelected ? [] : selectableMessageIds
+                );
+              }}
+            >
+              {areAllDeletableSelected ? 'Deselect all' : 'Select all'}
+            </Button>
+            <Button type="secondary" small onClick={() => handleToggleSelectionMode(false)}>
+              Cancel
+            </Button>
+            <Button
+              type="destructive"
+              small
+              disabled={selectedMessageIds.length === 0}
+              onClick={() => setShowBulkDeleteModal(true)}
+            >
+              Delete
+            </Button>
+          </Box>
+        </Box>
       )}
     </>
   );

--- a/packages/ui-elements/src/components/Tooltip/Tooltip.js
+++ b/packages/ui-elements/src/components/Tooltip/Tooltip.js
@@ -32,6 +32,7 @@ const Tooltip = ({ children, text, position }) => {
 
   return (
     <Box
+      is="span"
       onMouseEnter={handleMouseEnter}
       onMouseLeave={handleMouseLeave}
       onTouchStart={handleTouchStart}
@@ -43,9 +44,9 @@ const Tooltip = ({ children, text, position }) => {
     >
       {children}
       {isTooltipVisible && (
-        <Box css={styles.tooltip}>
+        <Box is="span" css={styles.tooltip}>
           {text.charAt(0).toUpperCase() + text.slice(1)}
-          <Box css={styles.tooltipArrow} />
+          <Box is="span" css={styles.tooltipArrow} />
         </Box>
       )}
     </Box>


### PR DESCRIPTION
# Add multi-message selection and bulk delete flow

## Acceptance Criteria fulfillment

- [x] Added Select message action in message toolbox (placed after Edit) to enter selection mode.
- [x] Implemented global message selection with checkboxes and bottom action bar (Select all/Deselect all, Cancel, Delete).
- [x] Added bulk delete confirmation + batch delete execution with permission-aware handling and result toast feedback.

Fixes #1249 


https://github.com/user-attachments/assets/ec4f8228-fd6c-47b1-b581-4a65e25eecf5


## PR Test Details

**Note**: The PR will be ready for live testing at https://rocketchat.github.io/EmbeddedChat/pulls/pr-1250 after approval. 