### PR TITLE
fix(api): remove redundant typingHandlerLock and spinlock loop

### DIFF
--- a/packages/api/src/EmbeddedChatApi.ts
+++ b/packages/api/src/EmbeddedChatApi.ts
@@ -7,8 +7,6 @@ import {
   ApiError,
 } from "@embeddedchat/auth";
 
-// mutliple typing status can come at the same time they should be processed in order.
-let typingHandlerLock = 0;
 export default class EmbeddedChatApi {
   host: string;
   rid: string;
@@ -448,13 +446,6 @@ export default class EmbeddedChatApi {
     typingUser: string;
     isTyping: boolean;
   }) {
-    // don't wait for more than 2 seconds. Though in practical, the waiting time is insignificant.
-    setTimeout(() => {
-      typingHandlerLock = 0;
-    }, 2000);
-    // eslint-disable-next-line no-empty
-    while (typingHandlerLock) {}
-    typingHandlerLock = 1;
     // move user to front if typing else remove it.
     const idx = this.typingUsers.indexOf(typingUser);
     if (idx !== -1) {
@@ -463,7 +454,6 @@ export default class EmbeddedChatApi {
     if (isTyping) {
       this.typingUsers.unshift(typingUser);
     }
-    typingHandlerLock = 0;
     const newTypingStatus = cloneArray(this.typingUsers);
     this.onTypingStatusCallbacks.forEach((callback) =>
       callback(newTypingStatus)


### PR DESCRIPTION
Hey @Aryan-Verma-999, here is the Pull Request for the issue. Please review it and let me know if you have any feedback!

### Summary
Removes the global `typingHandlerLock` variable, fallback `setTimeout`, and synchronous `while (typingHandlerLock) {}` spinlock loop from `packages/api/src/EmbeddedChatApi.ts`.

### Context & Issue
Fixes #1354.

### Logic & Implementation Details

1. **Leveraging Event-Loop Task Queue Semantics**: 
   In single-threaded JavaScript, incoming WebSocket events are queued and processed sequentially off the Event Loop. Synchronous function execution is atomic and completes without thread context switching. Therefore, mutex spinlocks like `while (lock) {}` are redundant and pose a deadlock risk if the lock remains set.

2. **Atomic Array Management**:
   `handleTypingEvent` now directly and safely performs atomic array updates:
   - Uses `indexOf` and `splice` to clear existing instances of the user from `this.typingUsers`.
   - Uses `unshift` to prepend the active typing user to the front of the list.
   - Operates in microsecond execution time with zero main-thread blocking.

3. **Clean Subscriber Broadcasting**:
   Creates an immutable copy via `cloneArray(this.typingUsers)` and broadcasts the updated status array to all `onTypingStatusCallbacks` listeners.

### Verification
- Tested rapid and concurrent typing event execution locally (`http://localhost:5173/` & `http://localhost:6006/`).
- Verified zero main-thread deadlocks or CPU spikes.
- Workspace builds cleanly via `yarn build`.
