### PR TITLE
fix: add error boundaries to prevent full app crashes (#1270)

### DIFF
--- a/.changeset/react-error-boundary.md
+++ b/.changeset/react-error-boundary.md
@@ -1,0 +1,5 @@
+---
+'@embeddedchat/react': patch
+---
+
+Added React Error Boundaries to prevent application crashes on component errors.

--- a/packages/react/src/views/ChatLayout/ChatLayout.js
+++ b/packages/react/src/views/ChatLayout/ChatLayout.js
@@ -1,5 +1,6 @@
 import React, { useEffect, useRef, useCallback } from 'react';
 import { Box, useComponentOverrides } from '@embeddedchat/ui-elements';
+import { ErrorBoundary } from '../ErrorBoundary';
 import styles from './ChatLayout.styles';
 import {
   useChannelStore,
@@ -143,17 +144,21 @@ const ChatLayout = () => {
       onDrop={(e) => handleDragDrop(e)}
     >
       <Box css={styles.chatMain}>
-        <ChatBody
-          anonymousMode={anonymousMode}
-          showRoles={showRoles}
-          messageListRef={messageListRef}
-          scrollToBottom={scrollToBottom}
-          clearUnreadDividerRef={clearUnreadDividerRef}
-        />
-        <ChatInput
-          scrollToBottom={scrollToBottom}
-          clearUnreadDividerRef={clearUnreadDividerRef}
-        />
+        <ErrorBoundary>
+          <ChatBody
+            anonymousMode={anonymousMode}
+            showRoles={showRoles}
+            messageListRef={messageListRef}
+            scrollToBottom={scrollToBottom}
+            clearUnreadDividerRef={clearUnreadDividerRef}
+          />
+        </ErrorBoundary>
+        <ErrorBoundary>
+          <ChatInput
+            scrollToBottom={scrollToBottom}
+            clearUnreadDividerRef={clearUnreadDividerRef}
+          />
+        </ErrorBoundary>
         <div id="emoji-popup" />
       </Box>
 

--- a/packages/react/src/views/EmbeddedChat.js
+++ b/packages/react/src/views/EmbeddedChat.js
@@ -31,6 +31,8 @@ import { styles } from './EmbeddedChat.styles';
 import GlobalStyles from './GlobalStyles';
 import { overrideECProps } from '../lib/overrideECProps';
 
+import { ErrorBoundary } from './ErrorBoundary';
+
 const EmbeddedChat = (props) => {
   const [remoteOverrides, setRemoteOverrides] = useState({});
 
@@ -288,37 +290,39 @@ const EmbeddedChat = (props) => {
 
   return (
     <ThemeProvider theme={resolvedTheme} mode={dark ? 'dark' : 'light'}>
-      <RCInstanceProvider value={RCContextValue}>
-        <Box
-          css={[
-            styles.embeddedchat(resolvedTheme, dark),
-            css`
-              width: ${width};
-              height: ${height};
-              position: relative;
-            `,
-            fullScreen && styles.fullscreen,
-          ]}
-          className={`ec-embedded-chat ${className} ${classNames}`}
-          style={{ ...style, ...styleOverrides }}
-        >
-          <GlobalStyles />
-          <ToastBarProvider position={toastBarPosition}>
-            {hideHeader ? null : (
-              <ChatHeader
-                isClosable={isClosable}
-                setClosableState={setClosableState}
-                fullScreen={fullScreen}
-                setFullScreen={setFullScreen}
-              />
-            )}
+      <ErrorBoundary>
+        <RCInstanceProvider value={RCContextValue}>
+          <Box
+            css={[
+              styles.embeddedchat(resolvedTheme, dark),
+              css`
+                width: ${width};
+                height: ${height};
+                position: relative;
+              `,
+              fullScreen && styles.fullscreen,
+            ]}
+            className={`ec-embedded-chat ${className} ${classNames}`}
+            style={{ ...style, ...styleOverrides }}
+          >
+            <GlobalStyles />
+            <ToastBarProvider position={toastBarPosition}>
+              {hideHeader ? null : (
+                <ChatHeader
+                  isClosable={isClosable}
+                  setClosableState={setClosableState}
+                  fullScreen={fullScreen}
+                  setFullScreen={setFullScreen}
+                />
+              )}
 
-            <ChatLayout />
+              <ChatLayout />
 
-            <div id="overlay-items" />
-          </ToastBarProvider>
-        </Box>
-      </RCInstanceProvider>
+              <div id="overlay-items" />
+            </ToastBarProvider>
+          </Box>
+        </RCInstanceProvider>
+      </ErrorBoundary>
     </ThemeProvider>
   );
 };

--- a/packages/react/src/views/ErrorBoundary/ErrorBoundary.js
+++ b/packages/react/src/views/ErrorBoundary/ErrorBoundary.js
@@ -1,0 +1,49 @@
+import React from 'react';
+import PropTypes from 'prop-types';
+import { Box, Button, Icon } from '@embeddedchat/ui-elements';
+import { styles } from './ErrorBoundary.styles';
+
+class ErrorBoundary extends React.Component {
+  constructor(props) {
+    super(props);
+    this.state = { hasError: false };
+  }
+
+  static getDerivedStateFromError() {
+    return { hasError: true };
+  }
+
+  componentDidCatch(error, errorInfo) {
+    console.error('ErrorBoundary caught an error:', error, errorInfo);
+  }
+
+  render() {
+    if (this.state.hasError) {
+      return (
+        <Box css={styles.errorContainer}>
+          <Icon name="report" size="3rem" color="#ff5050" css={styles.icon} />
+          <h2 css={styles.heading}>Something went wrong.</h2>
+          <p css={styles.text}>
+            The application encountered an unexpected error.
+          </p>
+          <Box css={styles.buttons}>
+            <Button onClick={() => this.setState({ hasError: false })}>
+              Try Again
+            </Button>
+            <Button onClick={() => window.location.reload()} type="primary">
+              Reload Page
+            </Button>
+          </Box>
+        </Box>
+      );
+    }
+
+    return this.props.children;
+  }
+}
+
+ErrorBoundary.propTypes = {
+  children: PropTypes.node,
+};
+
+export default ErrorBoundary;

--- a/packages/react/src/views/ErrorBoundary/ErrorBoundary.styles.js
+++ b/packages/react/src/views/ErrorBoundary/ErrorBoundary.styles.js
@@ -1,0 +1,31 @@
+import { css } from '@emotion/react';
+
+export const styles = {
+  errorContainer: css`
+    display: flex;
+    flex-direction: column;
+    align-items: center;
+    justify-content: center;
+    height: 100%;
+    width: 100%;
+    padding: 2rem;
+    text-align: center;
+    background-color: inherit;
+    color: inherit;
+  `,
+  icon: css`
+    margin-bottom: 1rem;
+  `,
+  heading: css`
+    margin-bottom: 0.5rem;
+    font-size: 1.25rem;
+  `,
+  text: css`
+    margin-bottom: 1.5rem;
+    opacity: 0.8;
+  `,
+  buttons: css`
+    display: flex;
+    gap: 1rem;
+  `,
+};

--- a/packages/react/src/views/ErrorBoundary/ErrorBoundary.test.js
+++ b/packages/react/src/views/ErrorBoundary/ErrorBoundary.test.js
@@ -1,0 +1,38 @@
+import React from 'react';
+import { render, screen, fireEvent } from '@testing-library/react';
+import { ErrorBoundary } from './index';
+
+const ProblemChild = () => {
+  throw new Error('Test Error');
+};
+
+describe('ErrorBoundary', () => {
+  beforeEach(() => {
+    jest.spyOn(console, 'error').mockImplementation(() => {});
+  });
+
+  afterEach(() => {
+    console.error.mockRestore();
+  });
+
+  test('renders children if no error', () => {
+    render(
+      <ErrorBoundary>
+        <div data-testid="child">Child Content</div>
+      </ErrorBoundary>
+    );
+
+    expect(screen.getByTestId('child')).toBeInTheDocument();
+  });
+
+  test('renders fallback UI on error and logs error', () => {
+    render(
+      <ErrorBoundary>
+        <ProblemChild />
+      </ErrorBoundary>
+    );
+
+    expect(screen.getByText('Something went wrong.')).toBeInTheDocument();
+    expect(console.error).toHaveBeenCalled();
+  });
+});

--- a/packages/react/src/views/ErrorBoundary/index.js
+++ b/packages/react/src/views/ErrorBoundary/index.js
@@ -1,0 +1,1 @@
+export { default as ErrorBoundary } from './ErrorBoundary';


### PR DESCRIPTION
Fixes #1270

## Summary
Adds React Error Boundaries to prevent single-component errors from crashing 
the entire embedded chat widget.

## Changes
- New `ErrorBoundary` component (`packages/react/src/views/ErrorBoundary/`) 
  with a fallback UI (retry + reload) using the app's existing `Box`, `Button`, 
  and `Icon` components from `@embeddedchat/ui-elements`
- Wrapped the root `EmbeddedChat` component so any unhandled error shows the 
  fallback instead of a blank screen
- Wrapped `ChatBody` and `ChatInput` separately inside `ChatLayout` so an 
  error in one doesn't take down the other
- Added a changeset (patch, @embeddedchat/react)
- Added `ErrorBoundary.test.js` using `@testing-library/react`

## Note for reviewers
`packages/react` currently has `jest` as a dependency but no working Jest 
config/test script wired up — running `npx jest` fails with 
"Cannot use import statement outside a module" since Babel isn't connected 
to Jest's transform pipeline. I added the test file following existing 
testing-library patterns used elsewhere in the codebase, but couldn't verify 
it runs locally due to this pre-existing gap. Happy to add a jest.config.js 
+ babel-jest setup as a follow-up if you'd like it in scope here.
