### PR TITLE
fix: convert all emoji shortnames in a message, not just the last

### DIFF
--- a/packages/react/src/lib/emoji.js
+++ b/packages/react/src/lib/emoji.js
@@ -1,12 +1,3 @@
 import emojione from 'emoji-toolkit';
 
-export const parseEmoji = (text) => {
-  const regx = /:([^:]*):/g;
-  const regx_data = text.match(regx);
-  if (regx_data) {
-    const result = regx_data[regx_data.length - 1];
-    const d = emojione.shortnameToUnicode(result);
-    if (d !== undefined) text = text.replace(result, d);
-  }
-  return text;
-};
+export const parseEmoji = (text) => emojione.shortnameToUnicode(text);


### PR DESCRIPTION
### Closes #1315

### Problem
`parseEmoji` collected every `:shortname:` match but then picked only the **last** one and ran a single `String.replace`, which swaps the **first** occurrence of that match. As a result a message with multiple shortnames left all but one as raw text:

- `":smile: and :heart:"` → `":smile: and ❤️"` (first emoji not converted)
- `":tada: foo :tada:"` → `"🎉 foo :tada:"` (wrong occurrence converted)

Most visible on **pasted text** and on **attachment captions** (`AttachmentPreview` parses the whole description once on submit). Incremental typing masked it because each shortname was converted as it completed.

### Fix
`emoji-toolkit`'s `shortnameToUnicode()` already converts every shortname in a string and leaves unknown shortnames and plain text untouched, so the hand-rolled match/replace is both buggy and unnecessary:

```js
export const parseEmoji = (text) => emojione.shortnameToUnicode(text);
```

### Verification
Checked against `emoji-toolkit@9.0.1` (the version this package depends on):

| Input | Before | After |
|---|---|---|
| `:smile: and :heart:` | `:smile: and ❤️` | `😄 and ❤️` |
| `:tada: foo :tada:` | `🎉 foo :tada:` | `🎉 foo 🎉` |
| `:not_real_xyz: :smile:` | `:not_real_xyz: 😄` | `:not_real_xyz: 😄` |
| `no emoji here` | unchanged | unchanged |

Plain text and unknown shortnames are preserved.