### PR TITLE
fix: store raw permissions so change-detection in useFetchChatData works

### DIFF
--- a/packages/react/src/hooks/useFetchChatData.js
+++ b/packages/react/src/hooks/useFetchChatData.js
@@ -107,6 +107,7 @@ const useFetchChatData = (showRoles) => {
         const permissionsMap = createPermissionsMap(permissions);
 
         permissionsRef.current = {
+          raw: permissions,
           map: permissionsMap,
         };
 


### PR DESCRIPTION
### Closes #1317

### Problem
`fetchAndSetPermissions` guards re-applying permissions with:

```js
JSON.stringify(permissions) !== JSON.stringify(permissionsRef.current.raw)
```

…but the ref was only ever set to `{ map: permissionsMap }` — `.raw` is never written. So the comparison reads `undefined` every time and is always truthy, meaning the permission map is rebuilt and `applyPermissions` (six zustand setters) runs on **every** call, even when permissions haven't changed. The change-detection is dead code.

### Fix
Store the raw permissions next to the map so the guard can actually compare:

```js
permissionsRef.current = {
  raw: permissions,
  map: permissionsMap,
};
```

Now an unchanged permissions payload short-circuits and returns the cached map, avoiding redundant setter calls / re-renders. One-line, behavior-preserving for the changed-permissions path.