### PR TITLE
fix: replace deprecated MongoDB query/field params with explicit REST params

### DIFF
--- a/packages/api/src/EmbeddedChatApi.ts
+++ b/packages/api/src/EmbeddedChatApi.ts
@@ -544,35 +544,23 @@ export default class EmbeddedChatApi {
     this.sdk.connection.close();
   }
 
-  /**
-   * @param {boolean} anonymousMode
-   * @param {Object} options This object should include query or fields.
-   * query - json object which accepts MongoDB query operators.
-   * fields - json object with properties that have either 1 or 0 to include them or exclude them
-   * @returns messages
-   */
   async getMessages(
     anonymousMode = false,
     options: {
-      query?: object | undefined;
-      field?: object | undefined;
-    } = {
-      query: undefined,
-      field: undefined,
-    },
+      oldest?: string;
+      latest?: string;
+      count?: number;
+    } = {},
     isChannelPrivate = false
   ) {
     const roomType = isChannelPrivate ? "groups" : "channels";
     const endp = anonymousMode ? "anonymousread" : "messages";
-    const query = options?.query
-      ? `&query=${JSON.stringify(options.query)}`
-      : "";
-    const field = options?.field
-      ? `&field=${JSON.stringify(options.field)}`
-      : "";
+    const oldest = options?.oldest ? `&oldest=${options.oldest}` : "";
+    const latest = options?.latest ? `&latest=${options.latest}` : "";
+    const count = options?.count != null ? `&count=${options.count}` : "";
     try {
       return await this._restRequest(
-        `/v1/${roomType}.${endp}?roomId=${this.rid}${query}${field}`
+        `/v1/${roomType}.${endp}?roomId=${this.rid}${oldest}${latest}${count}`
       );
     } catch (err: any) {
       console.error(err instanceof Error ? err.message : err);
@@ -583,28 +571,22 @@ export default class EmbeddedChatApi {
   async getOlderMessages(
     anonymousMode = false,
     options: {
-      query?: object | undefined;
-      field?: object | undefined;
+      oldest?: string;
+      latest?: string;
+      count?: number;
       offset?: number;
-    } = {
-      query: undefined,
-      field: undefined,
-      offset: 50,
-    },
+    } = {},
     isChannelPrivate = false
   ) {
     const roomType = isChannelPrivate ? "groups" : "channels";
     const endp = anonymousMode ? "anonymousread" : "messages";
-    const query = options?.query
-      ? `&query=${JSON.stringify(options.query)}`
-      : "";
-    const field = options?.field
-      ? `&field=${JSON.stringify(options.field)}`
-      : "";
-    const offset = options?.offset ? options.offset : 0;
+    const oldest = options?.oldest ? `&oldest=${options.oldest}` : "";
+    const latest = options?.latest ? `&latest=${options.latest}` : "";
+    const count = options?.count != null ? `&count=${options.count}` : "";
+    const offset = options?.offset ? `&offset=${options.offset}` : "&offset=0";
     try {
       return await this._restRequest(
-        `/v1/${roomType}.${endp}?roomId=${this.rid}${query}${field}&offset=${offset}`
+        `/v1/${roomType}.${endp}?roomId=${this.rid}${oldest}${latest}${count}${offset}`
       );
     } catch (err: any) {
       console.error(err instanceof Error ? err.message : String(err));

--- a/packages/react/src/hooks/useFetchChatData.js
+++ b/packages/react/src/hooks/useFetchChatData.js
@@ -10,7 +10,7 @@ import {
 } from '../store';
 
 const useFetchChatData = (showRoles) => {
-  const { RCInstance, ECOptions } = useContext(RCContext);
+  const { RCInstance } = useContext(RCContext);
   const setMemberRoles = useMemberStore((state) => state.setMemberRoles);
   const isChannelPrivate = useChannelStore((state) => state.isChannelPrivate);
   const setMessages = useMessageStore((state) => state.setMessages);
@@ -129,15 +129,7 @@ const useFetchChatData = (showRoles) => {
 
         const { messages, count } = await RCInstance.getMessages(
           anonymousMode,
-          ECOptions?.enableThreads
-            ? {
-                query: {
-                  tmid: {
-                    $exists: false,
-                  },
-                },
-              }
-            : undefined,
+          undefined,
           anonymousMode ? false : isChannelPrivate
         );
 
@@ -175,7 +167,6 @@ const useFetchChatData = (showRoles) => {
     [
       isUserAuthenticated,
       RCInstance,
-      ECOptions?.enableThreads,
       isChannelPrivate,
       showRoles,
       setMessages,

--- a/packages/react/src/views/ChatBody/ChatBody.js
+++ b/packages/react/src/views/ChatBody/ChatBody.js
@@ -224,16 +224,7 @@ const ChatBody = ({
         try {
           const olderMessages = await RCInstance.getOlderMessages(
             anonymousMode,
-            ECOptions?.enableThreads
-              ? {
-                  query: {
-                    tmid: {
-                      $exists: false,
-                    },
-                  },
-                  offset,
-                }
-              : undefined,
+            { offset },
             anonymousMode ? false : isChannelPrivate
           );
           const messageList = messageListRef.current;
@@ -280,7 +271,6 @@ const ChatBody = ({
     hasMoreMessages,
     RCInstance,
     isChannelPrivate,
-    ECOptions?.enableThreads,
     loadingOlderMessages,
     setScrollPosition,
     setIsUserScrolledUp,


### PR DESCRIPTION
# fix: replace deprecated MongoDB query/field params with explicit REST params


## Acceptance Criteria fulfillment

- [x] Remove query and field params (raw MongoDB operators) from getMessages and getOlderMessages, these were removed in RC 8.x
- [x] Replace with explicit, supported REST params: oldest, latest, count, offset
- [x] Update callers (useFetchChatData, ChatBody) to drop the now-invalid `query: { tmid: { $exists: false } }` option

## Video/Screenshots

## PR Test Details

**Note**: The PR will be ready for live testing at https://rocketchat.github.io/EmbeddedChat/pulls/pr-1321 after approval. Contributors are requested to replace `<pr_number>` with the actual PR number.
