### PR TITLE
fix: resolve email mention trigger and paginate member list retrieval

### DIFF
--- a/packages/api/src/EmbeddedChatApi.ts
+++ b/packages/api/src/EmbeddedChatApi.ts
@@ -1092,20 +1092,44 @@ export default class EmbeddedChatApi {
     const roomType = isChannelPrivate ? "groups" : "channels";
     try {
       const { userId, authToken } = (await this.auth.getCurrentUser()) || {};
-      const response = await fetch(
-        `${this.host}/api/v1/${roomType}.members?roomId=${this.rid}`,
-        {
-          headers: {
-            "Content-Type": "application/json",
-            "X-Auth-Token": authToken,
-            "X-User-Id": userId,
-          },
-          method: "GET",
+      let allMembers: any[] = [];
+      let offset = 0;
+      const count = 100;
+      let hasMore = true;
+
+      while (hasMore) {
+        const response = await fetch(
+          `${this.host}/api/v1/${roomType}.members?roomId=${this.rid}&offset=${offset}&count=${count}`,
+          {
+            headers: {
+              "Content-Type": "application/json",
+              "X-Auth-Token": authToken,
+              "X-User-Id": userId,
+            },
+            method: "GET",
+          }
+        );
+        const data = await response.json();
+        if (data && data.success && Array.isArray(data.members)) {
+          allMembers = allMembers.concat(data.members);
+          offset += data.members.length;
+          if (offset >= data.total || data.members.length < count) {
+            hasMore = false;
+          }
+        } else {
+          hasMore = false;
         }
-      );
-      return await response.json();
+      }
+      return {
+        members: allMembers,
+        success: true,
+      };
     } catch (err) {
       console.error(err instanceof Error ? err.message : err);
+      return {
+        members: [],
+        success: false,
+      };
     }
   }
 

--- a/packages/react/src/hooks/useSearchMentionUser.js
+++ b/packages/react/src/hooks/useSearchMentionUser.js
@@ -41,18 +41,24 @@ const useSearchMentionUser = (
           const query = message
             .substring(message.lastIndexOf('@') + 1)
             .toLowerCase();
-          const filteredMentionMembers = members.filter(
-            (member) =>
-              member.name.toLowerCase().includes(query) ||
-              member.username.toLowerCase().includes(query)
-          );
 
-          setFilteredMembers(filteredMentionMembers);
+          if (query.includes('.')) {
+            setShowMembersList(false);
+            setMentionIndex(-1);
+          } else {
+            const filteredMentionMembers = members.filter(
+              (member) =>
+                member.name.toLowerCase().includes(query) ||
+                member.username.toLowerCase().includes(query)
+            );
 
-          const isValidUsername = filteredMentionMembers.length > 0;
+            setFilteredMembers(filteredMentionMembers);
 
-          setShowMembersList(isValidUsername);
-          setMentionIndex(isValidUsername ? 0 : -1);
+            const isValidUsername = filteredMentionMembers.length > 0;
+
+            setShowMembersList(isValidUsername);
+            setMentionIndex(isValidUsername ? 0 : -1);
+          }
         }
       }
     },

--- a/packages/react/src/views/RoomMembers/RoomMember.js
+++ b/packages/react/src/views/RoomMembers/RoomMember.js
@@ -16,6 +16,7 @@ import { css } from '@emotion/react';
 import RoomMemberItem from './RoomMemberItem';
 import RCContext, { useRCContext } from '../../context/RCInstance';
 import useInviteStore from '../../store/inviteStore';
+import useChannelStore from '../../store/channelStore';
 import InviteMembers from './InviteMembers';
 import { getRoomMemberStyles } from './RoomMembers.styles';
 import LoadingIndicator from '../MessageAggregators/common/LoadingIndicator';
@@ -30,6 +31,7 @@ const RoomMembers = ({ members }) => {
 
   const toggleInviteView = useInviteStore((state) => state.toggleInviteView);
   const showInvite = useInviteStore((state) => state.showInvite);
+  const channelInfo = useChannelStore((state) => state.channelInfo);
   const [isLoading, setIsLoading] = useState(true);
   const { variantOverrides } = useComponentOverrides('RoomMember');
   const viewType = variantOverrides.viewType || 'Sidebar';
@@ -163,7 +165,7 @@ const RoomMembers = ({ members }) => {
                 <Divider />
               </Box>
               <Box>
-                Showing {displayedMembers} of {displayedMembers}
+                Showing {displayedMembers} of {channelInfo.usersCount || displayedMembers}
               </Box>
               <Box css={styles.memberList}>
                 {filteredMembers.length > 0 ? (


### PR DESCRIPTION
Resolves both **Issue #1287** and **Issue #1286**.

### Changes Made

#### 1. Fix Issue #1287: Mention autocomplete triggers on email addresses
- Prevented the mention suggestions popup from triggering or remaining visible when the search query portion after `@` contains a dot (`.`).
- This filters out domain/email-like typing patterns (e.g. `admin@example.com`) dynamically and self-corrects if the dot is deleted.
- File modified: `packages/react/src/hooks/useSearchMentionUser.js`

#### 2. Fix Issue #1286: Member list silently truncated at 100
- Implemented client-side pagination in the API client (`getChannelMembers`) to fetch members in batches of 100 using `offset` and `count` parameters until all members are fetched.
- Updated the sidebar to display the actual count of members using the `channelInfo.usersCount` value from Zustand store (e.g., `Showing 100 of 350` instead of `Showing 100 of 100`).
- Files modified: `packages/api/src/EmbeddedChatApi.ts`, `packages/react/src/views/RoomMembers/RoomMember.js`