### PR TITLE
fix: reject OAuth promise on popup close and guard malformed state param

### DIFF
--- a/packages/auth/src/loginWithRocketChatOAuth.ts
+++ b/packages/auth/src/loginWithRocketChatOAuth.ts
@@ -42,32 +42,44 @@ const loginWithRocketChatOAuth = async (config: { api: Api }) => {
 width=800,height=600,left=-1000,top=-1000,rel=opener`;
   const popup = window.open(authorizeUrl, "Login", params);
 
-  return new Promise<any>((resolve) => {
+  return new Promise<any>((resolve, reject) => {
     if (popup) {
+      const cleanup = () => {
+        clearInterval(checkInterval);
+        window.removeEventListener("message", onMessage);
+      };
+
       const onMessage = async (e: MessageEvent) => {
         if (e.origin !== new URL(config.api.baseUrl).origin) {
           return;
         }
         if (e.data.type === "rc-oauth-callback") {
+          cleanup();
           const { accessToken, expiresIn, serviceName } = e.data.credentials;
-          const response = await config.api.post("/api/v1/login", {
-            accessToken,
-            expiresIn,
-            serviceName,
-          });
-          popup.close();
-          resolve(response.data);
+          try {
+            const response = await config.api.post("/api/v1/login", {
+              accessToken,
+              expiresIn,
+              serviceName,
+            });
+            popup.close();
+            resolve(response.data);
+          } catch (err) {
+            reject(err);
+          }
         }
       };
+
       window.addEventListener("message", onMessage);
+
       const checkInterval = setInterval(() => {
         if (popup.closed) {
-          clearInterval(checkInterval);
-          window.removeEventListener("message", onMessage);
+          cleanup();
+          reject(new Error("OAuth login cancelled: popup closed by user"));
         }
       }, 1000);
     } else {
-      throw new Error("Popup blocked");
+      reject(new Error("Popup blocked"));
     }
   });
 };

--- a/packages/rc-app/endpoints/CallbackEndpoint.ts
+++ b/packages/rc-app/endpoints/CallbackEndpoint.ts
@@ -41,7 +41,14 @@ export class CallbackEndpoint extends ApiEndpoint {
             readEnvironment.getValueById("client-id"),
             readEnvironment.getValueById("client-secret"),
             getCallbackUrl(this.app),
-            Promise.resolve(decodeURIComponent(state)),
+            Promise.resolve((() => {
+                try {
+                    return decodeURIComponent(state);
+                } catch (_e) {
+                    console.warn("[CallbackEndpoint] Malformed state parameter, using raw value:", state);
+                    return state;
+                }
+            })()),
             getTokenUrl(read),
         ]);
 


### PR DESCRIPTION
Fixes **Issue #1274** and **Issue #1284**.

### Changes

#### 1. Fix #1274: OAuth login promise hangs forever if popup closed
- `loginWithRocketChatOAuth.ts`: Added `reject` to the Promise constructor.
- When the popup is closed (detected by `setInterval`), the promise now **rejects** with `"OAuth login cancelled: popup closed by user"` instead of hanging forever.
- Also: extracted a `cleanup()` helper to avoid duplicating `clearInterval` + `removeEventListener`.
- Also: wrapped the `api.post` call in try/catch so network errors during token exchange also propagate as rejections.
- File: `packages/auth/src/loginWithRocketChatOAuth.ts`

#### 2. Fix #1284: OAuth callback crashes on malformed `state` due to unhandled `decodeURIComponent` error
- `CallbackEndpoint.ts`: Wrapped `decodeURIComponent(state)` in a try/catch IIFE.
- If `state` contains invalid percent-encoding (e.g. `%XY`), the fallback returns the raw `state` string and logs a warning instead of crashing the entire callback endpoint.
- File: `packages/rc-app/endpoints/CallbackEndpoint.ts`

### Testing
- Close OAuth popup mid-flow → promise rejects, UI can show error instead of hanging.
- Pass `?state=%XY` to callback → graceful fallback, no server crash.