### PR TITLE
Emoji Picker Fix

### DIFF
--- a/packages/react/src/views/ChatInput/ChatInputFormattingToolbar.js
+++ b/packages/react/src/views/ChatInput/ChatInputFormattingToolbar.js
@@ -296,9 +296,8 @@ const ChatInputFormattingToolbar = ({
           if (itemInFormatter) {
             return (
               <Tooltip
-                text={`${itemInFormatter.name} ${
-                  itemInFormatter.shortcut && `(${itemInFormatter.shortcut})`
-                }`}
+                text={`${itemInFormatter.name} ${itemInFormatter.shortcut && `(${itemInFormatter.shortcut})`
+                  }`}
                 position="top"
                 key={`formatter-${itemInFormatter.name}`}
               >
@@ -341,7 +340,6 @@ const ChatInputFormattingToolbar = ({
         <EmojiPicker
           key="emoji-picker"
           handleEmojiClick={(emoji) => {
-            setEmojiOpen(false);
             handleEmojiClick(emoji);
           }}
           onClose={() => setEmojiOpen(false)}


### PR DESCRIPTION
## Brief Title

Keep Emoji Picker Open for Consecutive Emoji Selection

## Acceptance Criteria fulfillment

* [x] Remove `setEmojiOpen(false)` from the `handleEmojiClick` callback in `ChatInputFormattingToolbar.js`.
* [x] Allow users to select multiple emojis consecutively without reopening the picker.
* [x] Ensure the picker still closes when clicking outside, toggling the emoji button, or sending the message.

Fixes #

## Video/Screenshots

<img width="2272" height="860" alt="Screenshot 2026-08-21 121806" src="https://github.com/user-attachments/assets/03168b43-8fb9-405c-a42e-c161774ba830" />

## PR Test Details

* Open EmbeddedChat and click the Emoji icon in the toolbar.
* Select multiple emojis consecutively, such as `😀😅❤️`.
* Verify that the Emoji Picker remains open after each selection.
* Click outside the picker and verify that it closes.
* Toggle the emoji button and verify that the picker closes.
* Send a message and verify that the picker closes as expected.

**Note**: The PR will be ready for live testing at https://rocketchat.github.io/EmbeddedChat/pulls/pr-#1362 after approval. Contributors are requested to replace `#1362` with the actual PR number.
