### PR TITLE
feat: keep emoji picker open for multiple selections

### DIFF
--- a/packages/react/src/views/ChatInput/ChatInputFormattingToolbar.js
+++ b/packages/react/src/views/ChatInput/ChatInputFormattingToolbar.js
@@ -370,7 +370,6 @@ const ChatInputFormattingToolbar = ({
         <EmojiPicker
           key="emoji-picker"
           handleEmojiClick={(emoji) => {
-          
             handleEmojiClick(emoji);
           }}
           onClose={() => setEmojiOpen(false)}

--- a/packages/react/src/views/ChatInput/ChatInputFormattingToolbar.js
+++ b/packages/react/src/views/ChatInput/ChatInputFormattingToolbar.js
@@ -341,7 +341,7 @@ const ChatInputFormattingToolbar = ({
         <EmojiPicker
           key="emoji-picker"
           handleEmojiClick={(emoji) => {
-            setEmojiOpen(false);
+          
             handleEmojiClick(emoji);
           }}
           onClose={() => setEmojiOpen(false)}


### PR DESCRIPTION
fixes #1360
This change keep the emoji picker open after selecting an emoji.