### PR TITLE
fix: show full date in formatTimestamp for non-today timestamps

### DIFF
--- a/packages/react/src/lib/formatTimestamp.js
+++ b/packages/react/src/lib/formatTimestamp.js
@@ -10,11 +10,17 @@ const formatTimestamp = (timestamp) => {
   const options = { hour: 'numeric', minute: 'numeric', hour12: true };
   const formattedTime = date.toLocaleTimeString('en-US', options);
 
-  return isDifferentDay
-    ? `${date.toLocaleDateString('en-US', {
-        weekday: 'long',
-      })} ${formattedTime}`
-    : formattedTime;
+  if (!isDifferentDay) {
+    return formattedTime;
+  }
+
+  const formattedDate = date.toLocaleDateString('en-US', {
+    year: 'numeric',
+    month: 'short',
+    day: 'numeric',
+  });
+
+  return `${formattedDate}, ${formattedTime}`;
 };
 
 export default formatTimestamp;


### PR DESCRIPTION
# Show a full date for non-today timestamps in `formatTimestamp`

## Acceptance Criteria fulfillment

- [x] Timestamps from a previous day show an unambiguous date **with year**
- [x] Same-day timestamps still render as time-only
- [x] Output is consistent with the adjacent `createdAt` field and message dates

Fixes #1313

## Description

`formatTimestamp` (`packages/react/src/lib/formatTimestamp.js`) rendered any timestamp not from the current day as just a weekday + time:

```js
return isDifferentDay
  ? `${date.toLocaleDateString('en-US', { weekday: 'long' })} ${formattedTime}`
  : formattedTime;
```

Since `isDifferentDay` only means "not today", every past timestamp collapsed to a bare weekday. In the **Last login** field of the User Information panel this is ambiguous — a login from months (or over a year) ago is indistinguishable from a recent one, and no year is ever shown.

The fix returns time-only for same-day timestamps (unchanged) and a full date with year otherwise.

### Before / After

| timestamp | before | after |
|-----------|--------|-------|
| 90 days ago | `Tuesday 10:49 PM` | `Mar 3, 2026, 10:49 PM` |
| 400 days ago | `Sunday 10:49 PM` | `Apr 27, 2025, 10:49 PM` |
| today | `10:49 PM` | `10:49 PM` |

This matches how the adjacent **created at** field (`formatTimestampGetDate`) and message dates (`date-fns`) are already formatted.

## PR Test Details

Open a User Information panel for a user whose last login was on a previous day → **Last login** now shows a dated, unambiguous value instead of a bare weekday. `eslint` passes clean on the changed file.