### PR TITLE
# Fix OAuth callback crash on malformed `state` parameter  

### DIFF
--- a/packages/rc-app/endpoints/CallbackEndpoint.ts
+++ b/packages/rc-app/endpoints/CallbackEndpoint.ts
@@ -28,20 +28,54 @@ export class CallbackEndpoint extends ApiEndpoint {
         persis: IPersistence
     ): Promise<IApiResponse> {
         const { state, code } = request.query;
+        const contentSecurityPolicy =
+            "default-src 'self'; script-src 'self' 'unsafe-inline'; connect-src 'self'; img-src 'self' data:; style-src 'self' 'unsafe-inline'; frame-src 'self'; font-src 'self'; object-src 'none'";
+
+        if (typeof state !== "string") {
+            return {
+                status: 400,
+                content: await getCallbackContent(
+                    read,
+                    null,
+                    "",
+                    "Invalid state parameter"
+                ),
+                headers: {
+                    "Content-Security-Policy": contentSecurityPolicy,
+                },
+            };
+        }
+
+        let origin;
+        try {
+            origin = decodeURIComponent(state);
+        } catch (e) {
+            return {
+                status: 400,
+                content: await getCallbackContent(
+                    read,
+                    null,
+                    "",
+                    "Invalid state parameter"
+                ),
+                headers: {
+                    "Content-Security-Policy": contentSecurityPolicy,
+                },
+            };
+        }
+
         const readEnvironment = read.getEnvironmentReader().getSettings();
         const [
             customOAuthName,
             client_id,
             client_secret,
             redirect_uri,
-            origin,
             tokenUrl,
         ] = await Promise.all([
             readEnvironment.getValueById("custom-oauth-name"),
             readEnvironment.getValueById("client-id"),
             readEnvironment.getValueById("client-secret"),
             getCallbackUrl(this.app),
-            Promise.resolve(decodeURIComponent(state)),
             getTokenUrl(read),
         ]);
 
@@ -69,8 +103,7 @@ export class CallbackEndpoint extends ApiEndpoint {
                     response.data.error_description || "Unknown"
                 ),
                 headers: {
-                    "Content-Security-Policy":
-                        "default-src 'self'; script-src 'self' 'unsafe-inline'; connect-src 'self'; img-src 'self' data:; style-src 'self' 'unsafe-inline'; frame-src 'self'; font-src 'self'; object-src 'none'",
+                    "Content-Security-Policy": contentSecurityPolicy,
                 },
             };
         }
@@ -88,8 +121,7 @@ export class CallbackEndpoint extends ApiEndpoint {
                 false
             ),
             headers: {
-                "Content-Security-Policy":
-                    "default-src 'self'; script-src 'self' 'unsafe-inline'; connect-src 'self'; img-src 'self' data:; style-src 'self' 'unsafe-inline'; frame-src 'self'; font-src 'self'; object-src 'none'",
+                "Content-Security-Policy": contentSecurityPolicy,
             },
         };
     }


### PR DESCRIPTION
Fixes #1284

The OAuth callback endpoint crashes when receiving a malformed `state` query parameter because `decodeURIComponent` throws an unhandled `URIError`. This breaks the entire OAuth callback flow and login for affected users.

## Changes

- Add type validation for state parameter (must be string)
- Wrap `decodeURIComponent` in try/catch to catch `URIError`
- Return controlled 400 response with user-friendly error message instead of crashing endpoint
- Extract CSP header to constant to reduce duplication

The endpoint now gracefully handles both missing and malformed state values by returning a safe callback HTML response with appropriate error messaging.

## Testing

**Manual Testing:**
1. Trigger callback endpoint with malformed state: `/api/apps/public/{appId}/callback?code=valid_code&state=%E0%A4%A`
2. Verify endpoint returns 400 with error page instead of crashing
3. Verify valid state continues to work normally

**Regression Testing:**
- Full workspace build completed successfully (9 packages, 0 failures)
- Type checking passed for rc-app package