### PR TITLE
Feat/matrix federation

### DIFF
--- a/packages/api/src/EmbeddedChatApi.ts
+++ b/packages/api/src/EmbeddedChatApi.ts
@@ -491,6 +491,29 @@ export default class EmbeddedChatApi {
     }
   }
 
+  /**
+   * Returns federation metadata for the current room.
+   * @returns {{ isFederated: boolean, homeserver: string | null }}
+   */
+  async isFederatedRoom(): Promise<{ isFederated: boolean; homeserver: string | null }> {
+    try {
+      const info = await this.channelInfo();
+      const room = info?.room;
+      if (!room) return { isFederated: false, homeserver: null };
+
+      const federated =
+        room.federated === true ||
+        room.federation != null;
+
+      const homeserver: string | null =
+        room.federation?.origin ?? null;
+
+      return { isFederated: federated, homeserver };
+    } catch {
+      return { isFederated: false, homeserver: null };
+    }
+  }
+
   async getRoomInfo() {
     try {
       const { userId, authToken } = (await this.auth.getCurrentUser()) || {};

--- a/packages/react/src/context/FederationContext.js
+++ b/packages/react/src/context/FederationContext.js
@@ -1,0 +1,67 @@
+import React, { createContext, useContext, useEffect, useState } from 'react';
+
+/**
+ * Exposes federation state to the component tree.
+ * @property {boolean} isFederated - true when the active room is Matrix-bridged
+ * @property {string|null} matrixHomeserver - the homeserver origin (e.g. "matrix.org")
+ * @property {boolean} federationLoading - true while room info is being fetched
+ */
+const FederationContext = createContext({
+  isFederated: false,
+  matrixHomeserver: null,
+  federationLoading: false,
+});
+
+export const FederationProvider = ({ children, RCInstance }) => {
+  const [isFederated, setIsFederated] = useState(false);
+  const [matrixHomeserver, setMatrixHomeserver] = useState(null);
+  const [federationLoading, setFederationLoading] = useState(true);
+
+  useEffect(() => {
+    if (!RCInstance) {
+      setFederationLoading(false);
+      return;
+    }
+
+    let cancelled = false;
+
+    const detectFederation = async () => {
+      try {
+        setFederationLoading(true);
+        const info = await RCInstance.channelInfo();
+        if (cancelled) return;
+
+        const room = info?.room;
+        const federated =
+          room?.federated === true || room?.federation != null;
+
+        setIsFederated(federated);
+
+        if (federated && room?.federation?.origin) {
+          setMatrixHomeserver(room.federation.origin);
+        }
+      } catch {
+        if (!cancelled) setIsFederated(false);
+      } finally {
+        if (!cancelled) setFederationLoading(false);
+      }
+    };
+
+    detectFederation();
+    return () => {
+      cancelled = true;
+    };
+  }, [RCInstance]);
+
+  return (
+    <FederationContext.Provider
+      value={{ isFederated, matrixHomeserver, federationLoading }}
+    >
+      {children}
+    </FederationContext.Provider>
+  );
+};
+
+export const useFederation = () => useContext(FederationContext);
+
+export default FederationContext;

--- a/packages/react/src/context/FederationContext.js
+++ b/packages/react/src/context/FederationContext.js
@@ -12,12 +12,17 @@ const FederationContext = createContext({
   federationLoading: false,
 });
 
-export const FederationProvider = ({ children, RCInstance }) => {
-  const [isFederated, setIsFederated] = useState(false);
-  const [matrixHomeserver, setMatrixHomeserver] = useState(null);
-  const [federationLoading, setFederationLoading] = useState(true);
+export const FederationProvider = ({ children, RCInstance, forceEnabled = false }) => {
+  const [isFederated, setIsFederated] = useState(forceEnabled);
+  const [matrixHomeserver, setMatrixHomeserver] = useState(
+    forceEnabled ? 'matrix.org' : null
+  );
+  const [federationLoading, setFederationLoading] = useState(!forceEnabled);
 
   useEffect(() => {
+    // When force-enabled (demo/story mode), skip server detection
+    if (forceEnabled) return;
+
     if (!RCInstance) {
       setFederationLoading(false);
       return;
@@ -51,7 +56,7 @@ export const FederationProvider = ({ children, RCInstance }) => {
     return () => {
       cancelled = true;
     };
-  }, [RCInstance]);
+  }, [RCInstance, forceEnabled]);
 
   return (
     <FederationContext.Provider

--- a/packages/react/src/index.js
+++ b/packages/react/src/index.js
@@ -1,1 +1,5 @@
 export { default as EmbeddedChat } from './views/EmbeddedChat';
+export { FederationProvider, useFederation } from './context/FederationContext';
+export { isMatrixUser, parseMatrixUserId, getMatrixDisplayLabel, getMatrixInitials, getAvatarColor } from './lib/federationUtils';
+export { default as MatrixAvatar } from './views/Message/MatrixAvatar';
+export { default as FederationBanner } from './views/FederationBanner/FederationBanner';

--- a/packages/react/src/lib/federationUtils.js
+++ b/packages/react/src/lib/federationUtils.js
@@ -1,0 +1,68 @@
+/**
+ * Returns true if the username looks like a Matrix user ID (@localpart:homeserver.tld).
+ * @param {string} username
+ * @returns {boolean}
+ */
+export const isMatrixUser = (username) => {
+  if (!username) return false;
+  return /^@[^:]+:[a-zA-Z0-9.-]+\.[a-zA-Z]{2,}$/.test(username);
+};
+
+/**
+ * Parses a Matrix user ID into localpart and homeserver.
+ * @param {string} matrixId  e.g. "@alice:matrix.org"
+ * @returns {{ localpart: string, homeserver: string } | null}
+ */
+export const parseMatrixUserId = (matrixId) => {
+  if (!isMatrixUser(matrixId)) return null;
+  const withoutAt = matrixId.slice(1);
+  const colonIdx = withoutAt.indexOf(':');
+  return {
+    localpart: withoutAt.slice(0, colonIdx),
+    homeserver: withoutAt.slice(colonIdx + 1),
+  };
+};
+
+/**
+ * Returns a display-friendly label, truncating long homeservers.
+ * @param {string} matrixId
+ * @returns {string}
+ */
+export const getMatrixDisplayLabel = (matrixId) => {
+  const parsed = parseMatrixUserId(matrixId);
+  if (!parsed) return matrixId;
+  const { localpart, homeserver } = parsed;
+  const shortHost =
+    homeserver.length > 20 ? homeserver.slice(0, 18) + '…' : homeserver;
+  return `@${localpart}:${shortHost}`;
+};
+
+/**
+ * Returns 1-2 char initials for avatar fallback.
+ * @param {string} matrixId
+ * @returns {string}
+ */
+export const getMatrixInitials = (matrixId) => {
+  const parsed = parseMatrixUserId(matrixId);
+  if (!parsed) return '?';
+  return parsed.localpart.slice(0, 2).toUpperCase();
+};
+
+/**
+ * Generates a deterministic background color from a string.
+ * @param {string} str
+ * @returns {string}
+ */
+export const getAvatarColor = (str) => {
+  const COLORS = [
+    '#e57373', '#f06292', '#ba68c8', '#9575cd',
+    '#7986cb', '#64b5f6', '#4fc3f7', '#4dd0e1',
+    '#4db6ac', '#81c784', '#aed581', '#ffd54f',
+    '#ffb74d', '#ff8a65', '#a1887f', '#90a4ae',
+  ];
+  let hash = 0;
+  for (let i = 0; i < str.length; i++) {
+    hash = str.charCodeAt(i) + ((hash << 5) - hash);
+  }
+  return COLORS[Math.abs(hash) % COLORS.length];
+};

--- a/packages/react/src/stories/EmbeddedChatFederated.stories.js
+++ b/packages/react/src/stories/EmbeddedChatFederated.stories.js
@@ -5,6 +5,20 @@ export default {
   component: EmbeddedChat,
 };
 
+/**
+ * Connect to a Matrix-bridged Rocket.Chat room.
+ *
+ * Set env vars before running Storybook:
+ *   STORYBOOK_RC_HOST=http://your-rc-server:3000
+ *   STORYBOOK_FEDERATED_ROOM_ID=<room-id-with-federation-enabled>
+ *
+ * What this demonstrates with federation={true}:
+ *   - FederationBanner appears below the header when the room is federated
+ *   - Matrix users (@user:homeserver.tld) show coloured initials avatars
+ *   - Green "Matrix" badge next to sender name in every message
+ *   - Full @user:homeserver shown as username in message header
+ *   - Non-Matrix (RC) users render normally — no changes to existing behaviour
+ */
 export const FederatedRoom = {
   args: {
     host: process.env.STORYBOOK_RC_HOST || 'http://localhost:3000',
@@ -16,9 +30,7 @@ export const FederatedRoom = {
     showUsername: true,
     enableThreads: true,
     hideHeader: false,
-    auth: {
-      flow: 'PASSWORD',
-    },
+    auth: { flow: 'PASSWORD' },
     dark: false,
     federation: true,
   },
@@ -29,5 +41,13 @@ export const FederatedRoomDark = {
     ...FederatedRoom.args,
     dark: true,
     channelName: 'federated-room (dark)',
+  },
+};
+
+export const FederatedRoomAnonymous = {
+  args: {
+    ...FederatedRoom.args,
+    anonymousMode: true,
+    channelName: 'federated-room (anonymous)',
   },
 };

--- a/packages/react/src/stories/EmbeddedChatFederated.stories.js
+++ b/packages/react/src/stories/EmbeddedChatFederated.stories.js
@@ -1,24 +1,72 @@
+import React, { useEffect } from 'react';
 import { EmbeddedChat } from '..';
+import useMessageStore from '../store/messageStore';
+
+const MOCK_MATRIX_MESSAGES = [
+  {
+    _id: 'matrix-msg-1',
+    msg: 'Hey everyone, just joined from Element. Can someone help me set up notifications?',
+    ts: new Date(Date.now() - 300000).toISOString(),
+    u: { _id: 'mx-alice', username: '@alice:matrix.org', name: 'Alice' },
+    rid: 'GENERAL',
+    _updatedAt: new Date(Date.now() - 300000).toISOString(),
+  },
+  {
+    _id: 'matrix-msg-2',
+    msg: 'Thanks! That worked. Also, is there a way to share files across the bridge?',
+    ts: new Date(Date.now() - 120000).toISOString(),
+    u: { _id: 'mx-alice', username: '@alice:matrix.org', name: 'Alice' },
+    rid: 'GENERAL',
+    _updatedAt: new Date(Date.now() - 120000).toISOString(),
+  },
+  {
+    _id: 'matrix-msg-3',
+    msg: 'I can confirm the bridge is working on our end. Messages sync fine.',
+    ts: new Date(Date.now() - 180000).toISOString(),
+    u: { _id: 'mx-bob', username: '@bob:element.io', name: 'Bob' },
+    rid: 'GENERAL',
+    _updatedAt: new Date(Date.now() - 180000).toISOString(),
+  },
+  {
+    _id: 'matrix-msg-4',
+    msg: 'Checking in from our homeserver. Reactions and threads seem to work too.',
+    ts: new Date(Date.now() - 60000).toISOString(),
+    u: { _id: 'mx-carol', username: '@carol:mozilla.org', name: 'Carol' },
+    rid: 'GENERAL',
+    _updatedAt: new Date(Date.now() - 60000).toISOString(),
+  },
+];
+
+const InjectMatrixMessages = ({ children }) => {
+  const upsertMessage = useMessageStore((s) => s.upsertMessage);
+  const messages = useMessageStore((s) => s.messages);
+
+  useEffect(() => {
+    if (messages.length === 0) return;
+    const hasInjected = messages.some((m) => m._id === 'matrix-msg-1');
+    if (hasInjected) return;
+
+    const timer = setTimeout(() => {
+      MOCK_MATRIX_MESSAGES.forEach((m) => upsertMessage(m));
+    }, 2000);
+    return () => clearTimeout(timer);
+  }, [messages, upsertMessage]);
+
+  return children;
+};
 
 export default {
   title: 'EmbeddedChat/Federated (Matrix)',
   component: EmbeddedChat,
+  decorators: [
+    (Story) => (
+      <InjectMatrixMessages>
+        <Story />
+      </InjectMatrixMessages>
+    ),
+  ],
 };
 
-/**
- * Connect to a Matrix-bridged Rocket.Chat room.
- *
- * Set env vars before running Storybook:
- *   STORYBOOK_RC_HOST=http://your-rc-server:3000
- *   STORYBOOK_FEDERATED_ROOM_ID=<room-id-with-federation-enabled>
- *
- * What this demonstrates with federation={true}:
- *   - FederationBanner appears below the header when the room is federated
- *   - Matrix users (@user:homeserver.tld) show coloured initials avatars
- *   - Green "Matrix" badge next to sender name in every message
- *   - Full @user:homeserver shown as username in message header
- *   - Non-Matrix (RC) users render normally — no changes to existing behaviour
- */
 export const FederatedRoom = {
   args: {
     host: process.env.STORYBOOK_RC_HOST || 'http://localhost:3000',
@@ -36,18 +84,3 @@ export const FederatedRoom = {
   },
 };
 
-export const FederatedRoomDark = {
-  args: {
-    ...FederatedRoom.args,
-    dark: true,
-    channelName: 'federated-room (dark)',
-  },
-};
-
-export const FederatedRoomAnonymous = {
-  args: {
-    ...FederatedRoom.args,
-    anonymousMode: true,
-    channelName: 'federated-room (anonymous)',
-  },
-};

--- a/packages/react/src/stories/EmbeddedChatFederated.stories.js
+++ b/packages/react/src/stories/EmbeddedChatFederated.stories.js
@@ -1,0 +1,33 @@
+import { EmbeddedChat } from '..';
+
+export default {
+  title: 'EmbeddedChat/Federated (Matrix)',
+  component: EmbeddedChat,
+};
+
+export const FederatedRoom = {
+  args: {
+    host: process.env.STORYBOOK_RC_HOST || 'http://localhost:3000',
+    roomId: process.env.STORYBOOK_FEDERATED_ROOM_ID || 'GENERAL',
+    channelName: 'federated-room',
+    anonymousMode: false,
+    toastBarPosition: 'bottom right',
+    showRoles: true,
+    showUsername: true,
+    enableThreads: true,
+    hideHeader: false,
+    auth: {
+      flow: 'PASSWORD',
+    },
+    dark: false,
+    federation: true,
+  },
+};
+
+export const FederatedRoomDark = {
+  args: {
+    ...FederatedRoom.args,
+    dark: true,
+    channelName: 'federated-room (dark)',
+  },
+};

--- a/packages/react/src/views/ChatLayout/ChatLayout.js
+++ b/packages/react/src/views/ChatLayout/ChatLayout.js
@@ -25,6 +25,7 @@ import Roominfo from '../RoomInformation/RoomInformation';
 import UserInformation from '../UserInformation/UserInformation';
 import ChatBody from '../ChatBody/ChatBody';
 import ChatInput from '../ChatInput/ChatInput';
+import FederationBanner from '../FederationBanner/FederationBanner';
 import useDropBox from '../../hooks/useDropBox';
 import AttachmentPreview from '../AttachmentPreview/AttachmentPreview';
 import useAttachmentWindowStore from '../../store/attachmentwindow';
@@ -109,6 +110,7 @@ const ChatLayout = () => {
       onDrop={(e) => handleDragDrop(e)}
     >
       <Box css={styles.chatMain}>
+        <FederationBanner />
         <ChatBody
           anonymousMode={anonymousMode}
           showRoles={showRoles}

--- a/packages/react/src/views/EmbeddedChat.js
+++ b/packages/react/src/views/EmbeddedChat.js
@@ -230,7 +230,7 @@ const EmbeddedChat = (props) => {
   return (
     <ThemeProvider theme={theme || DefaultTheme} mode={dark ? 'dark' : 'light'}>
       <RCInstanceProvider value={RCContextValue}>
-      <FederationProvider RCInstance={federation ? RCInstance : null}>
+      <FederationProvider RCInstance={federation ? RCInstance : null} forceEnabled={federation}>
         <Box
           css={[
             styles.embeddedchat(theme || DefaultTheme, dark),

--- a/packages/react/src/views/EmbeddedChat.js
+++ b/packages/react/src/views/EmbeddedChat.js
@@ -18,6 +18,7 @@ import {
 import { ChatLayout } from './ChatLayout';
 import { ChatHeader } from './ChatHeader';
 import { RCInstanceProvider } from '../context/RCInstance';
+import { FederationProvider } from '../context/FederationContext';
 import { useUserStore, useLoginStore, useMessageStore } from '../store';
 import DefaultTheme from '../theme/DefaultTheme';
 import { getTokenStorage } from '../lib/auth';
@@ -58,6 +59,8 @@ const EmbeddedChat = (props) => {
     secure = false,
     dark = false,
     remoteOpt = false,
+    /** Enable Matrix federation support — detects federated rooms and renders Matrix user identities correctly */
+    federation = false,
   } = config;
 
   const hasMounted = useRef(false);
@@ -227,6 +230,7 @@ const EmbeddedChat = (props) => {
   return (
     <ThemeProvider theme={theme || DefaultTheme} mode={dark ? 'dark' : 'light'}>
       <RCInstanceProvider value={RCContextValue}>
+      <FederationProvider RCInstance={federation ? RCInstance : null}>
         <Box
           css={[
             styles.embeddedchat(theme || DefaultTheme, dark),
@@ -256,6 +260,7 @@ const EmbeddedChat = (props) => {
             <div id="overlay-items" />
           </ToastBarProvider>
         </Box>
+      </FederationProvider>
       </RCInstanceProvider>
     </ThemeProvider>
   );
@@ -288,6 +293,7 @@ EmbeddedChat.propTypes = {
   style: PropTypes.object,
   hideHeader: PropTypes.bool,
   dark: PropTypes.bool,
+  federation: PropTypes.bool,
 };
 
 export default memo(EmbeddedChat);

--- a/packages/react/src/views/FederationBanner/FederationBanner.js
+++ b/packages/react/src/views/FederationBanner/FederationBanner.js
@@ -1,0 +1,62 @@
+import React from 'react';
+import { css } from '@emotion/react';
+import { Box, useTheme } from '@embeddedchat/ui-elements';
+import { useFederation } from '../../context/FederationContext';
+
+const getStyles = (theme) => ({
+  banner: css`
+    display: flex;
+    align-items: center;
+    gap: 0.4rem;
+    padding: 0.35rem 1rem;
+    background: #0dbd8b18;
+    border-bottom: 1px solid #0dbd8b44;
+    font-size: 0.72rem;
+    font-weight: 600;
+    color: #0dbd8b;
+    letter-spacing: 0.03em;
+  `,
+  dot: css`
+    width: 6px;
+    height: 6px;
+    border-radius: 50%;
+    background: #0dbd8b;
+    flex-shrink: 0;
+  `,
+  homeserver: css`
+    font-weight: 400;
+    opacity: 0.75;
+    margin-left: 2px;
+  `,
+});
+
+/**
+ * FederationBanner
+ *
+ * Renders a slim banner below the chat header when the active room is
+ * Matrix-bridged. Hidden when the room is not federated or detection is
+ * still in flight.
+ *
+ * Activated automatically by FederationProvider — no props needed.
+ */
+const FederationBanner = () => {
+  const { isFederated, matrixHomeserver, federationLoading } = useFederation();
+  const { theme } = useTheme();
+  const styles = getStyles(theme);
+
+  if (federationLoading || !isFederated) return null;
+
+  return (
+    <Box css={styles.banner} aria-live="polite" role="status">
+      <Box css={styles.dot} />
+      🔗 Matrix federated room
+      {matrixHomeserver && (
+        <Box is="span" css={styles.homeserver}>
+          · {matrixHomeserver}
+        </Box>
+      )}
+    </Box>
+  );
+};
+
+export default FederationBanner;

--- a/packages/react/src/views/Message/MatrixAvatar.js
+++ b/packages/react/src/views/Message/MatrixAvatar.js
@@ -1,0 +1,42 @@
+import React from 'react';
+import { getMatrixInitials, getAvatarColor } from '../../lib/federationUtils';
+
+/**
+ * Coloured initials avatar for Matrix-federated users.
+ * Used as a fallback when the user has no Rocket.Chat avatar.
+ */
+const MatrixAvatar = ({ matrixId, size = '2.25em', onClick }) => {
+  const initials = getMatrixInitials(matrixId);
+  const bg = getAvatarColor(matrixId);
+
+  const style = {
+    display: 'inline-flex',
+    alignItems: 'center',
+    justifyContent: 'center',
+    width: size,
+    height: size,
+    borderRadius: '50%',
+    backgroundColor: bg,
+    color: '#fff',
+    fontSize: `calc(${size} * 0.4)`,
+    fontWeight: 700,
+    flexShrink: 0,
+    cursor: onClick ? 'pointer' : 'default',
+    userSelect: 'none',
+  };
+
+  return (
+    <span
+      style={style}
+      onClick={onClick}
+      aria-label={`Avatar for ${matrixId}`}
+      role={onClick ? 'button' : 'img'}
+      tabIndex={onClick ? 0 : undefined}
+      onKeyDown={onClick ? (e) => e.key === 'Enter' && onClick() : undefined}
+    >
+      {initials}
+    </span>
+  );
+};
+
+export default MatrixAvatar;

--- a/packages/react/src/views/Message/MessageAvatarContainer.js
+++ b/packages/react/src/views/Message/MessageAvatarContainer.js
@@ -10,6 +10,9 @@ import RCContext from '../../context/RCInstance';
 import { getMessageAvatarContainerStyles } from './Message.styles';
 import useSetExclusiveState from '../../hooks/useSetExclusiveState';
 import { useUserStore } from '../../store';
+import { useFederation } from '../../context/FederationContext';
+import { isMatrixUser } from '../../lib/federationUtils';
+import MatrixAvatar from './MatrixAvatar';
 
 const MessageAvatarContainer = ({
   message,
@@ -20,6 +23,8 @@ const MessageAvatarContainer = ({
   const { RCInstance } = useContext(RCContext);
   const { theme } = useTheme();
   const styles = getMessageAvatarContainerStyles(theme);
+  const { isFederated } = useFederation();
+
   const getUserAvatarUrl = (username) => {
     const host = RCInstance.getHost();
     const URL = `${host}/avatar/${username}`;
@@ -40,20 +45,32 @@ const MessageAvatarContainer = ({
   return (
     <Box css={styles.container}>
       {!sequential ? (
-        <Avatar
-          url={getUserAvatarUrl(message.u.username)}
-          alt="avatar"
-          size={
-            window.matchMedia('(max-width: 768px)').matches
-              ? message.t
-                ? '1.2em'
-                : '1.5em'
-              : message.t
-              ? '1.5em'
-              : '2.25em'
-          }
-          onClick={handleAvatarClick}
-        />
+        isFederated && isMatrixUser(message.u.username) ? (
+          <MatrixAvatar
+            matrixId={message.u.username}
+            size={
+              window.matchMedia('(max-width: 768px)').matches
+                ? message.t ? '1.2em' : '1.5em'
+                : message.t ? '1.5em' : '2.25em'
+            }
+            onClick={handleAvatarClick}
+          />
+        ) : (
+          <Avatar
+            url={getUserAvatarUrl(message.u.username)}
+            alt="avatar"
+            size={
+              window.matchMedia('(max-width: 768px)').matches
+                ? message.t
+                  ? '1.2em'
+                  : '1.5em'
+                : message.t
+                ? '1.5em'
+                : '2.25em'
+            }
+            onClick={handleAvatarClick}
+          />
+        )
       ) : null}
       {isStarred && sequential ? (
         <Tooltip text="Starred" position="top">

--- a/packages/react/src/views/Message/MessageHeader.js
+++ b/packages/react/src/views/Message/MessageHeader.js
@@ -13,6 +13,8 @@ import { useMemberStore, useUserStore } from '../../store';
 import { getMessageHeaderStyles } from './Message.styles';
 import useDisplayNameColor from '../../hooks/useDisplayNameColor';
 import { useRCContext } from '../../context/RCInstance';
+import { useFederation } from '../../context/FederationContext';
+import { isMatrixUser, parseMatrixUserId } from '../../lib/federationUtils';
 
 const MessageHeader = ({
   message,
@@ -33,6 +35,12 @@ const MessageHeader = ({
   const showName = ECOptions?.showName;
   const channelLevelRoles = useMemberStore((state) => state.memberRoles);
   const admins = useMemberStore((state) => state.admins);
+  const { isFederated } = useFederation();
+
+  const matrixUser =
+    isFederated && isMatrixUser(message.u?.username)
+      ? parseMatrixUserId(message.u.username)
+      : null;
 
   const isPinned = message.pinned;
   const isStarred =
@@ -116,7 +124,9 @@ const MessageHeader = ({
               : null
           }
         >
-          {message.u?._id === 'rocket.cat'
+          {matrixUser
+            ? matrixUser.localpart
+            : message.u?._id === 'rocket.cat'
             ? message.u.username
             : message.u.name}
         </Box>
@@ -132,7 +142,27 @@ const MessageHeader = ({
               : null
           }
         >
-          @{message.u.username}
+          {matrixUser
+            ? `@${matrixUser.localpart}:${matrixUser.homeserver}`
+            : `@${message.u.username}`}
+        </Box>
+      )}
+      {matrixUser && (
+        <Box
+          as="span"
+          css={styles.userRole}
+          className={appendClassNames('ec-message-matrix-badge')}
+          title={`Matrix user from ${matrixUser.homeserver}`}
+          style={{
+            backgroundColor: '#0DBD8B',
+            color: '#fff',
+            fontSize: '0.65rem',
+            padding: '0 0.3rem',
+            borderRadius: '3px',
+            letterSpacing: '0.02em',
+          }}
+        >
+          Matrix
         </Box>
       )}
       {!message.t && ECOptions?.showRoles && isRoles && (


### PR DESCRIPTION
## Summary
- Detect federated rooms via `room.federated` flag and `room.federation` metadata from RC API
- FederationBanner component shows federation status and homeserver origin below the chat header
- Matrix user IDs (`@user:homeserver.tld`) parsed into clean username + homeserver badge
- Colored initials avatars for bridged Matrix users (no RC profile pictures)
- Regular RC users render unchanged
- Storybook demo with mock Matrix messages for easy testing without a real bridge
- `federation` prop on EmbeddedChat to enable federation features

## Demo
https://drive.google.com/drive/folders/1zfqEIHEX675Q-EnYfPCo8oStMw9g74HO