### PR TITLE
fix: remove trailing space in formatting toolbar tooltips

### DIFF
--- a/packages/react/src/views/ChatInput/ChatInputFormattingToolbar.js
+++ b/packages/react/src/views/ChatInput/ChatInputFormattingToolbar.js
@@ -216,7 +216,7 @@ const ChatInputFormattingToolbar = ({
           </React.Fragment>
         ) : (
           <Tooltip
-            text={`${item.name} ${item.shortcut && `(${item.shortcut})`}`}
+            text={`${item.name}${item.shortcut ? ` (${item.shortcut})` : ''}`}
             position="top"
             key={`formatter-${item.name}`}
           >
@@ -296,8 +296,10 @@ const ChatInputFormattingToolbar = ({
           if (itemInFormatter) {
             return (
               <Tooltip
-                text={`${itemInFormatter.name} ${
-                  itemInFormatter.shortcut && `(${itemInFormatter.shortcut})`
+                text={`${itemInFormatter.name}${
+                  itemInFormatter.shortcut
+                    ? ` (${itemInFormatter.shortcut})`
+                    : ''
                 }`}
                 position="top"
                 key={`formatter-${itemInFormatter.name}`}


### PR DESCRIPTION
# Fix trailing space in formatting toolbar tooltips

## Acceptance Criteria fulfillment

- [x] Tooltips for formatters **with** a shortcut still render as `name (shortcut)`
- [x] Tooltips for formatters **without** a shortcut (strike, code, multiline) render as just `name` — no trailing space
- [x] Fix applied to both the main toolbar and the small-screen toolbar

Fixes #1280

## Description

The `Tooltip` text template literal in `ChatInputFormattingToolbar.js` unconditionally inserted a space between the formatter name and the optional shortcut:

```js
text={`${item.name} ${item.shortcut && `(${item.shortcut})`}`}
```

When `item.shortcut` is an empty string (formatters like `strike`, `code`, `multiline`), `item.shortcut && ...` evaluates to `''`, but the leading space in the template was still included — so the tooltip rendered as `"strike "`, `"code "`, `"multiline "` with a trailing space.

The space is now part of the conditional, so it only appears when there is an actual shortcut:

```js
text={`${item.name}${item.shortcut ? ` (${item.shortcut})` : ''}`}
```

The same pattern existed in the small-screen toolbar block, so it was fixed there too.

## PR Test Details

1. Open the chat input formatting toolbar.
2. Hover the **strike**, **code**, and **multiline** buttons → tooltip shows the bare name, no trailing space.
3. Hover **bold** / **italic** (which have shortcuts) → tooltip still shows `name (shortcut)`.

Lint passes on the changed file (`eslint` clean; pre-existing unrelated warnings untouched).