### PR TITLE
fix(ui): prevent message timestamp overlap in small containers

### DIFF
--- a/packages/react/src/views/Message/Message.styles.js
+++ b/packages/react/src/views/Message/Message.styles.js
@@ -1,3 +1,4 @@
+
 import { css } from '@emotion/react';
 
 export const getMessageStyles = ({ theme }) => {
@@ -11,9 +12,6 @@ export const getMessageStyles = ({ theme }) => {
       padding-left: 2.25rem;
       padding-right: 2.25rem;
       color: ${theme.colors.foreground};
-      @media (max-width: 768px) {
-        padding-left: 0.8rem;
-      }
     `,
     messageEditing: css`
       background-color: ${theme.colors.secondary};
@@ -77,9 +75,6 @@ export const getMessageDividerStyles = (theme) => {
       margin-bottom: 0.75rem;
       padding-left: 1.25rem;
       padding-right: 1.25rem;
-      @media (max-width: 780px) {
-        z-index: 1;
-      }
     `,
 
     dividerContent: css`
@@ -129,9 +124,6 @@ export const getUnreadMessageDividerStyles = (theme, mode) => {
       margin-bottom: 0.75rem;
       padding-left: 1.25rem;
       padding-right: 1.25rem;
-      @media (max-width: 780px) {
-        z-index: 1;
-      }
     `,
 
     dividerContent: css`
@@ -165,6 +157,7 @@ export const getMessageHeaderStyles = (theme) => {
     header: css`
       display: flex;
       flex-direction: row;
+      flex-wrap: wrap;
       flex-grow: 0;
       flex-shrink: 1;
       min-width: 1px;
@@ -228,7 +221,8 @@ export const getMessageHeaderStyles = (theme) => {
       font-weight: 400;
       line-height: 1rem;
       flex-shrink: 0;
-      margin-left: 0.25rem;
+      margin-left: auto; 
+      min-width: fit-content;   
     `,
     messageStatus: css`
       display: flex;


### PR DESCRIPTION

 Changes
- Removed viewport-based media queries
- Added `flex-wrap: wrap` to the message header
- Updated timestamp styling using:
  - margin-left: auto
  - min-width: fit-content
  - flex-shrink: 0

Why this change?
EmbeddedChat is used inside flexible containers, not just full-screen views. 
Using media queries based on viewport width does not handle all cases.

This solution ensures the layout adapts correctly regardless of container size.

 Result
- No timestamp overlap
- Works in small containers and embedded views
- Maintains clean responsive layout
