### PR TITLE
fix: handle network errors during login to prevent TypeError crash

### DIFF
--- a/packages/api/src/EmbeddedChatApi.ts
+++ b/packages/api/src/EmbeddedChatApi.ts
@@ -143,6 +143,7 @@ export default class EmbeddedChatApi {
         return { error: authErrorRes?.error };
       }
       console.error(error);
+      return { error: error instanceof Error ? error.message : 'unknown-error' };
     }
   }
 

--- a/packages/react/src/hooks/useRCAuth.js
+++ b/packages/react/src/hooks/useRCAuth.js
@@ -25,6 +25,14 @@ export const useRCAuth = () => {
   const handleLogin = async (userOrEmail, password, code) => {
     try {
       const res = await RCInstance.login(userOrEmail, password, code);
+      if (!res) {
+        dispatchToastMessage({
+          type: 'error',
+          message:
+            'Unable to connect to server. Please check your connection and try again.',
+        });
+        return;
+      }
       if (res.error === 'Unauthorized' || res.error === 403) {
         dispatchToastMessage({
           type: 'error',


### PR DESCRIPTION
## Summary

Fixes #1210 — login crashes with `TypeError: Cannot read properties of undefined (reading 'error')` when a network error occurs during authentication.

## Root Cause

The `login` method in `EmbeddedChatApi.ts` catches errors but only returns a structured response for 401 errors. For all other errors (network failures, DNS errors, etc.), it `console.error()`s and implicitly returns `undefined`. The calling code in `useRCAuth.js` then tries to access `res.error`, which throws a `TypeError`.

## Changes

### `packages/api/src/EmbeddedChatApi.ts`
- Return `{ error: error.message }` (or `{ error: 'unknown-error' }`) for all non-401 errors instead of implicitly returning `undefined`

### `packages/react/src/hooks/useRCAuth.js`
- Added a null guard on the login response as a defensive check
- Shows a user-friendly toast message ("Unable to connect to server...") if the response is missing

## Testing

- Verified the fix handles the case described in the issue (network error → graceful toast instead of crash)
- The existing catch block in `handleLogin` still handles truly unexpected errors