### PR TITLE
fix: remove trailing space in tooltip text

### DIFF
--- a/packages/react/src/views/ChatInput/ChatInputFormattingToolbar.js
+++ b/packages/react/src/views/ChatInput/ChatInputFormattingToolbar.js
@@ -216,7 +216,7 @@ const ChatInputFormattingToolbar = ({
           </React.Fragment>
         ) : (
           <Tooltip
-            text={`${item.name} ${item.shortcut && `(${item.shortcut})`}`}
+           text={`${item.name}${item.shortcut ? ` (${item.shortcut})` : ""}`}
             position="top"
             key={`formatter-${item.name}`}
           >


### PR DESCRIPTION
[# Brief Title](fix: remove trailing space in tooltip text)

### Problem
Tooltip text for formatting options (`strike`, `code`, `multiline`) rendered with a trailing space when no shortcut was defined.  
Example: "strike " instead of "strike".

### Cause
Template literal included an unconditional space before the shortcut expression:
`${item.name} ${item.shortcut && `(${item.shortcut})`}`

### Solution
Made the space conditional along with the shortcut:
`${item.name}${item.shortcut ? ` (${item.shortcut})` : ""}`

### Result
- If shortcut exists → `strike (Ctrl+S)`
- If shortcut is empty → `strike` (no trailing space)

This ensures tooltips are clean and consistent.
