### PR TITLE
fix: url-encode api query params and fix tooltip trailing space

### DIFF
--- a/packages/api/src/EmbeddedChatApi.ts
+++ b/packages/api/src/EmbeddedChatApi.ts
@@ -489,7 +489,7 @@ export default class EmbeddedChatApi {
     try {
       const { userId, authToken } = (await this.auth.getCurrentUser()) || {};
       const response = await fetch(
-        `${this.host}/api/v1/rooms.info?roomId=${this.rid}`,
+        `${this.host}/api/v1/rooms.info?roomId=${encodeURIComponent(this.rid)}`,
         {
           headers: {
             "Content-Type": "application/json",
@@ -556,15 +556,15 @@ export default class EmbeddedChatApi {
     const roomType = isChannelPrivate ? "groups" : "channels";
     const endp = anonymousMode ? "anonymousread" : "messages";
     const query = options?.query
-      ? `&query=${JSON.stringify(options.query)}`
+      ? `&query=${encodeURIComponent(JSON.stringify(options.query))}`
       : "";
     const field = options?.field
-      ? `&field=${JSON.stringify(options.field)}`
+      ? `&field=${encodeURIComponent(JSON.stringify(options.field))}`
       : "";
     try {
       const { userId, authToken } = (await this.auth.getCurrentUser()) || {};
       const messages = await fetch(
-        `${this.host}/api/v1/${roomType}.${endp}?roomId=${this.rid}${query}${field}`,
+        `${this.host}/api/v1/${roomType}.${endp}?roomId=${encodeURIComponent(this.rid)}${query}${field}`,
         {
           headers: {
             "Content-Type": "application/json",
@@ -596,16 +596,16 @@ export default class EmbeddedChatApi {
     const roomType = isChannelPrivate ? "groups" : "channels";
     const endp = anonymousMode ? "anonymousread" : "messages";
     const query = options?.query
-      ? `&query=${JSON.stringify(options.query)}`
+      ? `&query=${encodeURIComponent(JSON.stringify(options.query))}`
       : "";
     const field = options?.field
-      ? `&field=${JSON.stringify(options.field)}`
+      ? `&field=${encodeURIComponent(JSON.stringify(options.field))}`
       : "";
     const offset = options?.offset ? options.offset : 0;
     try {
       const { userId, authToken } = (await this.auth.getCurrentUser()) || {};
       const messages = await fetch(
-        `${this.host}/api/v1/${roomType}.${endp}?roomId=${this.rid}${query}${field}&offset=${offset}`,
+        `${this.host}/api/v1/${roomType}.${endp}?roomId=${encodeURIComponent(this.rid)}${query}${field}&offset=${offset}`,
         {
           headers: {
             "Content-Type": "application/json",
@@ -625,7 +625,7 @@ export default class EmbeddedChatApi {
     try {
       const { userId, authToken } = (await this.auth.getCurrentUser()) || {};
       const messages = await fetch(
-        `${this.host}/api/v1/chat.getThreadMessages?tmid=${tmid}`,
+        `${this.host}/api/v1/chat.getThreadMessages?tmid=${encodeURIComponent(tmid)}`,
         {
           headers: {
             "Content-Type": "application/json",
@@ -646,7 +646,7 @@ export default class EmbeddedChatApi {
     try {
       const { userId, authToken } = (await this.auth.getCurrentUser()) || {};
       const roles = await fetch(
-        `${this.host}/api/v1/${roomType}.roles?roomId=${this.rid}`,
+        `${this.host}/api/v1/${roomType}.roles?roomId=${encodeURIComponent(this.rid)}`,
         {
           headers: {
             "Content-Type": "application/json",
@@ -666,7 +666,7 @@ export default class EmbeddedChatApi {
     try {
       const { userId, authToken } = (await this.auth.getCurrentUser()) || {};
       const roles = await fetch(
-        `${this.host}/api/v1/roles.getUsersInRole?role=${role}`,
+        `${this.host}/api/v1/roles.getUsersInRole?role=${encodeURIComponent(role)}`,
         {
           headers: {
             "Content-Type": "application/json",
@@ -785,8 +785,8 @@ export default class EmbeddedChatApi {
       const { userId, authToken } = (await this.auth.getCurrentUser()) || {};
       const url =
         typeGroup === ""
-          ? `${this.host}/api/v1/${roomType}.files?roomId=${this.rid}`
-          : `${this.host}/api/v1/${roomType}.files?roomId=${this.rid}&typeGroup=${typeGroup}`;
+          ? `${this.host}/api/v1/${roomType}.files?roomId=${encodeURIComponent(this.rid)}`
+          : `${this.host}/api/v1/${roomType}.files?roomId=${encodeURIComponent(this.rid)}&typeGroup=${encodeURIComponent(typeGroup)}`;
       const response = await fetch(url, {
         headers: {
           "Content-Type": "application/json",
@@ -805,7 +805,7 @@ export default class EmbeddedChatApi {
     try {
       const { userId, authToken } = (await this.auth.getCurrentUser()) || {};
       const response = await fetch(
-        `${this.host}/api/v1/rooms.images?roomId=${this.rid}`,
+        `${this.host}/api/v1/rooms.images?roomId=${encodeURIComponent(this.rid)}`,
         {
           headers: {
             "Content-Type": "application/json",
@@ -861,7 +861,7 @@ export default class EmbeddedChatApi {
     try {
       const { userId, authToken } = (await this.auth.getCurrentUser()) || {};
       const response = await fetch(
-        `${this.host}/api/v1/chat.getStarredMessages?roomId=${this.rid}`,
+        `${this.host}/api/v1/chat.getStarredMessages?roomId=${encodeURIComponent(this.rid)}`,
         {
           headers: {
             "Content-Type": "application/json",
@@ -881,7 +881,7 @@ export default class EmbeddedChatApi {
     try {
       const { userId, authToken } = (await this.auth.getCurrentUser()) || {};
       const response = await fetch(
-        `${this.host}/api/v1/chat.getPinnedMessages?roomId=${this.rid}`,
+        `${this.host}/api/v1/chat.getPinnedMessages?roomId=${encodeURIComponent(this.rid)}`,
         {
           headers: {
             "Content-Type": "application/json",
@@ -901,7 +901,7 @@ export default class EmbeddedChatApi {
     try {
       const { userId, authToken } = (await this.auth.getCurrentUser()) || {};
       const response = await fetch(
-        `${this.host}/api/v1/chat.getMentionedMessages?roomId=${this.rid}`,
+        `${this.host}/api/v1/chat.getMentionedMessages?roomId=${encodeURIComponent(this.rid)}`,
         {
           headers: {
             "Content-Type": "application/json",
@@ -1093,7 +1093,7 @@ export default class EmbeddedChatApi {
     try {
       const { userId, authToken } = (await this.auth.getCurrentUser()) || {};
       const response = await fetch(
-        `${this.host}/api/v1/${roomType}.members?roomId=${this.rid}`,
+        `${this.host}/api/v1/${roomType}.members?roomId=${encodeURIComponent(this.rid)}`,
         {
           headers: {
             "Content-Type": "application/json",
@@ -1113,7 +1113,7 @@ export default class EmbeddedChatApi {
     try {
       const { userId, authToken } = (await this.auth.getCurrentUser()) || {};
       const response = await fetch(
-        `${this.host}/api/v1/chat.search?roomId=${this.rid}&searchText=${text}`,
+        `${this.host}/api/v1/chat.search?roomId=${encodeURIComponent(this.rid)}&searchText=${encodeURIComponent(text)}`,
         {
           headers: {
             "Content-Type": "application/json",
@@ -1225,7 +1225,7 @@ export default class EmbeddedChatApi {
   async getUserStatus(reqUserId: string) {
     const { userId, authToken } = (await this.auth.getCurrentUser()) || {};
     const response = await fetch(
-      `${this.host}/api/v1/users.getStatus?userId=${reqUserId}`,
+      `${this.host}/api/v1/users.getStatus?userId=${encodeURIComponent(reqUserId)}`,
       {
         method: "GET",
         headers: {
@@ -1242,7 +1242,7 @@ export default class EmbeddedChatApi {
   async userInfo(reqUserId: string) {
     const { userId, authToken } = (await this.auth.getCurrentUser()) || {};
     const response = await fetch(
-      `${this.host}/api/v1/users.info?userId=${reqUserId}`,
+      `${this.host}/api/v1/users.info?userId=${encodeURIComponent(reqUserId)}`,
       {
         method: "GET",
         headers: {
@@ -1259,7 +1259,7 @@ export default class EmbeddedChatApi {
   async userData(username: string) {
     const { userId, authToken } = (await this.auth.getCurrentUser()) || {};
     const response = await fetch(
-      `${this.host}/api/v1/users.info?username=${username}`,
+      `${this.host}/api/v1/users.info?username=${encodeURIComponent(username)}`,
       {
         method: "GET",
         headers: {

--- a/packages/react/src/views/ChatInput/ChatInputFormattingToolbar.js
+++ b/packages/react/src/views/ChatInput/ChatInputFormattingToolbar.js
@@ -216,7 +216,7 @@ const ChatInputFormattingToolbar = ({
           </React.Fragment>
         ) : (
           <Tooltip
-            text={`${item.name} ${item.shortcut && `(${item.shortcut})`}`}
+            text={item.shortcut ? `${item.name} (${item.shortcut})` : item.name}
             position="top"
             key={`formatter-${item.name}`}
           >
@@ -296,9 +296,11 @@ const ChatInputFormattingToolbar = ({
           if (itemInFormatter) {
             return (
               <Tooltip
-                text={`${itemInFormatter.name} ${
-                  itemInFormatter.shortcut && `(${itemInFormatter.shortcut})`
-                }`}
+                text={
+                  itemInFormatter.shortcut
+                    ? `${itemInFormatter.name} (${itemInFormatter.shortcut})`
+                    : itemInFormatter.name
+                }
                 position="top"
                 key={`formatter-${itemInFormatter.name}`}
               >


### PR DESCRIPTION
Resolves **Issue #1280** (tooltip trailing space) and **Issue #1276** (URL special characters break search/API calls).

### Changes Made

#### 1. Fix Issue #1280: Trailing space in formatting toolbar tooltips when no shortcut defined
- Fixed tooltip text generation in `ChatInputFormattingToolbar.js` to conditionally render the shortcut suffix.
- **Before:** `text={\`${item.name} ${item.shortcut && \`(\${item.shortcut})\`}\`}` — appends a trailing space when `shortcut` is falsy.
- **After:** `text={item.shortcut ? \`\${item.name} (\${item.shortcut})\` : item.name}` — clean conditional rendering.
- File modified: `packages/react/src/views/ChatInput/ChatInputFormattingToolbar.js`

#### 2. Fix Issue #1276: Special characters (&, #, +) in search text break API requests
- Wrapped all dynamic query parameter values in `EmbeddedChatApi.ts` with `encodeURIComponent()` to ensure special characters are safely URL-encoded.
- This fixes the `chat.search` endpoint, room IDs, user IDs, thread IDs, role names, username lookups, and file/message filter parameters.
- File modified: `packages/api/src/EmbeddedChatApi.ts`

### Testing
- Tooltip: Buttons with no keyboard shortcut (e.g. Quote) no longer show a trailing space in their tooltip.
- Search: Queries containing `&`, `#`, `+`, or other reserved URL characters now correctly reach the server without corrupting the query string.