### PR TITLE
# fix: unblock Dependabot Security Updates (Node 24 Compat + brace-expansion CVE)

### DIFF
--- a/package.json
+++ b/package.json
@@ -9,7 +9,7 @@
   ],
   "scripts": {
     "preinstall": "node scripts/node-check.js",
-    "postinstall": "yarn build",
+    "postinstall": "node -e \"if (!process.env.DEPENDABOT && !process.env.DEPENDABOT_HOME && !process.env.CI) require('child_process').execSync('yarn build', {stdio:'inherit'})\"",
     "build": "lerna run build",
     "lint": "lerna run lint",
     "build:storybook": "lerna run build-storybook",

--- a/packages/react-native/package.json
+++ b/packages/react-native/package.json
@@ -57,5 +57,8 @@
 	"version": "0.0.5",
 	"private": true,
 	"name": "@embeddedchat/react-native",
-	"main": "start-app.js"
+	"main": "start-app.js",
+	"resolutions": {
+		"brace-expansion": "1.1.13"
+	}
 }

--- a/scripts/node-check.js
+++ b/scripts/node-check.js
@@ -2,6 +2,9 @@ const fs = require('fs');
 const path = require('path');
 const semver = require('semver');
 
+// Skip version check in automated dependency update environments
+if (process.env.DEPENDABOT || process.env.DEPENDABOT_HOME) process.exit(0);
+
 const nvmrcPath = path.join(__dirname, '../.nvmrc');
 const expectedVersion = fs.readFileSync(nvmrcPath).toString().trim();
 const expectedMajor = semver.major(expectedVersion);


### PR DESCRIPTION
# fix: Unblock Dependabot Security Updates (Node 24 Compat + brace-expansion CVE)

## Acceptance Criteria fulfillment

- [x] `node-check.js` skips the Node.js version enforcement when running inside Dependabot's container (`DEPENDABOT_HOME` is set), preventing `YN0009` build failures
- [x] `postinstall` build step is skipped in Dependabot and CI environments so `corepack yarn up` can complete without triggering a full monorepo build
- [x] Dependabot security updates for `handlebars`, `vm2`, `path-to-regexp`, and `node-forge` are unblocked (previously failing because Dependabot runs Node.js v24 while `node-check.js` enforced Node 22)
- [x] `brace-expansion` CVE in `/packages/react-native` is addressed by pinning to `1.1.13` via yarn `resolutions`

## Video/Screenshots

_No UI changes — infrastructure/tooling fix only._

## PR Test Details

**Root cause**: Dependabot's updater container runs **Node.js v24.15.0**, but `scripts/node-check.js` enforced Node 22 (major version check), causing `exit code 1` → `YN0009: embeddedchat@workspace:. couldn't be built successfully` on every Dependabot security update attempt against the root workspace.

**Changes**:
| File | Change |
|---|---|
| `scripts/node-check.js` | Exit early (success) when `DEPENDABOT_HOME` env var is set |
| `package.json` | Skip `postinstall: yarn build` in Dependabot and CI environments |
| `packages/react-native/package.json` | Add `resolutions` to pin `brace-expansion` to `1.1.13` |

**Note**: The PR will be ready for live testing at https://rocketchat.github.io/EmbeddedChat/pulls/pr-1296 after approval. Contributors are requested to replace `<pr_number>` with the actual PR number.