### PR TITLE
fix(react): resolve mongodb image pull error by upgrading to working tag

### DIFF
--- a/packages/react/docker-compose.yml
+++ b/packages/react/docker-compose.yml
@@ -18,7 +18,7 @@ services:
       - "0.0.0.0:3000:3000"
 
   mongodb:
-    image: docker.io/bitnami/mongodb:4.4
+    image: docker.io/bitnami/mongodb:latest
     restart: on-failure
     volumes:
       - mongodb_data:/bitnami/mongodb


### PR DESCRIPTION
### Summary of Changes
This PR resolves the `docker compose` startup failure caused by Broadcom/Bitnami's deletion of versioned community tags (e.g., `bitnami/mongodb:4.4`) from their public Docker Hub registry in late 2025. 

It upgrades the database layer in `packages/react/docker-compose.yml` to a working and pullable image setup.

Fixes : #1292 
---


### How to Verify / Test
1. Navigate to the react package directory:
```bash
cd packages/react
```
2. Purge old local volume configurations:
```bash
docker compose down -v
```
3. Launch the stack:
```bash
docker compose up -d
```
4. Verify both containers are running successfully:
```bash
docker compose ps
```

### PR Test Details
Note: The PR will be ready for live testing at https://rocketchat.github.io/EmbeddedChat/pulls/<pr_number> after approval. Contributors are requested to replace <pr_number> with the actual PR number.