### PR TITLE
fix: resolve private channel error-room-not-found race condition

### DIFF
--- a/packages/react/src/hooks/useFetchChatData.js
+++ b/packages/react/src/hooks/useFetchChatData.js
@@ -11,11 +11,10 @@ import {
 
 const useFetchChatData = (showRoles) => {
   const { RCInstance } = useContext(RCContext);
-  const setMemberRoles = useMemberStore((state) => state.setMemberRoles);
-  const isChannelPrivate = useChannelStore((state) => state.isChannelPrivate);
   const setMessages = useMessageStore((state) => state.setMessages);
   const setMessagesOffset = useMessageStore((state) => state.setMessagesOffset);
   const setAdmins = useMemberStore((state) => state.setAdmins);
+  const setMemberRoles = useMemberStore((state) => state.setMemberRoles);
   const permissionsRef = useRef(null);
   const setStarredMessages = useStarredMessageStore(
     (state) => state.setStarredMessages
@@ -127,10 +126,26 @@ const useFetchChatData = (showRoles) => {
           return;
         }
 
+        let channelIsPrivate = false;
+        if (!anonymousMode) {
+          const { channelInfo, setChannelInfo, setIsChannelPrivate } =
+            useChannelStore.getState();
+          if (channelInfo?._id) {
+            channelIsPrivate = channelInfo.t === 'p';
+          } else {
+            const res = await RCInstance.channelInfo();
+            if (res?.success) {
+              setChannelInfo(res.room);
+              channelIsPrivate = res.room.t === 'p';
+              if (channelIsPrivate) setIsChannelPrivate(true);
+            }
+          }
+        }
+
         const { messages, count } = await RCInstance.getMessages(
           anonymousMode,
           undefined,
-          anonymousMode ? false : isChannelPrivate
+          channelIsPrivate
         );
 
         if (messages) {
@@ -143,7 +158,7 @@ const useFetchChatData = (showRoles) => {
         }
 
         if (showRoles) {
-          const { roles } = await RCInstance.getChannelRoles(isChannelPrivate);
+          const { roles } = await RCInstance.getChannelRoles(channelIsPrivate);
           const fetchedRoles = await RCInstance.getUserRoles();
           const fetchedAdmins = fetchedRoles?.result;
 
@@ -167,7 +182,6 @@ const useFetchChatData = (showRoles) => {
     [
       isUserAuthenticated,
       RCInstance,
-      isChannelPrivate,
       showRoles,
       setMessages,
       setAdmins,


### PR DESCRIPTION
# fix: resolve private channel error-room-not-found race condition

## Acceptance Criteria fulfillment

- [x]  Private channels load correctly for members using groups.messages endpoint
- [x]  Public channels and anonymous mode are unaffected

## Root Cause
When a user authenticated, two effects fired simultaneously:

1. ChatHeader → getChannelInfo() → sets isChannelPrivate = true in the store
2. ChatBody → getMessagesAndRoles() → reads isChannelPrivate (still false) → calls channels.messages instead of groups.messages → error-room-not-found

isChannelPrivate defaulted to false, making it impossible to distinguish "not loaded yet" from "confirmed public".

## PR Test Details

**Note**: The PR will be ready for live testing at https://rocketchat.github.io/EmbeddedChat/pulls/pr-1323 after approval. Contributors are requested to replace `<pr_number>` with the actual PR number.
