### PR TITLE
Restore permission change detection in useFetchChatData

### DIFF
--- a/packages/react/src/hooks/useFetchChatData.js
+++ b/packages/react/src/hooks/useFetchChatData.js
@@ -106,6 +106,7 @@ const useFetchChatData = (showRoles) => {
         const permissionsMap = createPermissionsMap(permissions);
 
         permissionsRef.current = {
+          raw: permissions,
           map: permissionsMap,
         };
 


### PR DESCRIPTION
## Overview

`fetchAndSetPermissions` in `packages/react/src/hooks/useFetchChatData.js` is designed to fetch permissions and **only** rebuild and re-apply them when they have actually changed since the last fetch. That optimization was silently
broken — the change-detection guard could never short-circuit, so permissions were rebuilt and re-applied on every call. This PR fixes the root cause with a one-line change.

Fixes #1317

## Root cause

The function caches the previous result in `permissionsRef` and guards its work by comparing the incoming permissions against the previously stored **raw** permissions:

```js
JSON.stringify(permissions) !== JSON.stringify(permissionsRef.current.raw)
```

However, the ref was only ever assigned `{ map: permissionsMap }`, leaving `.raw` permanently `undefined`. The guard therefore reduced to `someJSONString !== undefined`, which is **always `true`** — so the
change-detection never took effect.

## Impact

Because the guard never short-circuited, every invocation of `fetchAndSetPermissions` would:

- Rebuild the permissions `Map` via `createPermissionsMap`, and
- Run `applyPermissions`, firing all six Zustand permission setters (`viewUserInfo`, `deleteMessage`, `deleteOwnMessage`, `forceDeleteMessage`, `userPin`, `editMessage`).

This resulted in redundant store writes and unnecessary re-renders even when the permissions returned by the server had not changed.

## Fix

Persist the raw permissions alongside the map so the comparison has a real previous value and can correctly skip the work when nothing changed:

```js
permissionsRef.current = {
  raw: permissions,
  map: permissionsMap,
};
```

- **Files changed:** 1 — `packages/react/src/hooks/useFetchChatData.js`
- **Lines changed:** +1
- No public API, signature, or behavioral change when permissions *do* change; unchanged permissions simply no longer trigger redundant work.

## Acceptance Criteria fulfillment

- [x] `fetchAndSetPermissions` no longer rebuilds the permissions map on every call
- [x] `applyPermissions` and the six permission setters only run when permissions actually change
- [x] Permission updates continue to apply correctly when permissions change
- [x] Change is minimal and scoped to the affected hook

## How to test

1. Open a channel and confirm permission-gated actions still work: edit message, delete message, delete own message, force delete, pin message, and view full user info.
2. Trigger `fetchAndSetPermissions` repeatedly with **unchanged** permissions and confirm the six setters no longer fire on each call (no redundant updates).
3. Change a relevant permission on the server, fetch again, and confirm the new permissions are applied correctly.

## Video/Screenshots

N/A — no visual change. This PR removes redundant state updates; user-facing
behavior is identical when permissions actually change.
