### PR TITLE
refactor: Migrate from @rocket.chat/sdk to @rocket.chat/ddp-client

### DIFF
--- a/.yarn/patches/typia-npm-9.7.2-5c5d9c80b4.patch
+++ b/.yarn/patches/typia-npm-9.7.2-5c5d9c80b4.patch
@@ -1,0 +1,17 @@
+diff --git a/lib/index.mjs b/lib/index.mjs
+index 35c18fc129e349205d3db64bfb7b9c589c726d35..7fe10a375d6e6d4d46bb1c4a776fdc75f062c3d3 100644
+--- a/lib/index.mjs
++++ b/lib/index.mjs
+@@ -1,4 +1,4 @@
+-import * as module from './module.mjs';
++import * as _module from './module.mjs';
+ export { assert, assertEquals, assertGuard, assertGuardEquals, createAssert, createAssertEquals, createAssertGuard, createAssertGuardEquals, createEquals, createIs, createRandom, createValidate, createValidateEquals, equals, is, random, validate, validateEquals } from './module.mjs';
+ import * as functional from './functional.mjs';
+ export { functional };
+@@ -22,5 +22,5 @@ export { TypeGuardError } from './TypeGuardError.mjs';
+ 
+ 
+ 
+-export { module as default };
++export { _module as default };
+ //# sourceMappingURL=index.mjs.map

--- a/package.json
+++ b/package.json
@@ -31,6 +31,7 @@
   },
   "resolutions": {
     "react": "^19.0.0",
-    "react-dom": "^19.0.0"
+    "react-dom": "^19.0.0",
+    "typia": "patch:typia@npm%3A9.7.2#./.yarn/patches/typia-npm-9.7.2-5c5d9c80b4.patch"
   }
 }

--- a/packages/api/package.json
+++ b/packages/api/package.json
@@ -24,6 +24,7 @@
   },
   "dependencies": {
     "@embeddedchat/auth": "workspace:^",
-    "@rocket.chat/sdk": "^1.0.0-alpha.42"
+    "@rocket.chat/ddp-client": "1.0.9-rc.2",
+    "@rocket.chat/emitter": "^0.31.25"
   }
 }

--- a/packages/api/src/EmbeddedChatApi.ts
+++ b/packages/api/src/EmbeddedChatApi.ts
@@ -1,4 +1,4 @@
-import { Rocketchat } from "@rocket.chat/sdk";
+import { DDPSDK } from "@rocket.chat/ddp-client";
 import cloneArray from "./cloneArray";
 import { ROCKETCHAT_APP_ID } from "./utils/constants";
 import {
@@ -12,7 +12,7 @@ let typingHandlerLock = 0;
 export default class EmbeddedChatApi {
   host: string;
   rid: string;
-  rcClient: Rocketchat;
+  sdk: DDPSDK;
   onMessageCallbacks: ((message: any) => void)[];
   onMessageDeleteCallbacks: ((messageId: string) => void)[];
   onTypingStatusCallbacks: ((users: string[]) => void)[];
@@ -21,6 +21,7 @@ export default class EmbeddedChatApi {
   typingUsers: string[];
   auth: RocketChatAuth;
   private _connectPromise: Promise<void> | null = null;
+  private _activeSubscriptions: { stop: () => void }[] = [];
 
   constructor(
     host: string,
@@ -29,11 +30,9 @@ export default class EmbeddedChatApi {
   ) {
     this.host = host;
     this.rid = rid;
-    this.rcClient = new Rocketchat({
-      protocol: "ddp",
-      host: this.host,
-      useSsl: !/http:\/\//.test(host),
-      reopen: 20000,
+    this.sdk = DDPSDK.create(this.host, {
+      retryCount: 10,
+      retryTime: 2000,
     });
     this.onMessageCallbacks = [];
     this.onMessageDeleteCallbacks = [];
@@ -200,91 +199,105 @@ export default class EmbeddedChatApi {
     return this._connectPromise;
   }
 
+  private _normalizeMessage(data: any) {
+    if (!data) return null;
+    const message = JSON.parse(JSON.stringify(data));
+    if (message.ts?.$date) {
+      message.ts = message.ts.$date;
+    }
+    if (!message.ts) {
+      message.ts = new Date().toISOString();
+    }
+    return message;
+  }
+
   private async _doConnect() {
     try {
-      await this.close(); // before connection, all previous subscriptions should be cancelled
-      await this.rcClient.connect({});
+      this.close(); // before connection, all previous subscriptions should be cancelled
+      await this.sdk.connection.connect();
       const token = (await this.auth.getCurrentUser())?.authToken;
-      await this.rcClient.resume({ token });
-      await this.rcClient.subscribeRoom(this.rid);
-      await this.rcClient.onMessage((data: any) => {
-        if (!data) {
-          return;
+      if (token) {
+        await this.sdk.account.loginWithToken(token);
+      }
+
+      // Subscribe to room messages
+      const roomMsgSub = this.sdk.stream(
+        "room-messages",
+        [this.rid, false],
+        (data: any) => {
+          const message = this._normalizeMessage(data);
+          if (message) {
+            this.onMessageCallbacks.forEach((callback) => callback(message));
+          }
         }
-        const message = JSON.parse(JSON.stringify(data));
-        if (message.ts?.$date) {
-          message.ts = message.ts.$date;
-        }
-        if (!message.ts) {
-          message.ts = new Date().toISOString();
-        }
-        this.onMessageCallbacks.map((callback) => callback(message));
-      });
-      await this.rcClient.subscribe(
-        "stream-notify-room",
-        `${this.rid}/user-activity`
       );
-      await this.rcClient.onStreamData(
-        "stream-notify-room",
-        (ddpMessage: any) => {
-          const [roomId, event] = ddpMessage.fields.eventName.split("/");
+      this._activeSubscriptions.push(roomMsgSub);
 
-          if (roomId !== this.rid) {
-            return;
-          }
-
-          if (event === "user-activity") {
-            const typingUser = ddpMessage.fields.args[0];
-            const isTyping = ddpMessage.fields.args[1]?.includes("user-typing");
+      // Subscribe to room notifications (typing, delete)
+      const notifyRoomSub = this.sdk.stream(
+        "notify-room",
+        [`${this.rid}/user-activity`, false],
+        (...args: any[]) => {
+          const typingUser = args[0];
+          const activities = args[1];
+          if (Array.isArray(activities)) {
+            const isTyping = activities.includes("user-typing");
             this.handleTypingEvent({ typingUser, isTyping });
+          } else {
+            // Legacy "typing" event: args[1] is a boolean
+            this.handleTypingEvent({ typingUser, isTyping: !!activities });
           }
+        }
+      );
+      this._activeSubscriptions.push(notifyRoomSub);
 
-          if (event === "typing") {
-            const typingUser = ddpMessage.fields.args[0];
-            const isTyping = ddpMessage.fields.args[1];
-            this.handleTypingEvent({ typingUser, isTyping });
-          }
-          if (event === "deleteMessage") {
-            const messageId = ddpMessage.fields.args[0]?._id;
-            this.onMessageDeleteCallbacks.map((callback) =>
+      // Subscribe to room delete events
+      const deleteRoomSub = this.sdk.stream(
+        "notify-room",
+        [`${this.rid}/deleteMessage`, false],
+        (...args: any[]) => {
+          const messageId = args[0]?._id;
+          if (messageId) {
+            this.onMessageDeleteCallbacks.forEach((callback) =>
               callback(messageId)
             );
           }
         }
       );
-      await this.rcClient.subscribeNotifyUser();
-      await this.rcClient.onStreamData(
-        "stream-notify-user",
-        (ddpMessage: any) => {
-          const [, event] = ddpMessage.fields.eventName.split("/");
-          const args: any[] = ddpMessage.fields.args
-            ? Array.isArray(ddpMessage.fields.args)
-              ? ddpMessage.fields.args
-              : [ddpMessage.fields.args]
-            : [];
-          if (event === "message") {
-            const data = args[0];
+      this._activeSubscriptions.push(deleteRoomSub);
+
+      // Subscribe to user notifications (action triggers, UI interactions)
+      const userId = this.sdk.account.uid;
+      if (userId) {
+        const notifyUserMsgSub = this.sdk.stream(
+          "notify-user",
+          [`${userId}/message`, false],
+          (data: any) => {
             if (!data || data?.rid !== this.rid) {
               return;
             }
-            const message = JSON.parse(JSON.stringify(data));
-            if (message.ts?.$date) {
-              message.ts = message.ts.$date;
+            const message = this._normalizeMessage(data);
+            if (message) {
+              message.renderType = "blocks";
+              this.onMessageCallbacks.forEach((callback) => callback(message));
             }
-            if (!message.ts) {
-              message.ts = new Date().toISOString();
-            }
-            message.renderType = "blocks";
-            this.onMessageCallbacks.map((callback) => callback(message));
-          } else if (event === "uiInteraction") {
+          }
+        );
+        this._activeSubscriptions.push(notifyUserMsgSub);
+
+        const notifyUserUiSub = this.sdk.stream(
+          "notify-user",
+          [`${userId}/uiInteraction`, false],
+          (data: any) => {
             this.onUiInteractionCallbacks.forEach((callback) =>
-              callback(args[0])
+              callback(data)
             );
           }
-        }
-      );
+        );
+        this._activeSubscriptions.push(notifyUserUiSub);
+      }
     } catch (err) {
-      await this.close();
+      this.close();
     }
   }
 
@@ -530,9 +543,10 @@ export default class EmbeddedChatApi {
     }
   }
 
-  async close() {
-    await this.rcClient.unsubscribeAll();
-    await this.rcClient.disconnect();
+  close() {
+    this._activeSubscriptions.forEach((sub) => sub.stop());
+    this._activeSubscriptions = [];
+    this.sdk.connection.close();
   }
 
   /**
@@ -697,7 +711,7 @@ export default class EmbeddedChatApi {
 
   async sendTypingStatus(username: string, typing: boolean) {
     try {
-      await this.rcClient.methodCall(
+      await this.sdk.call(
         "stream-notify-room",
         `${this.rid}/user-activity`,
         username,

--- a/packages/api/src/EmbeddedChatApi.ts
+++ b/packages/api/src/EmbeddedChatApi.ts
@@ -458,10 +458,10 @@ export default class EmbeddedChatApi {
   async updateUserNameThroughSuggestion(userid: string) {
     try {
       const suggestedUsername = await this._restRequest(
-        "/api/v1/users.getUsernameSuggestion"
+        "/v1/users.getUsernameSuggestion"
       );
       if (suggestedUsername.success) {
-        return await this._restRequest("/api/v1/users.update", "POST", {
+        return await this._restRequest("/v1/users.update", "POST", {
           userId: userid,
           data: { username: suggestedUsername.result },
         });
@@ -477,7 +477,7 @@ export default class EmbeddedChatApi {
 
     if (usernameRegExp.test(newUserName)) {
       try {
-        const result = await this._restRequest("/api/v1/users.update", "POST", {
+        const result = await this._restRequest("/v1/users.update", "POST", {
           userId: userid,
           data: { username: newUserName },
         });
@@ -498,7 +498,7 @@ export default class EmbeddedChatApi {
 
   async channelInfo() {
     try {
-      return await this._restRequest(`/api/v1/rooms.info?roomId=${this.rid}`);
+      return await this._restRequest(`/v1/rooms.info?roomId=${this.rid}`);
     } catch (err) {
       console.error(err instanceof Error ? err.message : err);
     }
@@ -514,7 +514,7 @@ export default class EmbeddedChatApi {
 
   async permissionInfo() {
     try {
-      return await this._restRequest("/api/v1/permissions.listAll");
+      return await this._restRequest("/v1/permissions.listAll");
     } catch (err) {
       console.error(err instanceof Error ? err.message : err);
     }
@@ -554,7 +554,7 @@ export default class EmbeddedChatApi {
       : "";
     try {
       return await this._restRequest(
-        `/api/v1/${roomType}.${endp}?roomId=${this.rid}${query}${field}`
+        `/v1/${roomType}.${endp}?roomId=${this.rid}${query}${field}`
       );
     } catch (err) {
       console.log(err);
@@ -585,7 +585,7 @@ export default class EmbeddedChatApi {
     const offset = options?.offset ? options.offset : 0;
     try {
       return await this._restRequest(
-        `/api/v1/${roomType}.${endp}?roomId=${this.rid}${query}${field}&offset=${offset}`
+        `/v1/${roomType}.${endp}?roomId=${this.rid}${query}${field}&offset=${offset}`
       );
     } catch (err) {
       console.log(err);
@@ -595,7 +595,7 @@ export default class EmbeddedChatApi {
   async getThreadMessages(tmid: string, isChannelPrivate = false) {
     try {
       return await this._restRequest(
-        `/api/v1/chat.getThreadMessages?tmid=${tmid}`
+        `/v1/chat.getThreadMessages?tmid=${tmid}`
       );
     } catch (err) {
       console.log(err);
@@ -606,7 +606,7 @@ export default class EmbeddedChatApi {
     const roomType = isChannelPrivate ? "groups" : "channels";
     try {
       return await this._restRequest(
-        `/api/v1/${roomType}.roles?roomId=${this.rid}`
+        `/v1/${roomType}.roles?roomId=${this.rid}`
       );
     } catch (err) {
       console.log(err);
@@ -616,7 +616,7 @@ export default class EmbeddedChatApi {
   async getUsersInRole(role: string) {
     try {
       return await this._restRequest(
-        `/api/v1/roles.getUsersInRole?role=${role}`
+        `/v1/roles.getUsersInRole?role=${role}`
       );
     } catch (err) {
       console.log(err);
@@ -662,7 +662,7 @@ export default class EmbeddedChatApi {
       messageObj.tmid = threadId;
     }
     try {
-      return await this._restRequest("/api/v1/chat.sendMessage", "POST", {
+      return await this._restRequest("/v1/chat.sendMessage", "POST", {
         message: messageObj,
       });
     } catch (err) {
@@ -672,7 +672,7 @@ export default class EmbeddedChatApi {
 
   async deleteMessage(msgId: string) {
     try {
-      return await this._restRequest("/api/v1/chat.delete", "POST", {
+      return await this._restRequest("/v1/chat.delete", "POST", {
         roomId: this.rid,
         msgId,
       });
@@ -683,7 +683,7 @@ export default class EmbeddedChatApi {
 
   async updateMessage(msgId: string, text: string) {
     try {
-      return await this._restRequest("/api/v1/chat.update", "POST", {
+      return await this._restRequest("/v1/chat.update", "POST", {
         roomId: this.rid,
         msgId,
         text,
@@ -698,8 +698,8 @@ export default class EmbeddedChatApi {
     try {
       const endpoint =
         typeGroup === ""
-          ? `/api/v1/${roomType}.files?roomId=${this.rid}`
-          : `/api/v1/${roomType}.files?roomId=${this.rid}&typeGroup=${typeGroup}`;
+          ? `/v1/${roomType}.files?roomId=${this.rid}`
+          : `/v1/${roomType}.files?roomId=${this.rid}&typeGroup=${typeGroup}`;
       return await this._restRequest(endpoint);
     } catch (err) {
       console.error(err instanceof Error ? err.message : err);
@@ -709,7 +709,7 @@ export default class EmbeddedChatApi {
   async getAllImages() {
     try {
       return await this._restRequest(
-        `/api/v1/rooms.images?roomId=${this.rid}`
+        `/v1/rooms.images?roomId=${this.rid}`
       );
     } catch (err) {
       console.error(err instanceof Error ? err.message : err);
@@ -718,7 +718,7 @@ export default class EmbeddedChatApi {
 
   async starMessage(mid: string) {
     try {
-      return await this._restRequest("/api/v1/chat.starMessage", "POST", {
+      return await this._restRequest("/v1/chat.starMessage", "POST", {
         messageId: mid,
       });
     } catch (err) {
@@ -728,7 +728,7 @@ export default class EmbeddedChatApi {
 
   async unstarMessage(mid: string) {
     try {
-      return await this._restRequest("/api/v1/chat.unStarMessage", "POST", {
+      return await this._restRequest("/v1/chat.unStarMessage", "POST", {
         messageId: mid,
       });
     } catch (err) {
@@ -739,7 +739,7 @@ export default class EmbeddedChatApi {
   async getStarredMessages() {
     try {
       return await this._restRequest(
-        `/api/v1/chat.getStarredMessages?roomId=${this.rid}`
+        `/v1/chat.getStarredMessages?roomId=${this.rid}`
       );
     } catch (err) {
       console.error(err instanceof Error ? err.message : err);
@@ -749,7 +749,7 @@ export default class EmbeddedChatApi {
   async getPinnedMessages() {
     try {
       return await this._restRequest(
-        `/api/v1/chat.getPinnedMessages?roomId=${this.rid}`
+        `/v1/chat.getPinnedMessages?roomId=${this.rid}`
       );
     } catch (err) {
       console.error(err instanceof Error ? err.message : err);
@@ -759,7 +759,7 @@ export default class EmbeddedChatApi {
   async getMentionedMessages() {
     try {
       return await this._restRequest(
-        `/api/v1/chat.getMentionedMessages?roomId=${this.rid}`
+        `/v1/chat.getMentionedMessages?roomId=${this.rid}`
       );
     } catch (err) {
       console.error(err instanceof Error ? err.message : err);
@@ -768,7 +768,7 @@ export default class EmbeddedChatApi {
 
   async pinMessage(mid: string) {
     try {
-      return await this._restRequest("/api/v1/chat.pinMessage", "POST", {
+      return await this._restRequest("/v1/chat.pinMessage", "POST", {
         messageId: mid,
       });
     } catch (err) {
@@ -778,7 +778,7 @@ export default class EmbeddedChatApi {
 
   async unpinMessage(mid: string) {
     try {
-      return await this._restRequest("/api/v1/chat.unPinMessage", "POST", {
+      return await this._restRequest("/v1/chat.unPinMessage", "POST", {
         messageId: mid,
       });
     } catch (err) {
@@ -788,7 +788,7 @@ export default class EmbeddedChatApi {
 
   async reactToMessage(emoji: string, messageId: string, shouldReact: string) {
     try {
-      return await this._restRequest("/api/v1/chat.react", "POST", {
+      return await this._restRequest("/v1/chat.react", "POST", {
         messageId,
         emoji,
         shouldReact,
@@ -800,7 +800,7 @@ export default class EmbeddedChatApi {
 
   async reportMessage(messageId: string, description: string) {
     try {
-      return await this._restRequest("/api/v1/chat.reportMessage", "POST", {
+      return await this._restRequest("/v1/chat.reportMessage", "POST", {
         messageId,
         description,
       });
@@ -811,7 +811,7 @@ export default class EmbeddedChatApi {
 
   async findOrCreateInvite() {
     try {
-      return await this._restRequest("/api/v1/findOrCreateInvite", "POST", {
+      return await this._restRequest("/v1/findOrCreateInvite", "POST", {
         rid: this.rid,
         days: 1,
         maxUses: 10,
@@ -838,7 +838,7 @@ export default class EmbeddedChatApi {
       form.append("file", file, fileName);
 
       const uploadResult = await this._restUpload(
-        `/api/v1/rooms.media/${this.rid}`,
+        `/v1/rooms.media/${this.rid}`,
         form
       );
 
@@ -848,7 +848,7 @@ export default class EmbeddedChatApi {
       }
 
       return await this._restRequest(
-        `/api/v1/rooms.mediaConfirm/${this.rid}/${uploadResult.file._id}`,
+        `/v1/rooms.mediaConfirm/${this.rid}/${uploadResult.file._id}`,
         "POST",
         threadId
           ? { msg: "", description: fileDescription || "", tmid: threadId }
@@ -861,7 +861,7 @@ export default class EmbeddedChatApi {
 
   async me() {
     try {
-      return await this._restRequest("/api/v1/me");
+      return await this._restRequest("/v1/me");
     } catch (err) {
       console.error(err instanceof Error ? err.message : err);
     }
@@ -871,7 +871,7 @@ export default class EmbeddedChatApi {
     const roomType = isChannelPrivate ? "groups" : "channels";
     try {
       return await this._restRequest(
-        `/api/v1/${roomType}.members?roomId=${this.rid}`
+        `/v1/${roomType}.members?roomId=${this.rid}`
       );
     } catch (err) {
       console.error(err instanceof Error ? err.message : err);
@@ -881,7 +881,7 @@ export default class EmbeddedChatApi {
   async getSearchMessages(text: string) {
     try {
       return await this._restRequest(
-        `/api/v1/chat.search?roomId=${this.rid}&searchText=${text}`
+        `/v1/chat.search?roomId=${this.rid}&searchText=${text}`
       );
     } catch (err) {
       console.error(err instanceof Error ? err.message : err);
@@ -891,7 +891,7 @@ export default class EmbeddedChatApi {
   async getMessageLimit() {
     try {
       return await this._restRequest(
-        "/api/v1/settings/Message_MaxAllowedSize"
+        "/v1/settings/Message_MaxAllowedSize"
       );
     } catch (err) {
       console.error(err instanceof Error ? err.message : err);
@@ -902,7 +902,7 @@ export default class EmbeddedChatApi {
     try {
       const triggerId = Math.random().toString(32).slice(2, 16);
       const interaction = await this._restRequest(
-        `/api/apps/ui.interaction/${appId}`,
+        `/apps/ui.interaction/${appId}`,
         "POST",
         { triggerId, ...userInteraction }
       );
@@ -914,7 +914,7 @@ export default class EmbeddedChatApi {
   }
 
   async getCommandsList() {
-    return await this._restRequest("/api/v1/commands.list");
+    return await this._restRequest("/v1/commands.list");
   }
 
   async execCommand({
@@ -926,7 +926,7 @@ export default class EmbeddedChatApi {
     params: string;
     tmid?: string;
   }) {
-    return await this._restRequest("/api/v1/commands.run", "POST", {
+    return await this._restRequest("/v1/commands.run", "POST", {
       command,
       params,
       tmid,
@@ -937,19 +937,19 @@ export default class EmbeddedChatApi {
 
   async getUserStatus(reqUserId: string) {
     return await this._restRequest(
-      `/api/v1/users.getStatus?userId=${reqUserId}`
+      `/v1/users.getStatus?userId=${reqUserId}`
     );
   }
 
   async userInfo(reqUserId: string) {
     return await this._restRequest(
-      `/api/v1/users.info?userId=${reqUserId}`
+      `/v1/users.info?userId=${reqUserId}`
     );
   }
 
   async userData(username: string) {
     return await this._restRequest(
-      `/api/v1/users.info?username=${username}`
+      `/v1/users.info?username=${username}`
     );
   }
 }

--- a/packages/api/src/EmbeddedChatApi.ts
+++ b/packages/api/src/EmbeddedChatApi.ts
@@ -22,6 +22,7 @@ export default class EmbeddedChatApi {
   auth: RocketChatAuth;
   private _connectPromise: Promise<void> | null = null;
   private _activeSubscriptions: { stop: () => void }[] = [];
+  private _authListener: ((user: any) => void) | null = null;
 
   constructor(
     host: string,
@@ -46,12 +47,12 @@ export default class EmbeddedChatApi {
       getToken,
       saveToken,
     });
+    this._registerAuthListener();
   }
 
-  private async _syncRestCredentials() {
-    const user = (await this.auth.getCurrentUser()) || {};
-    const userId = user.userId || user.data?.userId;
-    const authToken = user.authToken || user.data?.authToken;
+  private _applyCredentials(user: any) {
+    const userId = user?.userId || user?.data?.userId;
+    const authToken = user?.authToken || user?.data?.authToken;
     if (userId && authToken) {
       this.sdk.rest.setCredentials({
         "X-User-Id": userId,
@@ -60,12 +61,20 @@ export default class EmbeddedChatApi {
     }
   }
 
+  private _registerAuthListener() {
+    this._authListener = (user: any) => {
+      if (user) {
+        this._applyCredentials(user);
+      }
+    };
+    this.auth.onAuthChange(this._authListener);
+  }
+
   private async _restRequest(
     endpoint: string,
     method: "GET" | "POST" | "PUT" | "DELETE" = "GET",
     body?: any
   ) {
-    await this._syncRestCredentials();
     const options: RequestInit = {};
     if (body !== undefined) {
       options.headers = { "Content-Type": "application/json" };
@@ -76,7 +85,6 @@ export default class EmbeddedChatApi {
   }
 
   private async _restUpload(endpoint: string, formData: FormData) {
-    await this._syncRestCredentials();
     const response = await this.sdk.rest.send(endpoint, "POST", {
       body: formData,
     });
@@ -84,7 +92,12 @@ export default class EmbeddedChatApi {
   }
 
   setAuth(auth: RocketChatAuth) {
+    // Remove listener from the old auth instance before swapping.
+    if (this._authListener) {
+      this.auth.removeAuthListener(this._authListener);
+    }
     this.auth = auth;
+    this._registerAuthListener();
   }
 
   getAuth() {
@@ -253,12 +266,6 @@ export default class EmbeddedChatApi {
       this.close(); // before connection, all previous subscriptions should be cancelled
       await this.sdk.connection.connect();
 
-      // Sync REST credentials first so HTTP headers are ready before any request fires
-      await this._syncRestCredentials();
-
-      // Extract token from either flat or nested currentUser shape:
-      // - auto-login (resume token): currentUser = { userId, authToken, me }
-      // - password login: currentUser = { status, data: { userId, authToken, me } }
       const currentUser = (await this.auth.getCurrentUser()) as any;
       const token = currentUser?.authToken || currentUser?.data?.authToken;
       if (token) {
@@ -472,8 +479,7 @@ export default class EmbeddedChatApi {
         "/v1/users.getUsernameSuggestion"
       );
       if (suggestedUsername.success) {
-        await this._syncRestCredentials();
-        return await this.sdk.rest.post("/v1/users.update", {
+        return await this._restRequest("/v1/users.update", "POST", {
           userId: userid,
           data: { username: suggestedUsername.result },
         });
@@ -490,12 +496,10 @@ export default class EmbeddedChatApi {
 
     if (usernameRegExp.test(newUserName)) {
       try {
-        await this._syncRestCredentials();
-        const result = await this.sdk.rest.post("/v1/users.update", {
+        return await this._restRequest("/v1/users.update", "POST", {
           userId: userid,
           data: { username: newUserName },
         });
-        return result;
       } catch (err: any) {
         if (err?.errorType === "error-could-not-save-identity") {
           return await this.updateUserNameThroughSuggestion(userid);
@@ -509,8 +513,7 @@ export default class EmbeddedChatApi {
 
   async channelInfo(): Promise<any> {
     try {
-      await this._syncRestCredentials();
-      return await this.sdk.rest.get("/v1/rooms.info", { roomId: this.rid });
+      return await this._restRequest(`/v1/rooms.info?roomId=${this.rid}`);
     } catch (err: any) {
       console.error(err instanceof Error ? err.message : err);
       return err;
@@ -614,8 +617,7 @@ export default class EmbeddedChatApi {
     isChannelPrivate = false
   ): Promise<any> {
     try {
-      await this._syncRestCredentials();
-      return await this.sdk.rest.get("/v1/chat.getThreadMessages", { tmid });
+      return await this._restRequest(`/v1/chat.getThreadMessages?tmid=${tmid}`);
     } catch (err: any) {
       console.error(err instanceof Error ? err.message : String(err));
       return err;
@@ -682,8 +684,7 @@ export default class EmbeddedChatApi {
       messageObj.tmid = threadId;
     }
     try {
-      await this._syncRestCredentials();
-      return await this.sdk.rest.post("/v1/chat.sendMessage", {
+      return await this._restRequest("/v1/chat.sendMessage", "POST", {
         message: messageObj,
       });
     } catch (err: any) {
@@ -694,8 +695,7 @@ export default class EmbeddedChatApi {
 
   async deleteMessage(msgId: string): Promise<any> {
     try {
-      await this._syncRestCredentials();
-      return await this.sdk.rest.post("/v1/chat.delete", {
+      return await this._restRequest("/v1/chat.delete", "POST", {
         roomId: this.rid,
         msgId,
       });
@@ -707,8 +707,7 @@ export default class EmbeddedChatApi {
 
   async updateMessage(msgId: string, text: string): Promise<any> {
     try {
-      await this._syncRestCredentials();
-      return await this.sdk.rest.post("/v1/chat.update", {
+      return await this._restRequest("/v1/chat.update", "POST", {
         roomId: this.rid,
         msgId,
         text,
@@ -735,8 +734,7 @@ export default class EmbeddedChatApi {
 
   async getAllImages(): Promise<any> {
     try {
-      await this._syncRestCredentials();
-      return await this.sdk.rest.get("/v1/rooms.images", { roomId: this.rid });
+      return await this._restRequest(`/v1/rooms.images?roomId=${this.rid}`);
     } catch (err: any) {
       console.error(err instanceof Error ? err.message : err);
       return err;
@@ -767,10 +765,9 @@ export default class EmbeddedChatApi {
 
   async getStarredMessages(): Promise<any> {
     try {
-      await this._syncRestCredentials();
-      return await this.sdk.rest.get("/v1/chat.getStarredMessages", {
-        roomId: this.rid,
-      });
+      return await this._restRequest(
+        `/v1/chat.getStarredMessages?roomId=${this.rid}`
+      );
     } catch (err: any) {
       console.error(err instanceof Error ? err.message : err);
       return err;
@@ -779,10 +776,9 @@ export default class EmbeddedChatApi {
 
   async getPinnedMessages(): Promise<any> {
     try {
-      await this._syncRestCredentials();
-      return await this.sdk.rest.get("/v1/chat.getPinnedMessages", {
-        roomId: this.rid,
-      });
+      return await this._restRequest(
+        `/v1/chat.getPinnedMessages?roomId=${this.rid}`
+      );
     } catch (err: any) {
       console.error(err instanceof Error ? err.message : err);
       return err;
@@ -791,10 +787,9 @@ export default class EmbeddedChatApi {
 
   async getMentionedMessages(): Promise<any> {
     try {
-      await this._syncRestCredentials();
-      return await this.sdk.rest.get("/v1/chat.getMentionedMessages", {
-        roomId: this.rid,
-      });
+      return await this._restRequest(
+        `/v1/chat.getMentionedMessages?roomId=${this.rid}`
+      );
     } catch (err: any) {
       console.error(err instanceof Error ? err.message : err);
       return err;
@@ -828,8 +823,7 @@ export default class EmbeddedChatApi {
     shouldReact: boolean | string
   ): Promise<any> {
     try {
-      await this._syncRestCredentials();
-      return await this.sdk.rest.post("/v1/chat.react", {
+      return await this._restRequest("/v1/chat.react", "POST", {
         messageId,
         emoji,
         shouldReact:
@@ -845,8 +839,7 @@ export default class EmbeddedChatApi {
 
   async reportMessage(messageId: string, description: string): Promise<any> {
     try {
-      await this._syncRestCredentials();
-      return await this.sdk.rest.post("/v1/chat.reportMessage", {
+      return await this._restRequest("/v1/chat.reportMessage", "POST", {
         messageId,
         description,
       });
@@ -858,8 +851,7 @@ export default class EmbeddedChatApi {
 
   async findOrCreateInvite(): Promise<any> {
     try {
-      await this._syncRestCredentials();
-      return await this.sdk.rest.post("/v1/findOrCreateInvite", {
+      return await this._restRequest("/v1/findOrCreateInvite", "POST", {
         rid: this.rid,
         days: 1,
         maxUses: 10,
@@ -910,8 +902,7 @@ export default class EmbeddedChatApi {
 
   async me(): Promise<any> {
     try {
-      await this._syncRestCredentials();
-      return await this.sdk.rest.get("/v1/me");
+      return await this._restRequest("/v1/me");
     } catch (err: any) {
       console.error(err instanceof Error ? err.message : err);
       return err;
@@ -932,11 +923,11 @@ export default class EmbeddedChatApi {
 
   async getSearchMessages(text: string): Promise<any> {
     try {
-      await this._syncRestCredentials();
-      return await this.sdk.rest.get("/v1/chat.search", {
-        roomId: this.rid,
-        searchText: text,
-      });
+      return await this._restRequest(
+        `/v1/chat.search?roomId=${this.rid}&searchText=${encodeURIComponent(
+          text
+        )}`
+      );
     } catch (err: any) {
       console.error(err instanceof Error ? err.message : err);
       return err;
@@ -980,8 +971,7 @@ export default class EmbeddedChatApi {
     params: string;
     tmid?: string;
   }) {
-    await this._syncRestCredentials();
-    return await this.sdk.rest.post("/v1/commands.run", {
+    return await this._restRequest("/v1/commands.run", "POST", {
       command,
       params,
       tmid,
@@ -995,16 +985,12 @@ export default class EmbeddedChatApi {
   }
 
   async userInfo(reqUserId: string): Promise<any> {
-    await this._syncRestCredentials();
-    return await this.sdk.rest.get("/v1/users.info", {
-      userId: reqUserId,
-    });
+    return await this._restRequest(`/v1/users.info?userId=${reqUserId}`);
   }
 
   async userData(username: string): Promise<any> {
-    await this._syncRestCredentials();
-    return await this.sdk.rest.get("/v1/users.info", {
-      username,
-    });
+    return await this._restRequest(
+      `/v1/users.info?username=${encodeURIComponent(username)}`
+    );
   }
 }

--- a/packages/api/src/EmbeddedChatApi.ts
+++ b/packages/api/src/EmbeddedChatApi.ts
@@ -49,7 +49,9 @@ export default class EmbeddedChatApi {
   }
 
   private async _syncRestCredentials() {
-    const { userId, authToken } = (await this.auth.getCurrentUser()) || {};
+    const user = (await this.auth.getCurrentUser()) || {};
+    const userId = user.userId || user.data?.userId;
+    const authToken = user.authToken || user.data?.authToken;
     if (userId && authToken) {
       this.sdk.rest.setCredentials({
         "X-User-Id": userId,
@@ -145,8 +147,9 @@ export default class EmbeddedChatApi {
       if (response.error === "totp-required") {
         return response;
       }
-    } catch (err) {
+    } catch (err: any) {
       console.error(err instanceof Error ? err.message : err);
+      return err;
     }
   }
 
@@ -212,8 +215,9 @@ export default class EmbeddedChatApi {
   async logout() {
     try {
       await this.auth.logout();
-    } catch (err) {
+    } catch (err: any) {
       console.error(err instanceof Error ? err.message : err);
+      return err;
     }
   }
 
@@ -248,7 +252,15 @@ export default class EmbeddedChatApi {
     try {
       this.close(); // before connection, all previous subscriptions should be cancelled
       await this.sdk.connection.connect();
-      const token = (await this.auth.getCurrentUser())?.authToken;
+
+      // Sync REST credentials first so HTTP headers are ready before any request fires
+      await this._syncRestCredentials();
+
+      // Extract token from either flat or nested currentUser shape:
+      // - auto-login (resume token): currentUser = { userId, authToken, me }
+      // - password login: currentUser = { status, data: { userId, authToken, me } }
+      const currentUser = (await this.auth.getCurrentUser()) as any;
+      const token = currentUser?.authToken || currentUser?.data?.authToken;
       if (token) {
         await this.sdk.account.loginWithToken(token);
       }
@@ -448,8 +460,9 @@ export default class EmbeddedChatApi {
         return null;
       }
       return await response.json();
-    } catch (err) {
+    } catch (err: any) {
       console.error(err instanceof Error ? err.message : err);
+      return err;
     }
   }
 
@@ -465,8 +478,9 @@ export default class EmbeddedChatApi {
           data: { username: suggestedUsername.result },
         });
       }
-    } catch (error) {
+    } catch (error: any) {
       console.error(error instanceof Error ? error.message : error);
+      return error;
     }
   }
 
@@ -497,24 +511,27 @@ export default class EmbeddedChatApi {
     try {
       await this._syncRestCredentials();
       return await this.sdk.rest.get("/v1/rooms.info", { roomId: this.rid });
-    } catch (err) {
+    } catch (err: any) {
       console.error(err instanceof Error ? err.message : err);
+      return err;
     }
   }
 
   async getRoomInfo(): Promise<any> {
     try {
       return await this.channelInfo();
-    } catch (err) {
+    } catch (err: any) {
       console.error(err instanceof Error ? err.message : err);
+      return err;
     }
   }
 
   async permissionInfo() {
     try {
       return await this._restRequest("/v1/permissions.listAll");
-    } catch (err) {
+    } catch (err: any) {
       console.error(err instanceof Error ? err.message : err);
+      return err;
     }
   }
 
@@ -554,8 +571,9 @@ export default class EmbeddedChatApi {
       return await this._restRequest(
         `/v1/${roomType}.${endp}?roomId=${this.rid}${query}${field}`
       );
-    } catch (err) {
-      console.log(err);
+    } catch (err: any) {
+      console.error(err instanceof Error ? err.message : err);
+      return err;
     }
   }
 
@@ -585,8 +603,9 @@ export default class EmbeddedChatApi {
       return await this._restRequest(
         `/v1/${roomType}.${endp}?roomId=${this.rid}${query}${field}&offset=${offset}`
       );
-    } catch (err) {
-      console.log(err);
+    } catch (err: any) {
+      console.error(err instanceof Error ? err.message : String(err));
+      return err;
     }
   }
 
@@ -597,8 +616,9 @@ export default class EmbeddedChatApi {
     try {
       await this._syncRestCredentials();
       return await this.sdk.rest.get("/v1/chat.getThreadMessages", { tmid });
-    } catch (err) {
-      console.log(err);
+    } catch (err: any) {
+      console.error(err instanceof Error ? err.message : String(err));
+      return err;
     }
   }
 
@@ -608,16 +628,18 @@ export default class EmbeddedChatApi {
       return await this._restRequest(
         `/v1/${roomType}.roles?roomId=${this.rid}`
       );
-    } catch (err) {
-      console.log(err);
+    } catch (err: any) {
+      console.error(err instanceof Error ? err.message : String(err));
+      return err;
     }
   }
 
   async getUsersInRole(role: string) {
     try {
       return await this._restRequest(`/v1/roles.getUsersInRole?role=${role}`);
-    } catch (err) {
-      console.log(err);
+    } catch (err: any) {
+      console.error(err instanceof Error ? err.message : String(err));
+      return err;
     }
   }
 
@@ -664,8 +686,9 @@ export default class EmbeddedChatApi {
       return await this.sdk.rest.post("/v1/chat.sendMessage", {
         message: messageObj,
       });
-    } catch (err) {
+    } catch (err: any) {
       console.error(err instanceof Error ? err.message : err);
+      return err;
     }
   }
 
@@ -676,8 +699,9 @@ export default class EmbeddedChatApi {
         roomId: this.rid,
         msgId,
       });
-    } catch (err) {
+    } catch (err: any) {
       console.error(err instanceof Error ? err.message : err);
+      return err;
     }
   }
 
@@ -689,8 +713,9 @@ export default class EmbeddedChatApi {
         msgId,
         text,
       });
-    } catch (err) {
+    } catch (err: any) {
       console.error(err instanceof Error ? err.message : err);
+      return err;
     }
   }
 
@@ -702,8 +727,9 @@ export default class EmbeddedChatApi {
           ? `/v1/${roomType}.files?roomId=${this.rid}`
           : `/v1/${roomType}.files?roomId=${this.rid}&typeGroup=${typeGroup}`;
       return await this._restRequest(endpoint);
-    } catch (err) {
+    } catch (err: any) {
       console.error(err instanceof Error ? err.message : err);
+      return err;
     }
   }
 
@@ -711,8 +737,9 @@ export default class EmbeddedChatApi {
     try {
       await this._syncRestCredentials();
       return await this.sdk.rest.get("/v1/rooms.images", { roomId: this.rid });
-    } catch (err) {
+    } catch (err: any) {
       console.error(err instanceof Error ? err.message : err);
+      return err;
     }
   }
 
@@ -721,8 +748,9 @@ export default class EmbeddedChatApi {
       return await this._restRequest("/v1/chat.starMessage", "POST", {
         messageId: mid,
       });
-    } catch (err) {
+    } catch (err: any) {
       console.error(err instanceof Error ? err.message : err);
+      return err;
     }
   }
 
@@ -731,8 +759,9 @@ export default class EmbeddedChatApi {
       return await this._restRequest("/v1/chat.unStarMessage", "POST", {
         messageId: mid,
       });
-    } catch (err) {
+    } catch (err: any) {
       console.error(err instanceof Error ? err.message : err);
+      return err;
     }
   }
 
@@ -742,8 +771,9 @@ export default class EmbeddedChatApi {
       return await this.sdk.rest.get("/v1/chat.getStarredMessages", {
         roomId: this.rid,
       });
-    } catch (err) {
+    } catch (err: any) {
       console.error(err instanceof Error ? err.message : err);
+      return err;
     }
   }
 
@@ -753,8 +783,9 @@ export default class EmbeddedChatApi {
       return await this.sdk.rest.get("/v1/chat.getPinnedMessages", {
         roomId: this.rid,
       });
-    } catch (err) {
+    } catch (err: any) {
       console.error(err instanceof Error ? err.message : err);
+      return err;
     }
   }
 
@@ -764,8 +795,9 @@ export default class EmbeddedChatApi {
       return await this.sdk.rest.get("/v1/chat.getMentionedMessages", {
         roomId: this.rid,
       });
-    } catch (err) {
+    } catch (err: any) {
       console.error(err instanceof Error ? err.message : err);
+      return err;
     }
   }
 
@@ -784,25 +816,30 @@ export default class EmbeddedChatApi {
       return await this._restRequest("/v1/chat.unPinMessage", "POST", {
         messageId: mid,
       });
-    } catch (err) {
+    } catch (err: any) {
       console.error(err instanceof Error ? err.message : err);
+      return err;
     }
   }
 
   async reactToMessage(
     emoji: string,
     messageId: string,
-    shouldReact: string
+    shouldReact: boolean | string
   ): Promise<any> {
     try {
       await this._syncRestCredentials();
       return await this.sdk.rest.post("/v1/chat.react", {
         messageId,
         emoji,
-        shouldReact: shouldReact === "true",
+        shouldReact:
+          typeof shouldReact === "string"
+            ? shouldReact === "true"
+            : shouldReact,
       });
-    } catch (err) {
+    } catch (err: any) {
       console.error(err instanceof Error ? err.message : err);
+      return err;
     }
   }
 
@@ -813,8 +850,9 @@ export default class EmbeddedChatApi {
         messageId,
         description,
       });
-    } catch (err) {
+    } catch (err: any) {
       console.error(err instanceof Error ? err.message : err);
+      return err;
     }
   }
 
@@ -826,8 +864,9 @@ export default class EmbeddedChatApi {
         days: 1,
         maxUses: 10,
       });
-    } catch (err) {
-      console.log(err);
+    } catch (err: any) {
+      console.error(err instanceof Error ? err.message : String(err));
+      return err;
     }
   }
 
@@ -873,8 +912,9 @@ export default class EmbeddedChatApi {
     try {
       await this._syncRestCredentials();
       return await this.sdk.rest.get("/v1/me");
-    } catch (err) {
+    } catch (err: any) {
       console.error(err instanceof Error ? err.message : err);
+      return err;
     }
   }
 
@@ -884,8 +924,9 @@ export default class EmbeddedChatApi {
       return await this._restRequest(
         `/v1/${roomType}.members?roomId=${this.rid}`
       );
-    } catch (err) {
+    } catch (err: any) {
       console.error(err instanceof Error ? err.message : err);
+      return err;
     }
   }
 
@@ -896,16 +937,18 @@ export default class EmbeddedChatApi {
         roomId: this.rid,
         searchText: text,
       });
-    } catch (err) {
+    } catch (err: any) {
       console.error(err instanceof Error ? err.message : err);
+      return err;
     }
   }
 
   async getMessageLimit() {
     try {
       return await this._restRequest("/v1/settings/Message_MaxAllowedSize");
-    } catch (err) {
+    } catch (err: any) {
       console.error(err instanceof Error ? err.message : err);
+      return err;
     }
   }
 

--- a/packages/api/src/EmbeddedChatApi.ts
+++ b/packages/api/src/EmbeddedChatApi.ts
@@ -322,9 +322,7 @@ export default class EmbeddedChatApi {
           "notify-user",
           [`${userId}/uiInteraction`, false],
           (data: any) => {
-            this.onUiInteractionCallbacks.forEach((callback) =>
-              callback(data)
-            );
+            this.onUiInteractionCallbacks.forEach((callback) => callback(data));
           }
         );
         this._activeSubscriptions.push(notifyUserUiSub);
@@ -461,7 +459,8 @@ export default class EmbeddedChatApi {
         "/v1/users.getUsernameSuggestion"
       );
       if (suggestedUsername.success) {
-        return await this._restRequest("/v1/users.update", "POST", {
+        await this._syncRestCredentials();
+        return await this.sdk.rest.post("/v1/users.update", {
           userId: userid,
           data: { username: suggestedUsername.result },
         });
@@ -477,18 +476,16 @@ export default class EmbeddedChatApi {
 
     if (usernameRegExp.test(newUserName)) {
       try {
-        const result = await this._restRequest("/v1/users.update", "POST", {
+        await this._syncRestCredentials();
+        const result = await this.sdk.rest.post("/v1/users.update", {
           userId: userid,
           data: { username: newUserName },
         });
-        if (
-          !result.success &&
-          result.errorType === "error-could-not-save-identity"
-        ) {
+        return result;
+      } catch (err: any) {
+        if (err?.errorType === "error-could-not-save-identity") {
           return await this.updateUserNameThroughSuggestion(userid);
         }
-        return result;
-      } catch (err) {
         console.error(err instanceof Error ? err.message : err);
       }
     } else {
@@ -496,15 +493,16 @@ export default class EmbeddedChatApi {
     }
   }
 
-  async channelInfo() {
+  async channelInfo(): Promise<any> {
     try {
-      return await this._restRequest(`/v1/rooms.info?roomId=${this.rid}`);
+      await this._syncRestCredentials();
+      return await this.sdk.rest.get("/v1/rooms.info", { roomId: this.rid });
     } catch (err) {
       console.error(err instanceof Error ? err.message : err);
     }
   }
 
-  async getRoomInfo() {
+  async getRoomInfo(): Promise<any> {
     try {
       return await this.channelInfo();
     } catch (err) {
@@ -592,11 +590,13 @@ export default class EmbeddedChatApi {
     }
   }
 
-  async getThreadMessages(tmid: string, isChannelPrivate = false) {
+  async getThreadMessages(
+    tmid: string,
+    isChannelPrivate = false
+  ): Promise<any> {
     try {
-      return await this._restRequest(
-        `/v1/chat.getThreadMessages?tmid=${tmid}`
-      );
+      await this._syncRestCredentials();
+      return await this.sdk.rest.get("/v1/chat.getThreadMessages", { tmid });
     } catch (err) {
       console.log(err);
     }
@@ -615,9 +615,7 @@ export default class EmbeddedChatApi {
 
   async getUsersInRole(role: string) {
     try {
-      return await this._restRequest(
-        `/v1/roles.getUsersInRole?role=${role}`
-      );
+      return await this._restRequest(`/v1/roles.getUsersInRole?role=${role}`);
     } catch (err) {
       console.log(err);
     }
@@ -653,7 +651,7 @@ export default class EmbeddedChatApi {
    * @param {*} message should be a string or an rc message object
    * Refer https://developer.rocket.chat/reference/api/schema-definition/message#message-object
    */
-  async sendMessage(message: any, threadId: string) {
+  async sendMessage(message: any, threadId: string): Promise<any> {
     const messageObj =
       typeof message === "string"
         ? { rid: this.rid, msg: message }
@@ -662,7 +660,8 @@ export default class EmbeddedChatApi {
       messageObj.tmid = threadId;
     }
     try {
-      return await this._restRequest("/v1/chat.sendMessage", "POST", {
+      await this._syncRestCredentials();
+      return await this.sdk.rest.post("/v1/chat.sendMessage", {
         message: messageObj,
       });
     } catch (err) {
@@ -670,9 +669,10 @@ export default class EmbeddedChatApi {
     }
   }
 
-  async deleteMessage(msgId: string) {
+  async deleteMessage(msgId: string): Promise<any> {
     try {
-      return await this._restRequest("/v1/chat.delete", "POST", {
+      await this._syncRestCredentials();
+      return await this.sdk.rest.post("/v1/chat.delete", {
         roomId: this.rid,
         msgId,
       });
@@ -681,9 +681,10 @@ export default class EmbeddedChatApi {
     }
   }
 
-  async updateMessage(msgId: string, text: string) {
+  async updateMessage(msgId: string, text: string): Promise<any> {
     try {
-      return await this._restRequest("/v1/chat.update", "POST", {
+      await this._syncRestCredentials();
+      return await this.sdk.rest.post("/v1/chat.update", {
         roomId: this.rid,
         msgId,
         text,
@@ -706,11 +707,10 @@ export default class EmbeddedChatApi {
     }
   }
 
-  async getAllImages() {
+  async getAllImages(): Promise<any> {
     try {
-      return await this._restRequest(
-        `/v1/rooms.images?roomId=${this.rid}`
-      );
+      await this._syncRestCredentials();
+      return await this.sdk.rest.get("/v1/rooms.images", { roomId: this.rid });
     } catch (err) {
       console.error(err instanceof Error ? err.message : err);
     }
@@ -736,31 +736,34 @@ export default class EmbeddedChatApi {
     }
   }
 
-  async getStarredMessages() {
+  async getStarredMessages(): Promise<any> {
     try {
-      return await this._restRequest(
-        `/v1/chat.getStarredMessages?roomId=${this.rid}`
-      );
+      await this._syncRestCredentials();
+      return await this.sdk.rest.get("/v1/chat.getStarredMessages", {
+        roomId: this.rid,
+      });
     } catch (err) {
       console.error(err instanceof Error ? err.message : err);
     }
   }
 
-  async getPinnedMessages() {
+  async getPinnedMessages(): Promise<any> {
     try {
-      return await this._restRequest(
-        `/v1/chat.getPinnedMessages?roomId=${this.rid}`
-      );
+      await this._syncRestCredentials();
+      return await this.sdk.rest.get("/v1/chat.getPinnedMessages", {
+        roomId: this.rid,
+      });
     } catch (err) {
       console.error(err instanceof Error ? err.message : err);
     }
   }
 
-  async getMentionedMessages() {
+  async getMentionedMessages(): Promise<any> {
     try {
-      return await this._restRequest(
-        `/v1/chat.getMentionedMessages?roomId=${this.rid}`
-      );
+      await this._syncRestCredentials();
+      return await this.sdk.rest.get("/v1/chat.getMentionedMessages", {
+        roomId: this.rid,
+      });
     } catch (err) {
       console.error(err instanceof Error ? err.message : err);
     }
@@ -786,21 +789,27 @@ export default class EmbeddedChatApi {
     }
   }
 
-  async reactToMessage(emoji: string, messageId: string, shouldReact: string) {
+  async reactToMessage(
+    emoji: string,
+    messageId: string,
+    shouldReact: string
+  ): Promise<any> {
     try {
-      return await this._restRequest("/v1/chat.react", "POST", {
+      await this._syncRestCredentials();
+      return await this.sdk.rest.post("/v1/chat.react", {
         messageId,
         emoji,
-        shouldReact,
+        shouldReact: shouldReact === "true",
       });
     } catch (err) {
       console.error(err instanceof Error ? err.message : err);
     }
   }
 
-  async reportMessage(messageId: string, description: string) {
+  async reportMessage(messageId: string, description: string): Promise<any> {
     try {
-      return await this._restRequest("/v1/chat.reportMessage", "POST", {
+      await this._syncRestCredentials();
+      return await this.sdk.rest.post("/v1/chat.reportMessage", {
         messageId,
         description,
       });
@@ -809,9 +818,10 @@ export default class EmbeddedChatApi {
     }
   }
 
-  async findOrCreateInvite() {
+  async findOrCreateInvite(): Promise<any> {
     try {
-      return await this._restRequest("/v1/findOrCreateInvite", "POST", {
+      await this._syncRestCredentials();
+      return await this.sdk.rest.post("/v1/findOrCreateInvite", {
         rid: this.rid,
         days: 1,
         maxUses: 10,
@@ -859,9 +869,10 @@ export default class EmbeddedChatApi {
     }
   }
 
-  async me() {
+  async me(): Promise<any> {
     try {
-      return await this._restRequest("/v1/me");
+      await this._syncRestCredentials();
+      return await this.sdk.rest.get("/v1/me");
     } catch (err) {
       console.error(err instanceof Error ? err.message : err);
     }
@@ -878,11 +889,13 @@ export default class EmbeddedChatApi {
     }
   }
 
-  async getSearchMessages(text: string) {
+  async getSearchMessages(text: string): Promise<any> {
     try {
-      return await this._restRequest(
-        `/v1/chat.search?roomId=${this.rid}&searchText=${text}`
-      );
+      await this._syncRestCredentials();
+      return await this.sdk.rest.get("/v1/chat.search", {
+        roomId: this.rid,
+        searchText: text,
+      });
     } catch (err) {
       console.error(err instanceof Error ? err.message : err);
     }
@@ -890,9 +903,7 @@ export default class EmbeddedChatApi {
 
   async getMessageLimit() {
     try {
-      return await this._restRequest(
-        "/v1/settings/Message_MaxAllowedSize"
-      );
+      return await this._restRequest("/v1/settings/Message_MaxAllowedSize");
     } catch (err) {
       console.error(err instanceof Error ? err.message : err);
     }
@@ -926,7 +937,8 @@ export default class EmbeddedChatApi {
     params: string;
     tmid?: string;
   }) {
-    return await this._restRequest("/v1/commands.run", "POST", {
+    await this._syncRestCredentials();
+    return await this.sdk.rest.post("/v1/commands.run", {
       command,
       params,
       tmid,
@@ -936,20 +948,20 @@ export default class EmbeddedChatApi {
   }
 
   async getUserStatus(reqUserId: string) {
-    return await this._restRequest(
-      `/v1/users.getStatus?userId=${reqUserId}`
-    );
+    return await this._restRequest(`/v1/users.getStatus?userId=${reqUserId}`);
   }
 
-  async userInfo(reqUserId: string) {
-    return await this._restRequest(
-      `/v1/users.info?userId=${reqUserId}`
-    );
+  async userInfo(reqUserId: string): Promise<any> {
+    await this._syncRestCredentials();
+    return await this.sdk.rest.get("/v1/users.info", {
+      userId: reqUserId,
+    });
   }
 
-  async userData(username: string) {
-    return await this._restRequest(
-      `/v1/users.info?username=${username}`
-    );
+  async userData(username: string): Promise<any> {
+    await this._syncRestCredentials();
+    return await this.sdk.rest.get("/v1/users.info", {
+      username,
+    });
   }
 }

--- a/packages/api/src/EmbeddedChatApi.ts
+++ b/packages/api/src/EmbeddedChatApi.ts
@@ -48,6 +48,39 @@ export default class EmbeddedChatApi {
     });
   }
 
+  private async _syncRestCredentials() {
+    const { userId, authToken } = (await this.auth.getCurrentUser()) || {};
+    if (userId && authToken) {
+      this.sdk.rest.setCredentials({
+        "X-User-Id": userId,
+        "X-Auth-Token": authToken,
+      });
+    }
+  }
+
+  private async _restRequest(
+    endpoint: string,
+    method: "GET" | "POST" | "PUT" | "DELETE" = "GET",
+    body?: any
+  ) {
+    await this._syncRestCredentials();
+    const options: RequestInit = {};
+    if (body !== undefined) {
+      options.headers = { "Content-Type": "application/json" };
+      options.body = typeof body === "string" ? body : JSON.stringify(body);
+    }
+    const response = await this.sdk.rest.send(endpoint, method, options);
+    return response.json();
+  }
+
+  private async _restUpload(endpoint: string, formData: FormData) {
+    await this._syncRestCredentials();
+    const response = await this.sdk.rest.send(endpoint, "POST", {
+      body: formData,
+    });
+    return response.json();
+  }
+
   setAuth(auth: RocketChatAuth) {
     this.auth = auth;
   }
@@ -424,36 +457,14 @@ export default class EmbeddedChatApi {
 
   async updateUserNameThroughSuggestion(userid: string) {
     try {
-      const { userId, authToken } = (await this.auth.getCurrentUser()) || {};
-      const response = await fetch(
-        `${this.host}/api/v1/users.getUsernameSuggestion`,
-        {
-          headers: {
-            "Content-Type": "application/json",
-            "X-Auth-Token": authToken,
-            "X-User-Id": userId,
-          },
-          method: "GET",
-        }
+      const suggestedUsername = await this._restRequest(
+        "/api/v1/users.getUsernameSuggestion"
       );
-
-      const suggestedUsername = await response.json();
-
       if (suggestedUsername.success) {
-        const response2 = await fetch(`${this.host}/api/v1/users.update`, {
-          body: JSON.stringify({
-            userId: userid,
-            data: { username: suggestedUsername.result },
-          }),
-          headers: {
-            "Content-Type": "application/json",
-            "X-Auth-Token": authToken,
-            "X-User-Id": userId,
-          },
-          method: "POST",
+        return await this._restRequest("/api/v1/users.update", "POST", {
+          userId: userid,
+          data: { username: suggestedUsername.result },
         });
-
-        return await response2.json();
       }
     } catch (error) {
       console.error(error instanceof Error ? error.message : error);
@@ -462,27 +473,14 @@ export default class EmbeddedChatApi {
 
   async updateUserUsername(userid: string, username: string) {
     const newUserName = username.replace(/\s/g, ".").toLowerCase();
-
     const usernameRegExp = /[0-9a-zA-Z-_.]+/;
 
     if (usernameRegExp.test(newUserName)) {
       try {
-        const { userId, authToken } = (await this.auth.getCurrentUser()) || {};
-        const response = await fetch(`${this.host}/api/v1/users.update`, {
-          body: JSON.stringify({
-            userId: userid,
-            data: { username: newUserName },
-          }),
-          headers: {
-            "Content-Type": "application/json",
-            "X-Auth-Token": authToken,
-            "X-User-Id": userId,
-          },
-          method: "POST",
+        const result = await this._restRequest("/api/v1/users.update", "POST", {
+          userId: userid,
+          data: { username: newUserName },
         });
-
-        const result = await response.json();
-
         if (
           !result.success &&
           result.errorType === "error-could-not-save-identity"
@@ -500,19 +498,7 @@ export default class EmbeddedChatApi {
 
   async channelInfo() {
     try {
-      const { userId, authToken } = (await this.auth.getCurrentUser()) || {};
-      const response = await fetch(
-        `${this.host}/api/v1/rooms.info?roomId=${this.rid}`,
-        {
-          headers: {
-            "Content-Type": "application/json",
-            "X-Auth-Token": authToken,
-            "X-User-Id": userId,
-          },
-          method: "GET",
-        }
-      );
-      return await response.json();
+      return await this._restRequest(`/api/v1/rooms.info?roomId=${this.rid}`);
     } catch (err) {
       console.error(err instanceof Error ? err.message : err);
     }
@@ -528,22 +514,13 @@ export default class EmbeddedChatApi {
 
   async permissionInfo() {
     try {
-      const { userId, authToken } = (await this.auth.getCurrentUser()) || {};
-      const response = await fetch(`${this.host}/api/v1/permissions.listAll`, {
-        headers: {
-          "Content-Type": "application/json",
-          "X-Auth-Token": authToken,
-          "X-User-Id": userId,
-        },
-        method: "GET",
-      });
-      return await response.json();
+      return await this._restRequest("/api/v1/permissions.listAll");
     } catch (err) {
       console.error(err instanceof Error ? err.message : err);
     }
   }
 
-  close() {
+  async close() {
     this._activeSubscriptions.forEach((sub) => sub.stop());
     this._activeSubscriptions = [];
     this.sdk.connection.close();
@@ -576,19 +553,9 @@ export default class EmbeddedChatApi {
       ? `&field=${JSON.stringify(options.field)}`
       : "";
     try {
-      const { userId, authToken } = (await this.auth.getCurrentUser()) || {};
-      const messages = await fetch(
-        `${this.host}/api/v1/${roomType}.${endp}?roomId=${this.rid}${query}${field}`,
-        {
-          headers: {
-            "Content-Type": "application/json",
-            "X-Auth-Token": authToken,
-            "X-User-Id": userId,
-          },
-          method: "GET",
-        }
+      return await this._restRequest(
+        `/api/v1/${roomType}.${endp}?roomId=${this.rid}${query}${field}`
       );
-      return await messages.json();
     } catch (err) {
       console.log(err);
     }
@@ -617,19 +584,9 @@ export default class EmbeddedChatApi {
       : "";
     const offset = options?.offset ? options.offset : 0;
     try {
-      const { userId, authToken } = (await this.auth.getCurrentUser()) || {};
-      const messages = await fetch(
-        `${this.host}/api/v1/${roomType}.${endp}?roomId=${this.rid}${query}${field}&offset=${offset}`,
-        {
-          headers: {
-            "Content-Type": "application/json",
-            "X-Auth-Token": authToken,
-            "X-User-Id": userId,
-          },
-          method: "GET",
-        }
+      return await this._restRequest(
+        `/api/v1/${roomType}.${endp}?roomId=${this.rid}${query}${field}&offset=${offset}`
       );
-      return await messages.json();
     } catch (err) {
       console.log(err);
     }
@@ -637,19 +594,9 @@ export default class EmbeddedChatApi {
 
   async getThreadMessages(tmid: string, isChannelPrivate = false) {
     try {
-      const { userId, authToken } = (await this.auth.getCurrentUser()) || {};
-      const messages = await fetch(
-        `${this.host}/api/v1/chat.getThreadMessages?tmid=${tmid}`,
-        {
-          headers: {
-            "Content-Type": "application/json",
-            "X-Auth-Token": authToken,
-            "X-User-Id": userId,
-          },
-          method: "GET",
-        }
+      return await this._restRequest(
+        `/api/v1/chat.getThreadMessages?tmid=${tmid}`
       );
-      return await messages.json();
     } catch (err) {
       console.log(err);
     }
@@ -658,19 +605,9 @@ export default class EmbeddedChatApi {
   async getChannelRoles(isChannelPrivate = false) {
     const roomType = isChannelPrivate ? "groups" : "channels";
     try {
-      const { userId, authToken } = (await this.auth.getCurrentUser()) || {};
-      const roles = await fetch(
-        `${this.host}/api/v1/${roomType}.roles?roomId=${this.rid}`,
-        {
-          headers: {
-            "Content-Type": "application/json",
-            "X-Auth-Token": authToken,
-            "X-User-Id": userId,
-          },
-          method: "GET",
-        }
+      return await this._restRequest(
+        `/api/v1/${roomType}.roles?roomId=${this.rid}`
       );
-      return await roles.json();
     } catch (err) {
       console.log(err);
     }
@@ -678,19 +615,9 @@ export default class EmbeddedChatApi {
 
   async getUsersInRole(role: string) {
     try {
-      const { userId, authToken } = (await this.auth.getCurrentUser()) || {};
-      const roles = await fetch(
-        `${this.host}/api/v1/roles.getUsersInRole?role=${role}`,
-        {
-          headers: {
-            "Content-Type": "application/json",
-            "X-Auth-Token": authToken,
-            "X-User-Id": userId,
-          },
-          method: "GET",
-        }
+      return await this._restRequest(
+        `/api/v1/roles.getUsersInRole?role=${role}`
       );
-      return await roles.json();
     } catch (err) {
       console.log(err);
     }
@@ -729,29 +656,15 @@ export default class EmbeddedChatApi {
   async sendMessage(message: any, threadId: string) {
     const messageObj =
       typeof message === "string"
-        ? {
-            rid: this.rid,
-            msg: message,
-          }
-        : {
-            ...message,
-            rid: this.rid,
-          };
+        ? { rid: this.rid, msg: message }
+        : { ...message, rid: this.rid };
     if (threadId) {
       messageObj.tmid = threadId;
     }
     try {
-      const { userId, authToken } = (await this.auth.getCurrentUser()) || {};
-      const response = await fetch(`${this.host}/api/v1/chat.sendMessage`, {
-        body: JSON.stringify({ message: messageObj }),
-        headers: {
-          "Content-Type": "application/json",
-          "X-Auth-Token": authToken,
-          "X-User-Id": userId,
-        },
-        method: "POST",
+      return await this._restRequest("/api/v1/chat.sendMessage", "POST", {
+        message: messageObj,
       });
-      return await response.json();
     } catch (err) {
       console.error(err instanceof Error ? err.message : err);
     }
@@ -759,17 +672,10 @@ export default class EmbeddedChatApi {
 
   async deleteMessage(msgId: string) {
     try {
-      const { userId, authToken } = (await this.auth.getCurrentUser()) || {};
-      const response = await fetch(`${this.host}/api/v1/chat.delete`, {
-        body: JSON.stringify({ roomId: this.rid, msgId }),
-        headers: {
-          "Content-Type": "application/json",
-          "X-Auth-Token": authToken,
-          "X-User-Id": userId,
-        },
-        method: "POST",
+      return await this._restRequest("/api/v1/chat.delete", "POST", {
+        roomId: this.rid,
+        msgId,
       });
-      return await response.json();
     } catch (err) {
       console.error(err instanceof Error ? err.message : err);
     }
@@ -777,17 +683,11 @@ export default class EmbeddedChatApi {
 
   async updateMessage(msgId: string, text: string) {
     try {
-      const { userId, authToken } = (await this.auth.getCurrentUser()) || {};
-      const response = await fetch(`${this.host}/api/v1/chat.update`, {
-        body: JSON.stringify({ roomId: this.rid, msgId, text }),
-        headers: {
-          "Content-Type": "application/json",
-          "X-Auth-Token": authToken,
-          "X-User-Id": userId,
-        },
-        method: "POST",
+      return await this._restRequest("/api/v1/chat.update", "POST", {
+        roomId: this.rid,
+        msgId,
+        text,
       });
-      return await response.json();
     } catch (err) {
       console.error(err instanceof Error ? err.message : err);
     }
@@ -796,20 +696,11 @@ export default class EmbeddedChatApi {
   async getAllFiles(isChannelPrivate = false, typeGroup: string) {
     const roomType = isChannelPrivate ? "groups" : "channels";
     try {
-      const { userId, authToken } = (await this.auth.getCurrentUser()) || {};
-      const url =
+      const endpoint =
         typeGroup === ""
-          ? `${this.host}/api/v1/${roomType}.files?roomId=${this.rid}`
-          : `${this.host}/api/v1/${roomType}.files?roomId=${this.rid}&typeGroup=${typeGroup}`;
-      const response = await fetch(url, {
-        headers: {
-          "Content-Type": "application/json",
-          "X-Auth-Token": authToken,
-          "X-User-Id": userId,
-        },
-        method: "GET",
-      });
-      return await response.json();
+          ? `/api/v1/${roomType}.files?roomId=${this.rid}`
+          : `/api/v1/${roomType}.files?roomId=${this.rid}&typeGroup=${typeGroup}`;
+      return await this._restRequest(endpoint);
     } catch (err) {
       console.error(err instanceof Error ? err.message : err);
     }
@@ -817,19 +708,9 @@ export default class EmbeddedChatApi {
 
   async getAllImages() {
     try {
-      const { userId, authToken } = (await this.auth.getCurrentUser()) || {};
-      const response = await fetch(
-        `${this.host}/api/v1/rooms.images?roomId=${this.rid}`,
-        {
-          headers: {
-            "Content-Type": "application/json",
-            "X-Auth-Token": authToken,
-            "X-User-Id": userId,
-          },
-          method: "GET",
-        }
+      return await this._restRequest(
+        `/api/v1/rooms.images?roomId=${this.rid}`
       );
-      return await response.json();
     } catch (err) {
       console.error(err instanceof Error ? err.message : err);
     }
@@ -837,17 +718,9 @@ export default class EmbeddedChatApi {
 
   async starMessage(mid: string) {
     try {
-      const { userId, authToken } = (await this.auth.getCurrentUser()) || {};
-      const response = await fetch(`${this.host}/api/v1/chat.starMessage`, {
-        body: JSON.stringify({ messageId: mid }),
-        headers: {
-          "Content-Type": "application/json",
-          "X-Auth-Token": authToken,
-          "X-User-Id": userId,
-        },
-        method: "POST",
+      return await this._restRequest("/api/v1/chat.starMessage", "POST", {
+        messageId: mid,
       });
-      return await response.json();
     } catch (err) {
       console.error(err instanceof Error ? err.message : err);
     }
@@ -855,17 +728,9 @@ export default class EmbeddedChatApi {
 
   async unstarMessage(mid: string) {
     try {
-      const { userId, authToken } = (await this.auth.getCurrentUser()) || {};
-      const response = await fetch(`${this.host}/api/v1/chat.unStarMessage`, {
-        body: JSON.stringify({ messageId: mid }),
-        headers: {
-          "Content-Type": "application/json",
-          "X-Auth-Token": authToken,
-          "X-User-Id": userId,
-        },
-        method: "POST",
+      return await this._restRequest("/api/v1/chat.unStarMessage", "POST", {
+        messageId: mid,
       });
-      return await response.json();
     } catch (err) {
       console.error(err instanceof Error ? err.message : err);
     }
@@ -873,19 +738,9 @@ export default class EmbeddedChatApi {
 
   async getStarredMessages() {
     try {
-      const { userId, authToken } = (await this.auth.getCurrentUser()) || {};
-      const response = await fetch(
-        `${this.host}/api/v1/chat.getStarredMessages?roomId=${this.rid}`,
-        {
-          headers: {
-            "Content-Type": "application/json",
-            "X-Auth-Token": authToken,
-            "X-User-Id": userId,
-          },
-          method: "GET",
-        }
+      return await this._restRequest(
+        `/api/v1/chat.getStarredMessages?roomId=${this.rid}`
       );
-      return await response.json();
     } catch (err) {
       console.error(err instanceof Error ? err.message : err);
     }
@@ -893,19 +748,9 @@ export default class EmbeddedChatApi {
 
   async getPinnedMessages() {
     try {
-      const { userId, authToken } = (await this.auth.getCurrentUser()) || {};
-      const response = await fetch(
-        `${this.host}/api/v1/chat.getPinnedMessages?roomId=${this.rid}`,
-        {
-          headers: {
-            "Content-Type": "application/json",
-            "X-Auth-Token": authToken,
-            "X-User-Id": userId,
-          },
-          method: "GET",
-        }
+      return await this._restRequest(
+        `/api/v1/chat.getPinnedMessages?roomId=${this.rid}`
       );
-      return await response.json();
     } catch (err) {
       console.error(err instanceof Error ? err.message : err);
     }
@@ -913,19 +758,9 @@ export default class EmbeddedChatApi {
 
   async getMentionedMessages() {
     try {
-      const { userId, authToken } = (await this.auth.getCurrentUser()) || {};
-      const response = await fetch(
-        `${this.host}/api/v1/chat.getMentionedMessages?roomId=${this.rid}`,
-        {
-          headers: {
-            "Content-Type": "application/json",
-            "X-Auth-Token": authToken,
-            "X-User-Id": userId,
-          },
-          method: "GET",
-        }
+      return await this._restRequest(
+        `/api/v1/chat.getMentionedMessages?roomId=${this.rid}`
       );
-      return await response.json();
     } catch (err) {
       console.error(err instanceof Error ? err.message : err);
     }
@@ -933,37 +768,19 @@ export default class EmbeddedChatApi {
 
   async pinMessage(mid: string) {
     try {
-      const { userId, authToken } = (await this.auth.getCurrentUser()) || {};
-      const response = await fetch(`${this.host}/api/v1/chat.pinMessage`, {
-        body: JSON.stringify({ messageId: mid }),
-        headers: {
-          "Content-Type": "application/json",
-          "X-Auth-Token": authToken,
-          "X-User-Id": userId,
-        },
-        method: "POST",
+      return await this._restRequest("/api/v1/chat.pinMessage", "POST", {
+        messageId: mid,
       });
-      return await response.json();
     } catch (err) {
-      return {
-        error: err,
-      };
+      return { error: err };
     }
   }
 
   async unpinMessage(mid: string) {
     try {
-      const { userId, authToken } = (await this.auth.getCurrentUser()) || {};
-      const response = await fetch(`${this.host}/api/v1/chat.unPinMessage`, {
-        body: JSON.stringify({ messageId: mid }),
-        headers: {
-          "Content-Type": "application/json",
-          "X-Auth-Token": authToken,
-          "X-User-Id": userId,
-        },
-        method: "POST",
+      return await this._restRequest("/api/v1/chat.unPinMessage", "POST", {
+        messageId: mid,
       });
-      return await response.json();
     } catch (err) {
       console.error(err instanceof Error ? err.message : err);
     }
@@ -971,21 +788,11 @@ export default class EmbeddedChatApi {
 
   async reactToMessage(emoji: string, messageId: string, shouldReact: string) {
     try {
-      const { userId, authToken } = (await this.auth.getCurrentUser()) || {};
-      const response = await fetch(`${this.host}/api/v1/chat.react`, {
-        body: JSON.stringify({
-          messageId,
-          emoji,
-          shouldReact,
-        }),
-        headers: {
-          "Content-Type": "application/json",
-          "X-Auth-Token": authToken,
-          "X-User-Id": userId,
-        },
-        method: "POST",
+      return await this._restRequest("/api/v1/chat.react", "POST", {
+        messageId,
+        emoji,
+        shouldReact,
       });
-      return await response.json();
     } catch (err) {
       console.error(err instanceof Error ? err.message : err);
     }
@@ -993,17 +800,10 @@ export default class EmbeddedChatApi {
 
   async reportMessage(messageId: string, description: string) {
     try {
-      const { userId, authToken } = (await this.auth.getCurrentUser()) || {};
-      const response = await fetch(`${this.host}/api/v1/chat.reportMessage`, {
-        body: JSON.stringify({ messageId, description }),
-        headers: {
-          "Content-Type": "application/json",
-          "X-Auth-Token": authToken,
-          "X-User-Id": userId,
-        },
-        method: "POST",
+      return await this._restRequest("/api/v1/chat.reportMessage", "POST", {
+        messageId,
+        description,
       });
-      return await response.json();
     } catch (err) {
       console.error(err instanceof Error ? err.message : err);
     }
@@ -1011,17 +811,11 @@ export default class EmbeddedChatApi {
 
   async findOrCreateInvite() {
     try {
-      const { userId, authToken } = (await this.auth.getCurrentUser()) || {};
-      const response = await fetch(`${this.host}/api/v1/findOrCreateInvite`, {
-        method: "POST",
-        body: JSON.stringify({ rid: this.rid, days: 1, maxUses: 10 }),
-        headers: {
-          "Content-Type": "application/json",
-          "X-Auth-Token": authToken,
-          "X-User-Id": userId,
-        },
+      return await this._restRequest("/api/v1/findOrCreateInvite", "POST", {
+        rid: this.rid,
+        days: 1,
+        maxUses: 10,
       });
-      return await response.json();
     } catch (err) {
       console.log(err);
     }
@@ -1034,8 +828,8 @@ export default class EmbeddedChatApi {
     threadId = undefined
   ) {
     try {
-      const { userId, authToken } = (await this.auth.getCurrentUser()) || {};
-      if (!userId || !authToken) {
+      const currentUser = await this.auth.getCurrentUser();
+      if (!currentUser?.userId || !currentUser?.authToken) {
         console.error("sendAttachment: User not authenticated");
         return;
       }
@@ -1043,43 +837,23 @@ export default class EmbeddedChatApi {
       const form = new FormData();
       form.append("file", file, fileName);
 
-      const uploadResponse = await fetch(
-        `${this.host}/api/v1/rooms.media/${this.rid}`,
-        {
-          method: "POST",
-          body: form,
-          headers: {
-            "X-Auth-Token": authToken,
-            "X-User-Id": userId,
-          },
-        }
+      const uploadResult = await this._restUpload(
+        `/api/v1/rooms.media/${this.rid}`,
+        form
       );
-
-      const uploadResult = await uploadResponse.json();
 
       if (!uploadResult.success || !uploadResult.file?._id) {
         console.error("sendAttachment: Upload failed", uploadResult);
         return uploadResult;
       }
 
-      const confirmResponse = await fetch(
-        `${this.host}/api/v1/rooms.mediaConfirm/${this.rid}/${uploadResult.file._id}`,
-        {
-          method: "POST",
-          headers: {
-            "Content-Type": "application/json",
-            "X-Auth-Token": authToken,
-            "X-User-Id": userId,
-          },
-          body: JSON.stringify(
-            threadId
-              ? { msg: "", description: fileDescription || "", tmid: threadId }
-              : { msg: "", description: fileDescription || "" }
-          ),
-        }
+      return await this._restRequest(
+        `/api/v1/rooms.mediaConfirm/${this.rid}/${uploadResult.file._id}`,
+        "POST",
+        threadId
+          ? { msg: "", description: fileDescription || "", tmid: threadId }
+          : { msg: "", description: fileDescription || "" }
       );
-
-      return await confirmResponse.json();
     } catch (err) {
       console.error("sendAttachment error:", err);
     }
@@ -1087,16 +861,7 @@ export default class EmbeddedChatApi {
 
   async me() {
     try {
-      const { userId, authToken } = (await this.auth.getCurrentUser()) || {};
-      const response = await fetch(`${this.host}/api/v1/me`, {
-        headers: {
-          "Content-Type": "application/json",
-          "X-Auth-Token": authToken,
-          "X-User-Id": userId,
-        },
-        method: "GET",
-      });
-      return await response.json();
+      return await this._restRequest("/api/v1/me");
     } catch (err) {
       console.error(err instanceof Error ? err.message : err);
     }
@@ -1105,19 +870,9 @@ export default class EmbeddedChatApi {
   async getChannelMembers(isChannelPrivate = false) {
     const roomType = isChannelPrivate ? "groups" : "channels";
     try {
-      const { userId, authToken } = (await this.auth.getCurrentUser()) || {};
-      const response = await fetch(
-        `${this.host}/api/v1/${roomType}.members?roomId=${this.rid}`,
-        {
-          headers: {
-            "Content-Type": "application/json",
-            "X-Auth-Token": authToken,
-            "X-User-Id": userId,
-          },
-          method: "GET",
-        }
+      return await this._restRequest(
+        `/api/v1/${roomType}.members?roomId=${this.rid}`
       );
-      return await response.json();
     } catch (err) {
       console.error(err instanceof Error ? err.message : err);
     }
@@ -1125,19 +880,9 @@ export default class EmbeddedChatApi {
 
   async getSearchMessages(text: string) {
     try {
-      const { userId, authToken } = (await this.auth.getCurrentUser()) || {};
-      const response = await fetch(
-        `${this.host}/api/v1/chat.search?roomId=${this.rid}&searchText=${text}`,
-        {
-          headers: {
-            "Content-Type": "application/json",
-            "X-Auth-Token": authToken,
-            "X-User-Id": userId,
-          },
-          method: "GET",
-        }
+      return await this._restRequest(
+        `/api/v1/chat.search?roomId=${this.rid}&searchText=${text}`
       );
-      return await response.json();
     } catch (err) {
       console.error(err instanceof Error ? err.message : err);
     }
@@ -1145,19 +890,9 @@ export default class EmbeddedChatApi {
 
   async getMessageLimit() {
     try {
-      const { userId, authToken } = (await this.auth.getCurrentUser()) || {};
-      const response = await fetch(
-        `${this.host}/api/v1/settings/Message_MaxAllowedSize`,
-        {
-          headers: {
-            "Content-Type": "application/json",
-            "X-Auth-Token": authToken,
-            "X-User-Id": userId,
-          },
-          method: "GET",
-        }
+      return await this._restRequest(
+        "/api/v1/settings/Message_MaxAllowedSize"
       );
-      return await response.json();
     } catch (err) {
       console.error(err instanceof Error ? err.message : err);
     }
@@ -1165,27 +900,12 @@ export default class EmbeddedChatApi {
 
   async handleUiKitInteraction(appId: string, userInteraction: any) {
     try {
-      const { userId, authToken } = (await this.auth.getCurrentUser()) || {};
-
       const triggerId = Math.random().toString(32).slice(2, 16);
-
-      const response = await fetch(
-        `${this.host}/api/apps/ui.interaction/${appId}`,
-        {
-          headers: {
-            "Content-Type": "application/json",
-            "X-Auth-Token": authToken,
-            "X-User-Id": userId,
-          },
-          method: "POST",
-          body: JSON.stringify({
-            triggerId,
-            ...userInteraction,
-          }),
-        }
+      const interaction = await this._restRequest(
+        `/api/apps/ui.interaction/${appId}`,
+        "POST",
+        { triggerId, ...userInteraction }
       );
-
-      const interaction = await response.json();
       this.onActionTriggeredCallbacks.forEach((cb) => cb(interaction));
       return interaction;
     } catch (e) {
@@ -1194,17 +914,7 @@ export default class EmbeddedChatApi {
   }
 
   async getCommandsList() {
-    const { userId, authToken } = (await this.auth.getCurrentUser()) || {};
-    const response = await fetch(`${this.host}/api/v1/commands.list`, {
-      headers: {
-        "Content-Type": "application/json",
-        "X-Auth-Token": authToken,
-        "X-User-Id": userId,
-      },
-      method: "GET",
-    });
-    const data = await response.json();
-    return data;
+    return await this._restRequest("/api/v1/commands.list");
   }
 
   async execCommand({
@@ -1216,74 +926,30 @@ export default class EmbeddedChatApi {
     params: string;
     tmid?: string;
   }) {
-    const { userId, authToken } = (await this.auth.getCurrentUser()) || {};
-    const response = await fetch(`${this.host}/api/v1/commands.run`, {
-      headers: {
-        "Content-Type": "application/json",
-        "X-Auth-Token": authToken,
-        "X-User-Id": userId,
-      },
-      method: "POST",
-      body: JSON.stringify({
-        command,
-        params,
-        tmid,
-        roomId: this.rid,
-        triggerId: Math.random().toString(32).slice(2, 20),
-      }),
+    return await this._restRequest("/api/v1/commands.run", "POST", {
+      command,
+      params,
+      tmid,
+      roomId: this.rid,
+      triggerId: Math.random().toString(32).slice(2, 20),
     });
-    const data = await response.json();
-    return data;
   }
 
   async getUserStatus(reqUserId: string) {
-    const { userId, authToken } = (await this.auth.getCurrentUser()) || {};
-    const response = await fetch(
-      `${this.host}/api/v1/users.getStatus?userId=${reqUserId}`,
-      {
-        method: "GET",
-        headers: {
-          "Content-Type": "application/json",
-          "X-Auth-Token": authToken,
-          "X-User-Id": userId,
-        },
-      }
+    return await this._restRequest(
+      `/api/v1/users.getStatus?userId=${reqUserId}`
     );
-    const data = response.json();
-    return data;
   }
 
   async userInfo(reqUserId: string) {
-    const { userId, authToken } = (await this.auth.getCurrentUser()) || {};
-    const response = await fetch(
-      `${this.host}/api/v1/users.info?userId=${reqUserId}`,
-      {
-        method: "GET",
-        headers: {
-          "Content-Type": "application/json",
-          "X-Auth-Token": authToken,
-          "X-User-Id": userId,
-        },
-      }
+    return await this._restRequest(
+      `/api/v1/users.info?userId=${reqUserId}`
     );
-    const data = response.json();
-    return data;
   }
 
   async userData(username: string) {
-    const { userId, authToken } = (await this.auth.getCurrentUser()) || {};
-    const response = await fetch(
-      `${this.host}/api/v1/users.info?username=${username}`,
-      {
-        method: "GET",
-        headers: {
-          "Content-Type": "application/json",
-          "X-Auth-Token": authToken,
-          "X-User-Id": userId,
-        },
-      }
+    return await this._restRequest(
+      `/api/v1/users.info?username=${username}`
     );
-    const data = response.json();
-    return data;
   }
 }

--- a/packages/api/src/ddp-client.d.ts
+++ b/packages/api/src/ddp-client.d.ts
@@ -1,0 +1,15 @@
+// Type augmentation for @rocket.chat/ddp-client
+// The published .d.ts for DDPSDK is missing the stream() method declaration,
+// even though it exists in the JS implementation and the SDK interface it implements.
+// This augmentation adds it back so TypeScript can see it.
+import type { ClientStream } from "@rocket.chat/ddp-client/dist/types/ClientStream";
+
+declare module "@rocket.chat/ddp-client" {
+  interface DDPSDK {
+    stream(
+      name: string,
+      data: unknown,
+      cb: (...data: any[]) => void
+    ): ReturnType<ClientStream["subscribe"]> & { stop: () => void };
+  }
+}

--- a/packages/auth/src/RocketChatAuth.ts
+++ b/packages/auth/src/RocketChatAuth.ts
@@ -74,7 +74,10 @@ class RocketChatAuth {
       }
     );
     this.setUser(response.data);
-    this.notifyAuthListeners();
+    // Note: setUser → save() already calls notifyAuthListeners().
+    // Do NOT call it again here — a second notification would trigger
+    // a second connect() after the first resolves, causing close() to
+    // kill the active DDP session and all subscriptions.
     return this.currentUser;
   }
 
@@ -95,7 +98,7 @@ class RocketChatAuth {
       credentials
     );
     this.setUser(response.data);
-    this.notifyAuthListeners();
+    // setUser → save() already calls notifyAuthListeners().
     return this.currentUser;
   }
 

--- a/packages/auth/src/RocketChatAuth.ts
+++ b/packages/auth/src/RocketChatAuth.ts
@@ -74,10 +74,6 @@ class RocketChatAuth {
       }
     );
     this.setUser(response.data);
-    // Note: setUser → save() already calls notifyAuthListeners().
-    // Do NOT call it again here — a second notification would trigger
-    // a second connect() after the first resolves, causing close() to
-    // kill the active DDP session and all subscriptions.
     return this.currentUser;
   }
 
@@ -98,7 +94,6 @@ class RocketChatAuth {
       credentials
     );
     this.setUser(response.data);
-    // setUser → save() already calls notifyAuthListeners().
     return this.currentUser;
   }
 

--- a/packages/react/src/hooks/useFetchChatData.js
+++ b/packages/react/src/hooks/useFetchChatData.js
@@ -6,6 +6,7 @@ import {
   useMemberStore,
   useMessageStore,
   useStarredMessageStore,
+  usePinnedMessageStore,
 } from '../store';
 
 const useFetchChatData = (showRoles) => {
@@ -18,6 +19,9 @@ const useFetchChatData = (showRoles) => {
   const permissionsRef = useRef(null);
   const setStarredMessages = useStarredMessageStore(
     (state) => state.setStarredMessages
+  );
+  const setPinnedMessages = usePinnedMessageStore(
+    (state) => state.setPinnedMessages
   );
   const isUserAuthenticated = useUserStore(
     (state) => state.isUserAuthenticated
@@ -197,9 +201,27 @@ const useFetchChatData = (showRoles) => {
     [isUserAuthenticated, RCInstance, setStarredMessages]
   );
 
+  const getPinnedMessages = useCallback(
+    async (anonymousMode) => {
+      if (isUserAuthenticated) {
+        try {
+          if (!isUserAuthenticated && !anonymousMode) {
+            return;
+          }
+          const { messages } = await RCInstance.getPinnedMessages();
+          setPinnedMessages(messages);
+        } catch (e) {
+          console.error(e);
+        }
+      }
+    },
+    [isUserAuthenticated, RCInstance, setPinnedMessages]
+  );
+
   return {
     getMessagesAndRoles,
     getStarredMessages,
+    getPinnedMessages,
     fetchAndSetPermissions,
     permissionsRef,
   };

--- a/packages/react/src/hooks/useRCAuth.js
+++ b/packages/react/src/hooks/useRCAuth.js
@@ -50,9 +50,13 @@ export const useRCAuth = () => {
 
         if (res.status === 'success') {
           setIsLoginModalOpen(false);
-          setUserAvatarUrl(res.me.avatarUrl);
-          setAuthenticatedUserUsername(res.me.username);
-          setIsUserAuthenticated(true);
+          // Do NOT call setIsUserAuthenticated(true) here.
+          // EmbeddedChat.js's handleAuthChange listener fires once the auth
+          // token is persisted and calls RCInstance.connect(), which syncs
+          // REST credentials and re-establishes the DDP session before
+          // setting isUserAuthenticated=true. Calling it here races with
+          // connect() and causes all initial data fetches to fire with no
+          // auth headers, resulting in 401s.
           setIsTotpModalOpen(false);
           setEmailorUser(null);
           setPassword(null);

--- a/packages/react/src/hooks/useRCAuth.js
+++ b/packages/react/src/hooks/useRCAuth.js
@@ -50,13 +50,6 @@ export const useRCAuth = () => {
 
         if (res.status === 'success') {
           setIsLoginModalOpen(false);
-          // Do NOT call setIsUserAuthenticated(true) here.
-          // EmbeddedChat.js's handleAuthChange listener fires once the auth
-          // token is persisted and calls RCInstance.connect(), which syncs
-          // REST credentials and re-establishes the DDP session before
-          // setting isUserAuthenticated=true. Calling it here races with
-          // connect() and causes all initial data fetches to fire with no
-          // auth headers, resulting in 401s.
           setIsTotpModalOpen(false);
           setEmailorUser(null);
           setPassword(null);

--- a/packages/react/src/store/pinnedMessageStore.js
+++ b/packages/react/src/store/pinnedMessageStore.js
@@ -3,6 +3,8 @@ import { create } from 'zustand';
 const usePinnedMessageStore = create((set) => ({
   showPinned: false,
   setShowPinned: (showPinned) => set(() => ({ showPinned })),
+  pinnedMessages: [],
+  setPinnedMessages: (messages) => set(() => ({ pinnedMessages: messages })),
 }));
 
 export default usePinnedMessageStore;

--- a/packages/react/src/views/ChatLayout/ChatLayout.js
+++ b/packages/react/src/views/ChatLayout/ChatLayout.js
@@ -53,6 +53,9 @@ const ChatLayout = () => {
     (state) => state.showAllThreads
   );
   const showPinned = usePinnedMessageStore((state) => state.showPinned);
+  const setPinnedMessages = usePinnedMessageStore(
+    (state) => state.setPinnedMessages
+  );
   const showStarred = useStarredMessageStore((state) => state.showStarred);
   const showSearch = useSearchMessageStore((state) => state.showSearch);
   const showChannelinfo = useChannelStore((state) => state.showChannelinfo);
@@ -83,7 +86,7 @@ const ChatLayout = () => {
     }
   };
   const getStarredMessages = useCallback(async () => {
-    if (isUserAuthenticated) {
+    if (isUserAuthenticated && showStarred) {
       try {
         if (!isUserAuthenticated && !anonymousMode) {
           return;
@@ -94,10 +97,41 @@ const ChatLayout = () => {
         console.error(e);
       }
     }
-  }, [isUserAuthenticated, anonymousMode, RCInstance]);
+  }, [
+    isUserAuthenticated,
+    anonymousMode,
+    RCInstance,
+    showStarred,
+    setStarredMessages,
+  ]);
+
+  const getPinnedMessages = useCallback(async () => {
+    if (isUserAuthenticated && showPinned) {
+      try {
+        if (!isUserAuthenticated && !anonymousMode) {
+          return;
+        }
+        const { messages } = await RCInstance.getPinnedMessages();
+        setPinnedMessages(messages);
+      } catch (e) {
+        console.error(e);
+      }
+    }
+  }, [
+    isUserAuthenticated,
+    anonymousMode,
+    RCInstance,
+    showPinned,
+    setPinnedMessages,
+  ]);
+
   useEffect(() => {
     getStarredMessages();
-  }, [showSidebar]);
+  }, [getStarredMessages, showSidebar, showStarred]);
+
+  useEffect(() => {
+    getPinnedMessages();
+  }, [getPinnedMessages, showSidebar, showPinned]);
   return (
     <Box
       css={styles.layout}

--- a/packages/react/src/views/EmbeddedChat.js
+++ b/packages/react/src/views/EmbeddedChat.js
@@ -169,12 +169,17 @@ const EmbeddedChat = (props) => {
         RCInstance.connect()
           .then(() => {
             console.log(`Connected to RocketChat ${RCInstance.host}`);
-            const { me } = user;
-            setAuthenticatedAvatarUrl(me.avatarUrl);
-            setAuthenticatedUsername(me.username);
-            setAuthenticatedUserId(me._id);
-            setAuthenticatedName(me.name);
-            setAuthenticatedUserRoles(me.roles);
+            // currentUser shape differs by login method:
+            // - resume/OAuth: { userId, authToken, me: {...} }
+            // - password:     { status, data: { userId, authToken, me: {...} } }
+            const me = user.me || user.data?.me;
+            if (me) {
+              setAuthenticatedAvatarUrl(me.avatarUrl);
+              setAuthenticatedUsername(me.username);
+              setAuthenticatedUserId(me._id);
+              setAuthenticatedName(me.name);
+              setAuthenticatedUserRoles(me.roles);
+            }
             setIsUserAuthenticated(true);
           })
           .catch(console.error);

--- a/packages/react/src/views/EmbeddedChat.js
+++ b/packages/react/src/views/EmbeddedChat.js
@@ -169,9 +169,6 @@ const EmbeddedChat = (props) => {
         RCInstance.connect()
           .then(() => {
             console.log(`Connected to RocketChat ${RCInstance.host}`);
-            // currentUser shape differs by login method:
-            // - resume/OAuth: { userId, authToken, me: {...} }
-            // - password:     { status, data: { userId, authToken, me: {...} } }
             const me = user.me || user.data?.me;
             if (me) {
               setAuthenticatedAvatarUrl(me.avatarUrl);

--- a/packages/react/src/views/Message/Message.js
+++ b/packages/react/src/views/Message/Message.js
@@ -66,7 +66,7 @@ const Message = ({
   );
   const addQuoteMessage = useMessageStore((state) => state.addQuoteMessage);
   const openThread = useMessageStore((state) => state.openThread);
-  const { getStarredMessages } = useFetchChatData();
+  const { getStarredMessages, getPinnedMessages } = useFetchChatData();
   const dispatchToastMessage = useToastBarDispatch();
   const { editMessage, setEditMessage } = useMessageStore((state) => ({
     editMessage: state.editMessage,
@@ -146,6 +146,7 @@ const Message = ({
         type: 'success',
         message: isPinned ? 'Message unpinned' : 'Message pinned',
       });
+      getPinnedMessages();
     }
   };
 

--- a/packages/react/src/views/MessageAggregators/PinnedMessages.js
+++ b/packages/react/src/views/MessageAggregators/PinnedMessages.js
@@ -1,15 +1,18 @@
 import React from 'react';
 import { useComponentOverrides } from '@embeddedchat/ui-elements';
+import { usePinnedMessageStore } from '../../store';
 import { MessageAggregator } from './common/MessageAggregator';
 
 const PinnedMessages = () => {
   const { variantOverrides } = useComponentOverrides('PinnedMessages');
   const viewType = variantOverrides.viewType || 'Sidebar';
+  const pinnedMessages = usePinnedMessageStore((state) => state.pinnedMessages);
   return (
     <MessageAggregator
       title="Pinned Messages"
       iconName="pin"
       noMessageInfo="No Pinned Messages"
+      fetchedMessageList={pinnedMessages}
       shouldRender={(msg) => msg.pinned}
       viewType={viewType}
     />

--- a/packages/ui-elements/src/components/Tooltip/Tooltip.js
+++ b/packages/ui-elements/src/components/Tooltip/Tooltip.js
@@ -32,6 +32,7 @@ const Tooltip = ({ children, text, position }) => {
 
   return (
     <Box
+      is="span"
       onMouseEnter={handleMouseEnter}
       onMouseLeave={handleMouseLeave}
       onTouchStart={handleTouchStart}
@@ -43,9 +44,9 @@ const Tooltip = ({ children, text, position }) => {
     >
       {children}
       {isTooltipVisible && (
-        <Box css={styles.tooltip}>
+        <Box is="span" css={styles.tooltip}>
           {text.charAt(0).toUpperCase() + text.slice(1)}
-          <Box css={styles.tooltipArrow} />
+          <Box is="span" css={styles.tooltipArrow} />
         </Box>
       )}
     </Box>

--- a/yarn.lock
+++ b/yarn.lock
@@ -2442,7 +2442,8 @@ __metadata:
   resolution: "@embeddedchat/api@workspace:packages/api"
   dependencies:
     "@embeddedchat/auth": "workspace:^"
-    "@rocket.chat/sdk": ^1.0.0-alpha.42
+    "@rocket.chat/ddp-client": 1.0.9-rc.2
+    "@rocket.chat/emitter": ^0.31.25
     parcel: ^2.10.3
     rollup: ^3.23.0
     rollup-plugin-dts: ^6.0.1
@@ -4293,6 +4294,21 @@ __metadata:
   peerDependencies:
     react: "*"
   checksum: 24baa360cb83f7e1a9e6784ac11185d57eb895b0efd3070ec915693378330f35ff9feb248f650b9649fa3e1045601286585dc05795a4c734d4849b33900351ee
+  languageName: node
+  linkType: hard
+
+"@inquirer/external-editor@npm:^1.0.0":
+  version: 1.0.3
+  resolution: "@inquirer/external-editor@npm:1.0.3"
+  dependencies:
+    chardet: ^2.1.1
+    iconv-lite: ^0.7.0
+  peerDependencies:
+    "@types/node": ">=18"
+  peerDependenciesMeta:
+    "@types/node":
+      optional: true
+  checksum: 9bd7a05247a00408c194648c74046d8a212df1e6b9fe0879b945ebfc35c2524e995e43f7ecd83f14d0bd4e31f985d18819efc31c27810e2c2b838ded7261431f
   languageName: node
   linkType: hard
 
@@ -6674,6 +6690,20 @@ __metadata:
   languageName: node
   linkType: hard
 
+"@rocket.chat/api-client@npm:^0.2.56-rc.2":
+  version: 0.2.56
+  resolution: "@rocket.chat/api-client@npm:0.2.56"
+  dependencies:
+    "@rocket.chat/core-typings": ^8.4.0
+    "@rocket.chat/rest-typings": ^8.4.0
+    filter-obj: ^3.0.0
+    query-string: ^7.1.3
+    split-on-first: ^3.0.0
+    strict-uri-encode: ^2.0.0
+  checksum: 638235b735973618b6ab03c9e48b5159cd77993087fd129e06334f8aa1655a7e99e280db3b46f65ae2dfe460fcde05ec4c7e4e52473fb9e115143c3bf46b2b38
+  languageName: node
+  linkType: hard
+
 "@rocket.chat/apps-engine@npm:^1.36.0":
   version: 1.41.0
   resolution: "@rocket.chat/apps-engine@npm:1.41.0"
@@ -6692,10 +6722,44 @@ __metadata:
   languageName: node
   linkType: hard
 
+"@rocket.chat/core-typings@npm:^8.4.0, @rocket.chat/core-typings@npm:^8.4.1, @rocket.chat/core-typings@npm:~8.4.0-rc.2":
+  version: 8.4.1
+  resolution: "@rocket.chat/core-typings@npm:8.4.1"
+  dependencies:
+    "@rocket.chat/icons": ~0.47.0
+    "@rocket.chat/message-parser": ^0.31.36
+    "@rocket.chat/ui-kit": ~1.0.0
+    typia: "patch:typia@npm%3A9.7.2#~/.yarn/patches/typia-npm-9.7.2-5c5d9c80b4.patch"
+    zod: ~4.3.6
+  checksum: 0c05ac3e20a4c77a22d173188528a69e7b6dbd8ccfd22edabb9eb4589d3cfc74d783e59683fef41101fbb388dea697c70b2306045cc31fb474802076d8ef624e
+  languageName: node
+  linkType: hard
+
+"@rocket.chat/ddp-client@npm:1.0.9-rc.2":
+  version: 1.0.9-rc.2
+  resolution: "@rocket.chat/ddp-client@npm:1.0.9-rc.2"
+  dependencies:
+    "@rocket.chat/api-client": ^0.2.56-rc.2
+    "@rocket.chat/core-typings": ~8.4.0-rc.2
+    "@rocket.chat/media-signaling": ^1.0.0-rc.1
+    "@rocket.chat/rest-typings": ^8.4.0-rc.2
+  peerDependencies:
+    "@rocket.chat/emitter": "*"
+  checksum: b0197b1247bc9dc9a611caa4781b50256920c9c2ec8ca4b4eb304cb73a87832b8156b364c13b0be2152aad1272b5da8fd9b4f19230338b08e3d7ff7b197c0a67
+  languageName: node
+  linkType: hard
+
 "@rocket.chat/emitter@npm:^0.31.25":
   version: 0.31.25
   resolution: "@rocket.chat/emitter@npm:0.31.25"
   checksum: bcb7fbd947507446b9902157adea89ed873f499f5493e9de4eee14795e52a3678b2dd7353f827721f985773dc0a39f51f387bc4e40202e2afb666444437a6041
+  languageName: node
+  linkType: hard
+
+"@rocket.chat/emitter@npm:^0.32.0":
+  version: 0.32.0
+  resolution: "@rocket.chat/emitter@npm:0.32.0"
+  checksum: cf423b52ab01c620e748e089e7645bd2b0b99a921d3c95c7fad1a7ffacbb44a0f2573431c437c9a735d4fb020247356a82eb2f0bba6366e6d55145374811092e
   languageName: node
   linkType: hard
 
@@ -6718,6 +6782,23 @@ __metadata:
   languageName: node
   linkType: hard
 
+"@rocket.chat/icons@npm:~0.47.0":
+  version: 0.47.0
+  resolution: "@rocket.chat/icons@npm:0.47.0"
+  checksum: 80aacd3e6c4956eb9f93712e2655dbc4dc2f2eb507c74998eb6a1df2823869fd2c7e5b9e89d2ff688d50769a8ec7316fdcdf2cac4b34fb3c114cd3a4577f3a84
+  languageName: node
+  linkType: hard
+
+"@rocket.chat/media-signaling@npm:^1.0.0-rc.1":
+  version: 1.0.0
+  resolution: "@rocket.chat/media-signaling@npm:1.0.0"
+  dependencies:
+    "@rocket.chat/emitter": ^0.32.0
+    ajv: ^8.17.1
+  checksum: 80676474ee23f7624c47cabfc35b76a69f4a6d8336ff90fa1863de1f077e85275406ba6dee42dc72f0ed5d84f44c354bc57a7fe34e84765dee24806430a21bef
+  languageName: node
+  linkType: hard
+
 "@rocket.chat/message-parser@npm:^0.31.29":
   version: 0.31.29
   resolution: "@rocket.chat/message-parser@npm:0.31.29"
@@ -6727,16 +6808,25 @@ __metadata:
   languageName: node
   linkType: hard
 
-"@rocket.chat/sdk@npm:^1.0.0-alpha.42":
-  version: 1.0.0-alpha.42
-  resolution: "@rocket.chat/sdk@npm:1.0.0-alpha.42"
+"@rocket.chat/message-parser@npm:^0.31.36":
+  version: 0.31.36
+  resolution: "@rocket.chat/message-parser@npm:0.31.36"
   dependencies:
-    js-sha256: ^0.9.0
-    lru-cache: ^4.1.1
-    mem: ^4.0.0
-    tiny-events: ^1.0.1
-    universal-websocket-client: ^1.0.2
-  checksum: e54e0a6c7049c3fb14b9d3a7f32a082d6b282d1b77543fc09c22b252daf1c7663da348532de90c96013c8a571471012fea8193e063faf2dc0148c175bd15b3f8
+    tldts: ~6.1.86
+  checksum: b74f6e0a64da065cd4d881f278a9eddf322cf42f2aaf98e21075464cfb45d62628713f6bb7882b0a0e792928643f8a2385fb7c564d8f64e4cc6fbaa022ff40b4
+  languageName: node
+  linkType: hard
+
+"@rocket.chat/rest-typings@npm:^8.4.0, @rocket.chat/rest-typings@npm:^8.4.0-rc.2":
+  version: 8.4.1
+  resolution: "@rocket.chat/rest-typings@npm:8.4.1"
+  dependencies:
+    "@rocket.chat/core-typings": ^8.4.1
+    "@rocket.chat/message-parser": ^0.31.36
+    "@rocket.chat/ui-kit": ~1.0.0
+    ajv: ^8.17.1
+    ajv-formats: ^3.0.1
+  checksum: 8e24bde082a57542462777029fadcf5bdf8f0e213109b67f53c2ca7ac6b479fab44d32038b7d985856bd30ec20dc18fa8823b26965f88d3c6ecda6310bda2c43
   languageName: node
   linkType: hard
 
@@ -6746,6 +6836,17 @@ __metadata:
   peerDependencies:
     "@rocket.chat/icons": "*"
   checksum: 11ecd99c513f55eda7fae5a0247b91047c98e16d6571fb8fb6bf739df2f00a4b584f89ad117259196f5525340c101fe7093e6b685382a3efff54abcb99383d93
+  languageName: node
+  linkType: hard
+
+"@rocket.chat/ui-kit@npm:~1.0.0":
+  version: 1.0.0
+  resolution: "@rocket.chat/ui-kit@npm:1.0.0"
+  dependencies:
+    typia: ~9.7.2
+  peerDependencies:
+    "@rocket.chat/icons": "*"
+  checksum: f69a0739872fbd4e2fa69bf861f1b3c714269159082303fad1e48de4675ad7afde23ad8bd1dd1aae79dc223f6b65b2fc9cd1d9b9da73bee856e68a92280f93ad
   languageName: node
   linkType: hard
 
@@ -7048,6 +7149,13 @@ __metadata:
   languageName: node
   linkType: hard
 
+"@samchon/openapi@npm:^4.7.1":
+  version: 4.7.2
+  resolution: "@samchon/openapi@npm:4.7.2"
+  checksum: 1a46d654e5dfd70f8504a01fa127c618e408abcfb0c3e6fc7466f1737bed63b82404482cc6dedf8cd9e827623f1ab0fd79a995ad6a6415397d452b8e07099c5c
+  languageName: node
+  linkType: hard
+
 "@segment/loosely-validate-event@npm:^2.0.0":
   version: 2.0.0
   resolution: "@segment/loosely-validate-event@npm:2.0.0"
@@ -7158,6 +7266,13 @@ __metadata:
   dependencies:
     "@sinonjs/commons": ^1.7.0
   checksum: 09b5a158ce013a6c37613258bad79ca4efeb99b1f59c41c73cca36cac00b258aefcf46eeea970fccf06b989414d86fe9f54c1102272c0c3bdd51a313cea80949
+  languageName: node
+  linkType: hard
+
+"@standard-schema/spec@npm:^1.0.0":
+  version: 1.1.0
+  resolution: "@standard-schema/spec@npm:1.1.0"
+  checksum: 6245ebef5e698bb04752a22e996a7cc40406a404d9f68a9d4e1a7a10f2422da287247508e7b495a2f32bb38f3d57b4daf2c9ab4bf22d9bca13e20a3dc5ec575e
   languageName: node
   linkType: hard
 
@@ -9913,6 +10028,20 @@ __metadata:
   languageName: node
   linkType: hard
 
+"ajv-formats@npm:^3.0.1":
+  version: 3.0.1
+  resolution: "ajv-formats@npm:3.0.1"
+  dependencies:
+    ajv: ^8.0.0
+  peerDependencies:
+    ajv: ^8.0.0
+  peerDependenciesMeta:
+    ajv:
+      optional: true
+  checksum: f4e1fe232d67fcafc02eafe373a7a9962351e0439dd0736647ca75c93c3da23b430b6502c255ab4315410ae330d4f3013ac9fe226c40b2524ca93a58e786d086
+  languageName: node
+  linkType: hard
+
 "ajv-keywords@npm:^3.1.0, ajv-keywords@npm:^3.4.1, ajv-keywords@npm:^3.5.2":
   version: 3.5.2
   resolution: "ajv-keywords@npm:3.5.2"
@@ -9954,6 +10083,18 @@ __metadata:
     require-from-string: ^2.0.2
     uri-js: ^4.2.2
   checksum: 4dc13714e316e67537c8b31bc063f99a1d9d9a497eb4bbd55191ac0dcd5e4985bbb71570352ad6f1e76684fb6d790928f96ba3b2d4fd6e10024be9612fe3f001
+  languageName: node
+  linkType: hard
+
+"ajv@npm:^8.17.1":
+  version: 8.20.0
+  resolution: "ajv@npm:8.20.0"
+  dependencies:
+    fast-deep-equal: ^3.1.3
+    fast-uri: ^3.0.1
+    json-schema-traverse: ^1.0.0
+    require-from-string: ^2.0.2
+  checksum: 4f18ca5fcccff8c8b9a4d6f1a6a3a70ffc888e787624ca66f2d0162e04e8f9f2d289d8a1acdb9520d18bffcee975e7a789a9f8292b5c2c577c408cd2c3308cad
   languageName: node
   linkType: hard
 
@@ -10334,6 +10475,13 @@ __metadata:
     get-intrinsic: ^1.2.4
     is-string: ^1.0.7
   checksum: eb39ba5530f64e4d8acab39297c11c1c5be2a4ea188ab2b34aba5fb7224d918f77717a9d57a3e2900caaa8440e59431bdaf5c974d5212ef65d97f132e38e2d91
+  languageName: node
+  linkType: hard
+
+"array-timsort@npm:^1.0.3":
+  version: 1.0.3
+  resolution: "array-timsort@npm:1.0.3"
+  checksum: fd4b5b0911214bdc8b5699ed10d309685551b518b3819c611c967cff59b87aee01cf591a10e36a3f14dbff696984bd6682b845f6fdbf1217195e910f241a4f78
   languageName: node
   linkType: hard
 
@@ -11946,6 +12094,13 @@ __metadata:
   languageName: node
   linkType: hard
 
+"chardet@npm:^2.1.1":
+  version: 2.1.1
+  resolution: "chardet@npm:2.1.1"
+  checksum: 4e3dba2699018b79bb90a9562b5e5be27fcaab55250c12fa72f026b859fb24846396c346968546c14efc69b9f23aca3ef2b9816775012d08a4686ce3c362415c
+  languageName: node
+  linkType: hard
+
 "charenc@npm:0.0.2, charenc@npm:~0.0.1":
   version: 0.0.2
   resolution: "charenc@npm:0.0.2"
@@ -12430,6 +12585,16 @@ __metadata:
   version: 2.14.1
   resolution: "commander@npm:2.14.1"
   checksum: 26bd49febeac8efabb7488fb5a4a2480b04bc4c4eef3c50da93eead72959f7a5232d003deda5b9761937205721274e80108f6d1d2b45ae7a8387cfb92031084e
+  languageName: node
+  linkType: hard
+
+"comment-json@npm:^4.2.3":
+  version: 4.6.2
+  resolution: "comment-json@npm:4.6.2"
+  dependencies:
+    array-timsort: ^1.0.3
+    esprima: ^4.0.1
+  checksum: d235957843363c562ce6df85dd17cabe908e515ff8d7641cc90fdda624c1d3b73a85aec1bfe6a6601c3cc6ce8132aaa5dc35f99b0404d26c0a1f119fe97534ff
   languageName: node
   linkType: hard
 
@@ -13456,7 +13621,7 @@ __metadata:
   languageName: node
   linkType: hard
 
-"decode-uri-component@npm:^0.2.0":
+"decode-uri-component@npm:^0.2.0, decode-uri-component@npm:^0.2.2":
   version: 0.2.2
   resolution: "decode-uri-component@npm:0.2.2"
   checksum: 95476a7d28f267292ce745eac3524a9079058bbb35767b76e3ee87d42e34cd0275d2eb19d9d08c3e167f97556e8a2872747f5e65cbebcac8b0c98d83e285f139
@@ -13958,6 +14123,13 @@ __metadata:
   version: 10.0.0
   resolution: "dotenv@npm:10.0.0"
   checksum: f412c5fe8c24fbe313d302d2500e247ba8a1946492db405a4de4d30dd0eb186a88a43f13c958c5a7de303938949c4231c56994f97d05c4bc1f22478d631b4005
+  languageName: node
+  linkType: hard
+
+"drange@npm:^1.0.2":
+  version: 1.1.1
+  resolution: "drange@npm:1.1.1"
+  checksum: 7e6ed639f9ab4d826e79717e2b0685a7ab02ecd39dac6483305dcc43ea2a27dc78b538e10adaba35c086efab216ef1f53f22bc402abfd0d29454b1c5f48fecd1
   languageName: node
   linkType: hard
 
@@ -16006,6 +16178,13 @@ __metadata:
   languageName: node
   linkType: hard
 
+"fast-uri@npm:^3.0.1":
+  version: 3.1.2
+  resolution: "fast-uri@npm:3.1.2"
+  checksum: 73a6e1b04e6fcf7a09ed93316e72d643ef177d26969973784690708612141f2c2f74657120bab75bf5bbc26bfd535a32c90a8c3bc50aca50584cf01f98815afe
+  languageName: node
+  linkType: hard
+
 "fast-xml-parser@npm:^4.0.12":
   version: 4.3.2
   resolution: "fast-xml-parser@npm:4.3.2"
@@ -16186,6 +16365,20 @@ __metadata:
   dependencies:
     to-regex-range: ^5.0.1
   checksum: cc283f4e65b504259e64fd969bcf4def4eb08d85565e906b7d36516e87819db52029a76b6363d0f02d0d532f0033c9603b9e2d943d56ee3b0d4f7ad3328ff917
+  languageName: node
+  linkType: hard
+
+"filter-obj@npm:^1.1.0":
+  version: 1.1.0
+  resolution: "filter-obj@npm:1.1.0"
+  checksum: cf2104a7c45ff48e7f505b78a3991c8f7f30f28bd8106ef582721f321f1c6277f7751aacd5d83026cb079d9d5091082f588d14a72e7c5d720ece79118fa61e10
+  languageName: node
+  linkType: hard
+
+"filter-obj@npm:^3.0.0":
+  version: 3.0.0
+  resolution: "filter-obj@npm:3.0.0"
+  checksum: 93bee3cecc2bbd87cb9d786c4ba2ea36fbad5d237aec991deed419dcc892020dd46d0a77c982224ef45d922b1573c77be1588274b9d524c7389ccf8d1a91c330
   languageName: node
   linkType: hard
 
@@ -17947,6 +18140,15 @@ __metadata:
   languageName: node
   linkType: hard
 
+"iconv-lite@npm:^0.7.0":
+  version: 0.7.2
+  resolution: "iconv-lite@npm:0.7.2"
+  dependencies:
+    safer-buffer: ">= 2.1.2 < 3.0.0"
+  checksum: faf884c1f631a5d676e3e64054bed891c7c5f616b790082d99ccfbfd017c661a39db8009160268fd65fae57c9154d4d491ebc9c301f3446a078460ef114dc4b8
+  languageName: node
+  linkType: hard
+
 "icss-replace-symbols@npm:^1.1.0":
   version: 1.1.0
   resolution: "icss-replace-symbols@npm:1.1.0"
@@ -18225,6 +18427,29 @@ __metadata:
     through: ^2.3.6
     wrap-ansi: ^6.0.1
   checksum: 387ffb0a513559cc7414eb42c57556a60e302f820d6960e89d376d092e257a919961cd485a1b4de693dbb5c0de8bc58320bfd6247dfd827a873aa82a4215a240
+  languageName: node
+  linkType: hard
+
+"inquirer@npm:^8.2.5":
+  version: 8.2.7
+  resolution: "inquirer@npm:8.2.7"
+  dependencies:
+    "@inquirer/external-editor": ^1.0.0
+    ansi-escapes: ^4.2.1
+    chalk: ^4.1.1
+    cli-cursor: ^3.1.0
+    cli-width: ^3.0.0
+    figures: ^3.0.0
+    lodash: ^4.17.21
+    mute-stream: 0.0.8
+    ora: ^5.4.1
+    run-async: ^2.4.0
+    rxjs: ^7.5.5
+    string-width: ^4.1.0
+    strip-ansi: ^6.0.0
+    through: ^2.3.6
+    wrap-ansi: ^6.0.1
+  checksum: b7e39a04da31207826f675e2ff491bd35bb28efbe336e8fb49641d8353d4a312943514452fb0a23702e64f70c7e44188586880c902d67541aae579cd6564c3fb
   languageName: node
   linkType: hard
 
@@ -19857,13 +20082,6 @@ __metadata:
   languageName: node
   linkType: hard
 
-"js-sha256@npm:^0.9.0":
-  version: 0.9.0
-  resolution: "js-sha256@npm:0.9.0"
-  checksum: ffad54b3373f81581e245866abfda50a62c483803a28176dd5c28fd2d313e0bdf830e77dac7ff8afd193c53031618920f3d98daf21cbbe80082753ab639c0365
-  languageName: node
-  linkType: hard
-
 "js-tokens@npm:^3.0.0 || ^4.0.0, js-tokens@npm:^4.0.0":
   version: 4.0.0
   resolution: "js-tokens@npm:4.0.0"
@@ -20968,7 +21186,7 @@ __metadata:
   languageName: node
   linkType: hard
 
-"lru-cache@npm:^4.0.1, lru-cache@npm:^4.1.1":
+"lru-cache@npm:^4.0.1":
   version: 4.1.5
   resolution: "lru-cache@npm:4.1.5"
   dependencies:
@@ -21160,15 +21378,6 @@ __metadata:
   languageName: node
   linkType: hard
 
-"map-age-cleaner@npm:^0.1.1":
-  version: 0.1.3
-  resolution: "map-age-cleaner@npm:0.1.3"
-  dependencies:
-    p-defer: ^1.0.0
-  checksum: cb2804a5bcb3cbdfe4b59066ea6d19f5e7c8c196cd55795ea4c28f792b192e4c442426ae52524e5e1acbccf393d3bddacefc3d41f803e66453f6c4eda3650bc1
-  languageName: node
-  linkType: hard
-
 "map-cache@npm:^0.2.2":
   version: 0.2.2
   resolution: "map-cache@npm:0.2.2"
@@ -21294,17 +21503,6 @@ __metadata:
   version: 0.3.0
   resolution: "media-typer@npm:0.3.0"
   checksum: af1b38516c28ec95d6b0826f6c8f276c58aec391f76be42aa07646b4e39d317723e869700933ca6995b056db4b09a78c92d5440dc23657e6764be5d28874bba1
-  languageName: node
-  linkType: hard
-
-"mem@npm:^4.0.0":
-  version: 4.3.0
-  resolution: "mem@npm:4.3.0"
-  dependencies:
-    map-age-cleaner: ^0.1.1
-    mimic-fn: ^2.0.0
-    p-is-promise: ^2.0.0
-  checksum: cf488608e5d59c6cb68004b70de317222d4be9f857fd535dfa6a108e04f40821479c080bc763c417b1030569d303538c59d441280078cfce07fefd1c523f98ef
   languageName: node
   linkType: hard
 
@@ -21982,7 +22180,7 @@ __metadata:
   languageName: node
   linkType: hard
 
-"mimic-fn@npm:^2.0.0, mimic-fn@npm:^2.1.0":
+"mimic-fn@npm:^2.1.0":
   version: 2.1.0
   resolution: "mimic-fn@npm:2.1.0"
   checksum: d2421a3444848ce7f84bd49115ddacff29c15745db73f54041edc906c14b131a38d05298dae3081667627a59b2eb1ca4b436ff2e1b80f69679522410418b478a
@@ -23664,13 +23862,6 @@ __metadata:
   languageName: node
   linkType: hard
 
-"p-defer@npm:^1.0.0":
-  version: 1.0.0
-  resolution: "p-defer@npm:1.0.0"
-  checksum: 4271b935c27987e7b6f229e5de4cdd335d808465604644cb7b4c4c95bef266735859a93b16415af8a41fd663ee9e3b97a1a2023ca9def613dba1bad2a0da0c7b
-  languageName: node
-  linkType: hard
-
 "p-filter@npm:^2.1.0":
   version: 2.1.0
   resolution: "p-filter@npm:2.1.0"
@@ -23684,13 +23875,6 @@ __metadata:
   version: 1.0.0
   resolution: "p-finally@npm:1.0.0"
   checksum: 93a654c53dc805dd5b5891bab16eb0ea46db8f66c4bfd99336ae929323b1af2b70a8b0654f8f1eae924b2b73d037031366d645f1fd18b3d30cbd15950cc4b1d4
-  languageName: node
-  linkType: hard
-
-"p-is-promise@npm:^2.0.0":
-  version: 2.1.0
-  resolution: "p-is-promise@npm:2.1.0"
-  checksum: c9a8248c8b5e306475a5d55ce7808dbce4d4da2e3d69526e4991a391a7809bfd6cfdadd9bf04f1c96a3db366c93d9a0f5ee81d949e7b1684c4e0f61f747199ef
   languageName: node
   linkType: hard
 
@@ -23851,6 +24035,15 @@ __metadata:
   dependencies:
     p-reduce: ^2.0.0
   checksum: 8588bb8b004ee37e559c7e940a480c1742c42725d477b0776ff30b894920a3e48bddf8f60aa0ae82773e500a8fc99d75e947c450e0c2ce187aff72cc1b248f6d
+  languageName: node
+  linkType: hard
+
+"package-manager-detector@npm:^0.2.0":
+  version: 0.2.11
+  resolution: "package-manager-detector@npm:0.2.11"
+  dependencies:
+    quansync: ^0.2.7
+  checksum: cea626a294f04028ea291bf0a5a32a21e3914daef4f3959e708ae36f8f2d8097d813e8bb488f5d2b6edaf43a976c6a3d2c361ef8dd9a12c360a7129cd8e29e0f
   languageName: node
   linkType: hard
 
@@ -25346,6 +25539,25 @@ __metadata:
   languageName: node
   linkType: hard
 
+"quansync@npm:^0.2.7":
+  version: 0.2.11
+  resolution: "quansync@npm:0.2.11"
+  checksum: af484ed433f752c092d278232f68a6643e2cf0193f95ec60c84245e1f3662ef64da90f8fb1bc57dd407362ff181f246a9304ba53725dd7122f45c4a839f85a61
+  languageName: node
+  linkType: hard
+
+"query-string@npm:^7.1.3":
+  version: 7.1.3
+  resolution: "query-string@npm:7.1.3"
+  dependencies:
+    decode-uri-component: ^0.2.2
+    filter-obj: ^1.1.0
+    split-on-first: ^1.0.0
+    strict-uri-encode: ^2.0.0
+  checksum: 91af02dcd9cc9227a052841d5c2eecb80a0d6489d05625df506a097ef1c59037cfb5e907f39b84643cbfd535c955abec3e553d0130a7b510120c37d06e0f4346
+  languageName: node
+  linkType: hard
+
 "querystring-es3@npm:^0.2.0":
   version: 0.2.1
   resolution: "querystring-es3@npm:0.2.1"
@@ -25378,6 +25590,16 @@ __metadata:
   version: 0.28.0
   resolution: "ramda@npm:0.28.0"
   checksum: 44ea6e5010bba70151b6a92d8114a91915e8b5a16105cce65fae58c9d7386b812c429645e35f21141d7087568550ce383bc10ee1a65cdec951f4b69ea457e6a4
+  languageName: node
+  linkType: hard
+
+"randexp@npm:^0.5.3":
+  version: 0.5.3
+  resolution: "randexp@npm:0.5.3"
+  dependencies:
+    drange: ^1.0.2
+    ret: ^0.2.0
+  checksum: 9a4011b4b012debea545fc379a18208876fffc1179d2ac211351caf7626a3956efc4bc41e329bc5b241a671553eda58e0703933a9bcfdf90dde501ba1a2cf40a
   languageName: node
   linkType: hard
 
@@ -26460,6 +26682,13 @@ __metadata:
     onetime: ^5.1.0
     signal-exit: ^3.0.2
   checksum: f877dd8741796b909f2a82454ec111afb84eb45890eb49ac947d87991379406b3b83ff9673a46012fca0d7844bb989f45cc5b788254cf1a39b6b5a9659de0630
+  languageName: node
+  linkType: hard
+
+"ret@npm:^0.2.0":
+  version: 0.2.2
+  resolution: "ret@npm:0.2.2"
+  checksum: 774964bb413a3525e687bca92d81c1cd75555ec33147c32ecca22f3d06409e35df87952cfe3d57afff7650a0f7e42139cf60cb44e94c29dde390243bc1941f16
   languageName: node
   linkType: hard
 
@@ -27745,6 +27974,20 @@ __metadata:
   languageName: node
   linkType: hard
 
+"split-on-first@npm:^1.0.0":
+  version: 1.1.0
+  resolution: "split-on-first@npm:1.1.0"
+  checksum: 16ff85b54ddcf17f9147210a4022529b343edbcbea4ce977c8f30e38408b8d6e0f25f92cd35b86a524d4797f455e29ab89eb8db787f3c10708e0b47ebf528d30
+  languageName: node
+  linkType: hard
+
+"split-on-first@npm:^3.0.0":
+  version: 3.0.0
+  resolution: "split-on-first@npm:3.0.0"
+  checksum: 75dc27ecbac65cfbeab9a3b90cf046307220192d3d7a30e46aa0f19571cc9b4802aac813f3de2cc9b16f2e46aae72f275659b5d2614bb5369c77724d739e5f73
+  languageName: node
+  linkType: hard
+
 "split-string@npm:^3.0.1, split-string@npm:^3.0.2":
   version: 3.1.0
   resolution: "split-string@npm:3.1.0"
@@ -27990,6 +28233,13 @@ __metadata:
   dependencies:
     mixme: ^0.5.1
   checksum: 26ce872a6812d5c784fa1f042bfd403644bc1c019f64627b5012c4544830a5570bef98b47225b38120c5878b326f3d1a213cd999a2285c98b536e5e202ca5bdf
+  languageName: node
+  linkType: hard
+
+"strict-uri-encode@npm:^2.0.0":
+  version: 2.0.0
+  resolution: "strict-uri-encode@npm:2.0.0"
+  checksum: eaac4cf978b6fbd480f1092cab8b233c9b949bcabfc9b598dd79a758f7243c28765ef7639c876fa72940dac687181b35486ea01ff7df3e65ce3848c64822c581
   languageName: node
   linkType: hard
 
@@ -28891,13 +29141,6 @@ __metadata:
   languageName: node
   linkType: hard
 
-"tiny-events@npm:^1.0.1":
-  version: 1.0.1
-  resolution: "tiny-events@npm:1.0.1"
-  checksum: c1e374ee9fae6a5690c97a5a1d4edd527c5ba17e24738b97a796df189c1bd821bfbc083162b38e8b1be67ff7eb480694e44edec246f2eae5ebd61f25471f0acb
-  languageName: node
-  linkType: hard
-
 "tiny-invariant@npm:^1.3.1":
   version: 1.3.1
   resolution: "tiny-invariant@npm:1.3.1"
@@ -28940,6 +29183,13 @@ __metadata:
   languageName: node
   linkType: hard
 
+"tldts-core@npm:^6.1.86":
+  version: 6.1.86
+  resolution: "tldts-core@npm:6.1.86"
+  checksum: 0a715457e03101deff9b34cf45dcd91b81985ef32d35b8e9c4764dcf76369bf75394304997584080bb7b8897e94e20f35f3e8240a1ec87d6faba3cc34dc5a954
+  languageName: node
+  linkType: hard
+
 "tldts@npm:~5.7.112":
   version: 5.7.112
   resolution: "tldts@npm:5.7.112"
@@ -28948,6 +29198,17 @@ __metadata:
   bin:
     tldts: bin/cli.js
   checksum: 10832dab1cf4c32d1eac589ee7f301fff954b4419c1b8854599a08516b341fe22b16dd9a4d37b14446475a8812223413a76f9b7f61de6ba24df128891d62a136
+  languageName: node
+  linkType: hard
+
+"tldts@npm:~6.1.86":
+  version: 6.1.86
+  resolution: "tldts@npm:6.1.86"
+  dependencies:
+    tldts-core: ^6.1.86
+  bin:
+    tldts: bin/cli.js
+  checksum: e5c57664f73663c6c8f7770db02c0c03d6f877fe837854c72037be8092826f95b8e568962358441ef18431b80b7e40ed88391c70873ee7ec0d4344999a12e3de
   languageName: node
   linkType: hard
 
@@ -29544,6 +29805,44 @@ __metadata:
   languageName: node
   linkType: hard
 
+"typia@npm:9.7.2":
+  version: 9.7.2
+  resolution: "typia@npm:9.7.2"
+  dependencies:
+    "@samchon/openapi": ^4.7.1
+    "@standard-schema/spec": ^1.0.0
+    commander: ^10.0.0
+    comment-json: ^4.2.3
+    inquirer: ^8.2.5
+    package-manager-detector: ^0.2.0
+    randexp: ^0.5.3
+  peerDependencies:
+    typescript: ">=4.8.0 <5.10.0"
+  bin:
+    typia: lib/executable/typia.js
+  checksum: e3b3374702bf1e12b548bb46d7cb8a9ad9d3a0fbee9d15d1cda286f28a43504d83c2da5f097d5509ff4a138e13048108c60c2460616e42226405e65b77f5b7da
+  languageName: node
+  linkType: hard
+
+"typia@patch:typia@npm%3A9.7.2#./.yarn/patches/typia-npm-9.7.2-5c5d9c80b4.patch::locator=embeddedchat%40workspace%3A.":
+  version: 9.7.2
+  resolution: "typia@patch:typia@npm%3A9.7.2#./.yarn/patches/typia-npm-9.7.2-5c5d9c80b4.patch::version=9.7.2&hash=cc0415&locator=embeddedchat%40workspace%3A."
+  dependencies:
+    "@samchon/openapi": ^4.7.1
+    "@standard-schema/spec": ^1.0.0
+    commander: ^10.0.0
+    comment-json: ^4.2.3
+    inquirer: ^8.2.5
+    package-manager-detector: ^0.2.0
+    randexp: ^0.5.3
+  peerDependencies:
+    typescript: ">=4.8.0 <5.10.0"
+  bin:
+    typia: lib/executable/typia.js
+  checksum: 240a163efef623f88892b2d275082ae7339543a3ac623641b448087d07cf49f59047336eb9a72ddcbff63f208a0e9c6271d8a24e1a1b030bebfd98973782d68c
+  languageName: node
+  linkType: hard
+
 "ua-parser-js@npm:^1.0.35":
   version: 1.0.37
   resolution: "ua-parser-js@npm:1.0.37"
@@ -29569,13 +29868,6 @@ __metadata:
   bin:
     uglifyjs: bin/uglifyjs
   checksum: 7b3897df38b6fc7d7d9f4dcd658599d81aa2b1fb0d074829dd4e5290f7318dbca1f4af2f45acb833b95b1fe0ed4698662ab61b87e94328eb4c0a0d3435baf924
-  languageName: node
-  linkType: hard
-
-"ultron@npm:~1.1.0":
-  version: 1.1.1
-  resolution: "ultron@npm:1.1.1"
-  checksum: aa7b5ebb1b6e33287b9d873c6756c4b7aa6d1b23d7162ff25b0c0ce5c3c7e26e2ab141a5dc6e96c10ac4d00a372e682ce298d784f06ffcd520936590b4bc0653
   languageName: node
   linkType: hard
 
@@ -29724,15 +30016,6 @@ __metadata:
   version: 6.0.1
   resolution: "universal-user-agent@npm:6.0.1"
   checksum: fdc8e1ae48a05decfc7ded09b62071f571c7fe0bd793d700704c80cea316101d4eac15cc27ed2bb64f4ce166d2684777c3198b9ab16034f547abea0d3aa1c93c
-  languageName: node
-  linkType: hard
-
-"universal-websocket-client@npm:^1.0.2":
-  version: 1.0.2
-  resolution: "universal-websocket-client@npm:1.0.2"
-  dependencies:
-    ws: ^3.3.3
-  checksum: 6235a16d227e9a5aba752ebaaefd42a18c5ad59b15d36e1e7e102360c8b41d868da76a8f9bf6741ec88e0272cb081e863e360bbf388aefcd73bfc98c52678043
   languageName: node
   linkType: hard
 
@@ -30987,17 +31270,6 @@ __metadata:
   languageName: node
   linkType: hard
 
-"ws@npm:^3.3.3":
-  version: 3.3.3
-  resolution: "ws@npm:3.3.3"
-  dependencies:
-    async-limiter: ~1.0.0
-    safe-buffer: ~5.1.0
-    ultron: ~1.1.0
-  checksum: 20b7bf34bb88715b9e2d435b76088d770e063641e7ee697b07543815fabdb752335261c507a973955e823229d0af8549f39cc669825e5c8404aa0422615c81d9
-  languageName: node
-  linkType: hard
-
 "ws@npm:^6.2.2":
   version: 6.2.2
   resolution: "ws@npm:6.2.2"
@@ -31232,6 +31504,13 @@ __metadata:
   version: 1.2.2
   resolution: "yocto-queue@npm:1.2.2"
   checksum: 92dd9880c324dbc94ff4b677b7d350ba8d835619062b7102f577add7a59ab4d87f40edc5a03d77d369dfa9d11175b1b2ec4a06a6f8a5d8ce5d1306713f66ee41
+  languageName: node
+  linkType: hard
+
+"zod@npm:~4.3.6":
+  version: 4.3.6
+  resolution: "zod@npm:4.3.6"
+  checksum: 19cec761b46bae4b6e7e861ea740f3f248e50a6671825afc8a5758e27b35d6f20ccde9942422fd5cf6f8b697f18bd05ef8bb33f5f2db112ab25cc628de2fae47
   languageName: node
   linkType: hard
 


### PR DESCRIPTION
# Migrate from @rocket.chat/sdk to @rocket.chat/ddp-client

## Acceptance Criteria fulfillment

- [x] Replaced the legacy and deprecated `@rocket.chat/sdk` with the new official `@rocket.chat/ddp-client` package.
- [x] Refactored `EmbeddedChatApi.ts` to initialize `DDPSDK.create(host)` and establish standard DDP WebSocket sessions.
- [x] Migrated all REST calls from raw SDK wrappers to the modernized, type-safe `sdk.rest.get` and `sdk.rest.post` helper methods.
- [x] Normalised all API endpoints to clean paths 
- [x] Implemented `_syncRestCredentials()` to synchronize session tokens via `sdk.rest.setCredentials` on mount and re-authentications.
- [x] Eliminated legacy DDP method `.call(...)` invocations, replacing them with modern, standard REST endpoints.
- [x] Resolves consoleStructured data cloning crashes (`DOMException`) on caught responses by preventing direct raw Response logs.

**Known Issue (Working on it):** Attachment uploads and previews are successfully sent/uploaded, but their browser media previews yield 403 Forbidden because raw GET asset requests to `/file-upload/...` do not carry WebSocket auth headers. I am actively working on a secure solution in a separate, dedicated PR.

Fixes # (issue)

## Video/Screenshots

## PR Test Details

**Note**: The PR will be ready for live testing at https://rocketchat.github.io/EmbeddedChat/pulls/pr-1308 after approval. Contributors are requested to replace `<pr_number>` with the actual PR number.
