### PR TITLE
fix: fetch admin, moderator, and owner roles for message badges

### DIFF
--- a/packages/api/src/EmbeddedChatApi.ts
+++ b/packages/api/src/EmbeddedChatApi.ts
@@ -684,11 +684,23 @@ export default class EmbeddedChatApi {
 
   async getUserRoles() {
     try {
-      const response = await this.getUsersInRole("admin");
-      if (response && response.success) {
-        return { result: response.users };
+      const roleNames = ["admin", "moderator", "owner"];
+      const results = await Promise.all(
+        roleNames.map((role) => this.getUsersInRole(role))
+      );
+      const seenIds = new Set<string>();
+      const allUsers: any[] = [];
+      for (const response of results) {
+        if (response && response.success && Array.isArray(response.users)) {
+          for (const user of response.users) {
+            if (!seenIds.has(user._id)) {
+              seenIds.add(user._id);
+              allUsers.push(user);
+            }
+          }
+        }
       }
-      return { result: [] };
+      return { result: allUsers };
     } catch (err) {
       console.error(err instanceof Error ? err.message : err);
       return { result: [] };


### PR DESCRIPTION
Fixes **Issue #1288**: `getUserRoles` only fetches admins — moderator and owner badges are never shown.

### Root Cause
`getUserRoles()` in `EmbeddedChatApi.ts` was hardcoded to only call `getUsersInRole("admin")`. As a result:
- Only the **Admin** badge was populated from workspace-level roles.
- **Moderator** and **Owner** workspace-level role badges never appeared on messages.

### Fix
- Fetch `admin`, `moderator`, and `owner` role groups in **parallel** using `Promise.all`.
- Deduplicate results by `user._id` (a user could have multiple roles).
- Return the merged list as before — no changes needed in the React layer.

### File Changed
- `packages/api/src/EmbeddedChatApi.ts`

### Testing
In a channel where a user has moderator or owner workspace role:
- **Before**: Only Admin badge shown. Moderator/Owner badges missing.
- **After**: All three role types (Admin, Moderator, Owner) show correct badges next to message author names.