### PR TITLE
fix: resolve login crash, infinite renders, and logout scroll bugs

### DIFF
--- a/packages/react/src/views/ChatBody/ChatBody.js
+++ b/packages/react/src/views/ChatBody/ChatBody.js
@@ -86,6 +86,11 @@ const ChatBody = ({
     (state) => state.isUserAuthenticated
   );
 
+  const isUserAuthenticatedRef = useRef(isUserAuthenticated);
+  useEffect(() => {
+    isUserAuthenticatedRef.current = isUserAuthenticated;
+  }, [isUserAuthenticated]);
+
   const username = useUserStore((state) => state.username);
 
   const { getMessagesAndRoles, fetchAndSetPermissions, permissionsRef } =
@@ -217,7 +222,8 @@ const ChatBody = ({
       if (
         messageListRef.current.scrollTop === 0 &&
         !loadingOlderMessages &&
-        hasMoreMessages
+        hasMoreMessages &&
+        (isUserAuthenticatedRef.current || anonymousMode)
       ) {
         setLoadingOlderMessages(true);
 

--- a/packages/react/src/views/EmbeddedChat.js
+++ b/packages/react/src/views/EmbeddedChat.js
@@ -26,11 +26,13 @@ import GlobalStyles from './GlobalStyles';
 import { overrideECProps } from '../lib/overrideECProps';
 
 const EmbeddedChat = (props) => {
-  const [config, setConfig] = useState(() => props);
+  const [remoteOverrides, setRemoteOverrides] = useState({});
 
-  useEffect(() => {
-    setConfig(props);
-  }, [props]);
+  const config = useMemo(
+    () => ({ ...props, ...remoteOverrides }),
+    // eslint-disable-next-line react-hooks/exhaustive-deps
+    [props, remoteOverrides]
+  );
 
   const {
     isClosable = false,
@@ -52,13 +54,17 @@ const EmbeddedChat = (props) => {
     className = '',
     style = {},
     hideHeader = false,
-    auth = {
-      flow: 'PASSWORD',
-    },
+    auth: authProp = null,
     secure = false,
     dark = false,
     remoteOpt = false,
   } = config;
+
+  const auth = useMemo(
+    () => authProp ?? { flow: 'PASSWORD' },
+    // eslint-disable-next-line react-hooks/exhaustive-deps
+    [authProp?.flow, authProp?.credentials]
+  );
 
   const hasMounted = useRef(false);
   const { classNames, styleOverrides } = useComponentOverrides('EmbeddedChat');
@@ -208,7 +214,7 @@ const EmbeddedChat = (props) => {
 
         if (appInfo) {
           const remoteConfig = appInfo.propConfig;
-          setConfig((prevConfig) => overrideECProps(prevConfig, remoteConfig));
+          setRemoteOverrides((prev) => overrideECProps(prev, remoteConfig));
         }
       } catch (error) {
         console.error('Error fetching remote config:', error?.message || error);
@@ -219,7 +225,7 @@ const EmbeddedChat = (props) => {
     if (remoteOpt) {
       getConfig();
     }
-  }, [RCInstance, remoteOpt, setConfig, setIsSynced]);
+  }, [RCInstance, remoteOpt, setIsSynced]);
 
   const ECOptions = useMemo(
     () => ({

--- a/packages/ui-elements/src/components/Modal/Modal.js
+++ b/packages/ui-elements/src/components/Modal/Modal.js
@@ -72,4 +72,4 @@ export const Modal = forwardRef(
   }
 );
 
-Modal.displayName = Modal;
+Modal.displayName = 'Modal';


### PR DESCRIPTION
# Fix: Resolve Login Crash, Infinite Renders, and Logout Scroll Bugs


## Acceptance Criteria fulfillment

- [x]  Fix DataCloneError and modal unresponsiveness when clicking the "show password" icon.
- [x]  Fix the bug where successful login does not render the chat window.
- [x] Eliminate the infinite re-render loop that bombarded the /api/v1/login endpoint with requests (429 Too Many Requests).
- [x] Verify changes work gracefully in both development and build environments.

## Video/Screenshots

https://github.com/user-attachments/assets/fa083ea8-fd85-4047-91af-423425c537b5

## PR Test Details

**Note**: The PR will be ready for live testing at https://rocketchat.github.io/EmbeddedChat/pulls/pr-1319 after approval. Contributors are requested to replace `<pr_number>` with the actual PR number.
