### PR TITLE
fix: remove deprecated admin-role detection and fix settings 403

### DIFF
--- a/packages/api/src/EmbeddedChatApi.ts
+++ b/packages/api/src/EmbeddedChatApi.ts
@@ -618,7 +618,6 @@ export default class EmbeddedChatApi {
     }
   }
 
-
   async sendTypingStatus(username: string, typing: boolean) {
     try {
       await this.sdk.call(
@@ -897,7 +896,18 @@ export default class EmbeddedChatApi {
 
   async getMessageLimit() {
     try {
-      return await this._restRequest("/v1/settings/Message_MaxAllowedSize");
+      const response = await this._restRequest(
+        "/v1/settings.public?_id=Message_MaxAllowedSize"
+      );
+      if (
+        response &&
+        response.success &&
+        response.settings &&
+        response.settings.length > 0
+      ) {
+        return response.settings[0];
+      }
+      return null;
     } catch (err: any) {
       console.error(err instanceof Error ? err.message : err);
       return err;

--- a/packages/api/src/EmbeddedChatApi.ts
+++ b/packages/api/src/EmbeddedChatApi.ts
@@ -618,27 +618,6 @@ export default class EmbeddedChatApi {
     }
   }
 
-  async getUsersInRole(role: string) {
-    try {
-      return await this._restRequest(`/v1/roles.getUsersInRole?role=${role}`);
-    } catch (err: any) {
-      console.error(err instanceof Error ? err.message : String(err));
-      return err;
-    }
-  }
-
-  async getUserRoles() {
-    try {
-      const response = await this.getUsersInRole("admin");
-      if (response && response.success) {
-        return { result: response.users };
-      }
-      return { result: [] };
-    } catch (err) {
-      console.error(err instanceof Error ? err.message : err);
-      return { result: [] };
-    }
-  }
 
   async sendTypingStatus(username: string, typing: boolean) {
     try {

--- a/packages/react/src/hooks/useFetchChatData.js
+++ b/packages/react/src/hooks/useFetchChatData.js
@@ -13,7 +13,6 @@ const useFetchChatData = (showRoles) => {
   const { RCInstance } = useContext(RCContext);
   const setMessages = useMessageStore((state) => state.setMessages);
   const setMessagesOffset = useMessageStore((state) => state.setMessagesOffset);
-  const setAdmins = useMemberStore((state) => state.setAdmins);
   const setMemberRoles = useMemberStore((state) => state.setMemberRoles);
   const permissionsRef = useRef(null);
   const setStarredMessages = useStarredMessageStore(
@@ -159,11 +158,6 @@ const useFetchChatData = (showRoles) => {
 
         if (showRoles) {
           const { roles } = await RCInstance.getChannelRoles(channelIsPrivate);
-          const fetchedRoles = await RCInstance.getUserRoles();
-          const fetchedAdmins = fetchedRoles?.result;
-
-          const adminUsernames = fetchedAdmins?.map((user) => user.username);
-          setAdmins(adminUsernames);
 
           const rolesObj =
             roles?.length > 0
@@ -184,7 +178,6 @@ const useFetchChatData = (showRoles) => {
       RCInstance,
       showRoles,
       setMessages,
-      setAdmins,
       setMemberRoles,
     ]
   );

--- a/packages/react/src/hooks/useFetchChatData.js
+++ b/packages/react/src/hooks/useFetchChatData.js
@@ -178,6 +178,7 @@ const useFetchChatData = (showRoles) => {
       RCInstance,
       showRoles,
       setMessages,
+      setMessagesOffset,
       setMemberRoles,
     ]
   );

--- a/packages/react/src/store/memberStore.js
+++ b/packages/react/src/store/memberStore.js
@@ -5,9 +5,7 @@ const useMemberStore = create((set) => ({
   showMembers: false,
   setShowMembers: (showMembers) => set(() => ({ showMembers })),
   memberRoles: {},
-  admins: [],
   setMemberRoles: (memberRoles) => set((state) => ({ ...state, memberRoles })),
-  setAdmins: (admins) => set(() => ({ admins })),
   setMembersHandler: (memberList) => set(() => ({ members: memberList })),
 }));
 

--- a/packages/react/src/views/Message/MessageHeader.js
+++ b/packages/react/src/views/Message/MessageHeader.js
@@ -32,7 +32,6 @@ const MessageHeader = ({
   const showUsername = ECOptions?.showUsername;
   const showName = ECOptions?.showName;
   const channelLevelRoles = useMemberStore((state) => state.memberRoles);
-  const admins = useMemberStore((state) => state.admins);
 
   const isPinned = message.pinned;
   const isStarred =
@@ -137,16 +136,6 @@ const MessageHeader = ({
       )}
       {!message.t && ECOptions?.showRoles && isRoles && (
         <>
-          {admins?.includes(message?.u?.username) && (
-            <Box
-              as="span"
-              css={styles.userRole}
-              className={appendClassNames('ec-message-user-role')}
-            >
-              Admin
-            </Box>
-          )}
-
           {channelLevelRoles[message.u.username]?.roles?.map((role, index) => (
             <Box
               key={index}


### PR DESCRIPTION
# fix: remove deprecated admin-role detection and fix settings 403

## Acceptance Criteria fulfillment

- [x] Remove getUserRoles() and getUsersInRole() API methods to prevent 403 Forbidden errors for non-admin/regular users on RC 8.x.
- [x] Remove admins store state and dependencies across React hooks (useFetchChatData) and UI components (MessageHeader).
- [x] Ensure channel-level role representation (owner, moderator, etc.) via getChannelRoles remains fully functional.
- [x]  Update getMessageLimit() in EmbeddedChatApi to query `/v1/settings.public?_id=Message_MaxAllowedSize ` to resolve the 403 error on settings fetch.


## PR Test Details

**Note**: The PR will be ready for live testing at https://rocketchat.github.io/EmbeddedChat/pulls/pr-1324 after approval. Contributors are requested to replace `<pr_number>` with the actual PR number.
