### PR TITLE
feat/ai-theme-generator

### DIFF
--- a/packages/layout_editor/README.md
+++ b/packages/layout_editor/README.md
@@ -46,6 +46,53 @@ To apply your custom theme:
 
 Alternatively, you can paste the theme object into the Theme settings of the EmbeddedChat RC App. Note: These settings will only take effect if the `remoteOpt` prop is set to `true` when configuring EmbeddedChat.
 
+### AI Theme Generator integration
+
+The Layout Editor can generate a complete, accessible EmbeddedChat theme from a developer's description. It talks directly to Ollama running on the developer's machine—no API key or separate proxy service is required.
+
+Install Ollama, start a local model, then open the AI Theme Generator:
+
+```bash
+ollama run gemma4
+```
+
+The default URL is `http://localhost:11434` and the default model is `gemma4`; both can be changed directly in the panel or configured at build time:
+
+```bash
+VITE_OLLAMA_BASE_URL=http://localhost:11434
+VITE_OLLAMA_MODEL=gemma4
+```
+
+The adapter selector also supports OpenAI and Google Gemini. These providers
+use the shared `@embeddedchat/ai-adapter` package; enter a development API key,
+model, and optional compatible base URL in the panel. Keys are kept in memory
+only and are never stored by the Layout Editor.
+
+If the editor is served from `http://localhost:5173` and the browser reports a
+CORS error, start Ollama once with that origin allowed:
+
+```bash
+OLLAMA_ORIGINS=http://localhost:5173 ollama serve
+```
+
+Use the actual Layout Editor origin if it differs. Ollama permits local API
+access without authentication, and can be configured to allow additional web
+origins when needed.
+
+Ollama is asked for a narrow JSON schema:
+
+```json
+{
+  "primaryHex": "#f59e0b",
+  "accentHex": "#8b5cf6",
+  "radius": "0.5rem",
+  "fontFamily": "Arial, Helvetica, sans-serif",
+  "mode": "dark"
+}
+```
+
+The generator only allows local Ollama URLs (`localhost`, `127.0.0.1`, or `::1`). Follow-up prompts include prior instructions, but patch only the explicitly requested tokens—refining corner radius or typography cannot regenerate the palette. Select **Deterministic fallback** in the adapter selector to use the offline parser instead. The browser validates the response, checks text contrast, and presents a draft before applying or exporting the final JSON.
+
 ### Development
 
 Clone the repo, navigate to `packages/layout_editor`, then run:

--- a/packages/layout_editor/package.json
+++ b/packages/layout_editor/package.json
@@ -7,11 +7,13 @@
     "dev": "vite",
     "build": "vite build",
     "lint": "eslint . --ext js,jsx --report-unused-disable-directives --max-warnings 0",
+    "test": "node --test src/lib/*.test.js",
     "preview": "vite preview"
   },
   "dependencies": {
     "@dnd-kit/core": "^6.1.0",
     "@dnd-kit/sortable": "^8.0.0",
+    "@embeddedchat/ai-adapter": "workspace:*",
     "@embeddedchat/markups": "workspace:^",
     "@embeddedchat/ui-elements": "workspace:^",
     "react": "^19.0.0",

--- a/packages/layout_editor/src/components/SortableMenu/Menu.jsx
+++ b/packages/layout_editor/src/components/SortableMenu/Menu.jsx
@@ -42,6 +42,7 @@ const Menu = ({
           icon="kebab"
           size={size}
           onClick={handleMenuVisibility}
+          style={{ color: theme.theme.colors.foreground }}
         />
       </Tooltip>
 

--- a/packages/layout_editor/src/components/SurfaceMenu/SurfaceItem.jsx
+++ b/packages/layout_editor/src/components/SurfaceMenu/SurfaceItem.jsx
@@ -30,8 +30,12 @@ const SurfaceItem = ({
         label,
       },
     });
-  const theme = useTheme();
-  const styles = getSurfaceItemStyles(theme);
+  const themeContext = useTheme();
+  const styles = getSurfaceItemStyles(themeContext);
+  const iconColor =
+    type === 'destructive'
+      ? themeContext.theme.colors.destructive
+      : themeContext.theme.colors.foreground;
 
   const style = {
     transform: CSS.Transform.toString(transform),
@@ -59,6 +63,7 @@ const SurfaceItem = ({
             color={type}
             style={{
               cursor: cursor,
+              color: iconColor,
             }}
           />
 

--- a/packages/layout_editor/src/lib/generateThemeFromColor.js
+++ b/packages/layout_editor/src/lib/generateThemeFromColor.js
@@ -1,0 +1,377 @@
+const MINIMUM_TEXT_CONTRAST = 4.5;
+
+export const FONT_STACKS = {
+  sans: 'Arial, Helvetica, sans-serif',
+  serif: 'Georgia, "Times New Roman", serif',
+  mono: '"Courier New", Courier, monospace',
+};
+
+export const THEME_RADII = ['0rem', '0.25rem', '0.5rem', '1.5rem'];
+
+const clamp = (value, minimum, maximum) =>
+  Math.min(Math.max(value, minimum), maximum);
+
+const hsl = (hue, saturation, lightness) =>
+  `hsl(${Math.round(hue)}, ${Math.round(saturation)}%, ${Math.round(
+    lightness
+  )}%)`;
+
+export const normalizeHex = (value) => {
+  if (typeof value !== 'string') return null;
+  const match = value.trim().match(/^#?([a-f\d]{3}|[a-f\d]{6})$/i);
+  if (!match) return null;
+  const hex = match[1].length === 3
+    ? match[1].split('').map((character) => character + character).join('')
+    : match[1];
+  return `#${hex.toLowerCase()}`;
+};
+
+export const hexToHsl = (value) => {
+  const hex = normalizeHex(value);
+  if (!hex) return null;
+
+  const channels = [1, 3, 5].map((offset) =>
+    Number.parseInt(hex.slice(offset, offset + 2), 16) / 255
+  );
+  const [red, green, blue] = channels;
+  const maximum = Math.max(...channels);
+  const minimum = Math.min(...channels);
+  const delta = maximum - minimum;
+  const lightness = (maximum + minimum) / 2;
+
+  let hue = 0;
+  if (delta) {
+    if (maximum === red) hue = ((green - blue) / delta) % 6;
+    if (maximum === green) hue = (blue - red) / delta + 2;
+    if (maximum === blue) hue = (red - green) / delta + 4;
+    hue *= 60;
+    if (hue < 0) hue += 360;
+  }
+
+  const saturation = delta
+    ? delta / (1 - Math.abs(2 * lightness - 1))
+    : 0;
+  return { hue, saturation: saturation * 100, lightness: lightness * 100 };
+};
+
+const hslToRgb = ({ hue, saturation, lightness }) => {
+  const normalizedSaturation = saturation / 100;
+  const normalizedLightness = lightness / 100;
+  const chroma =
+    (1 - Math.abs(2 * normalizedLightness - 1)) * normalizedSaturation;
+  const second = chroma * (1 - Math.abs(((hue / 60) % 2) - 1));
+  const match = normalizedLightness - chroma / 2;
+  let channels = [0, 0, 0];
+
+  if (hue < 60) channels = [chroma, second, 0];
+  else if (hue < 120) channels = [second, chroma, 0];
+  else if (hue < 180) channels = [0, chroma, second];
+  else if (hue < 240) channels = [0, second, chroma];
+  else if (hue < 300) channels = [second, 0, chroma];
+  else channels = [chroma, 0, second];
+
+  return channels.map((channel) => channel + match);
+};
+
+const parseHsl = (value) => {
+  const match = typeof value === 'string'
+    ? value.match(/^hsl\(\s*([\d.]+)\s*,\s*([\d.]+)%\s*,\s*([\d.]+)%\s*\)$/i)
+    : null;
+  if (!match) return null;
+  return {
+    hue: Number(match[1]) % 360,
+    saturation: Number(match[2]),
+    lightness: Number(match[3]),
+  };
+};
+
+const toRgb = (value) => {
+  const hslValue = parseHsl(value);
+  if (hslValue) return hslToRgb(hslValue);
+  const hex = normalizeHex(value);
+  if (!hex) return null;
+  return [1, 3, 5].map(
+    (offset) => Number.parseInt(hex.slice(offset, offset + 2), 16) / 255
+  );
+};
+
+export const colorToHex = (value) => {
+  const rgb = toRgb(value);
+  if (!rgb) return null;
+  return `#${rgb
+    .map((channel) =>
+      Math.round(clamp(channel, 0, 1) * 255).toString(16).padStart(2, '0')
+    )
+    .join('')}`;
+};
+
+const relativeLuminance = (value) => {
+  const rgb = toRgb(value);
+  if (!rgb) return 0;
+  const [red, green, blue] = rgb.map((channel) =>
+    channel <= 0.03928
+      ? channel / 12.92
+      : ((channel + 0.055) / 1.055) ** 2.4
+  );
+  return 0.2126 * red + 0.7152 * green + 0.0722 * blue;
+};
+
+export const contrastRatio = (first, second) => {
+  const firstLuminance = relativeLuminance(first);
+  const secondLuminance = relativeLuminance(second);
+  return (
+    (Math.max(firstLuminance, secondLuminance) + 0.05) /
+    (Math.min(firstLuminance, secondLuminance) + 0.05)
+  );
+};
+
+const contrastingText = (background) => {
+  const white = 'hsl(0, 0%, 100%)';
+  // True black is necessary here: a softened dark gray can leave highly
+  // saturated mid-tone colors below the 4.5:1 AA threshold against both
+  // foreground options.
+  const black = 'hsl(0, 0%, 0%)';
+  return contrastRatio(background, white) >= contrastRatio(background, black)
+    ? white
+    : black;
+};
+
+const TOKEN_FOREGROUNDS = {
+  background: 'foreground',
+  card: 'cardForeground',
+  popover: 'popoverForeground',
+  primary: 'primaryForeground',
+  secondary: 'secondaryForeground',
+  muted: 'mutedForeground',
+  accent: 'accentForeground',
+  destructive: 'destructiveForeground',
+  warning: 'warningForeground',
+  success: 'successForeground',
+  info: 'infoForeground',
+};
+
+const foregroundColor = (color, background, direction) => {
+  let lightness = color.lightness;
+  for (let step = 0; step <= 100; step += 1) {
+    const candidate = hsl(color.hue, color.saturation, lightness);
+    if (contrastRatio(candidate, background) >= MINIMUM_TEXT_CONTRAST) {
+      return candidate;
+    }
+    lightness = clamp(lightness + direction, 0, 100);
+  }
+  return hsl(color.hue, color.saturation, lightness);
+};
+
+const semanticScheme = (seed, accent, mode) => {
+  const primarySaturation = clamp(Math.max(seed.saturation, 70), 70, 92);
+  const accentSaturation = clamp(Math.max(accent.saturation, 62), 62, 88);
+  const isLight = mode === 'light';
+  const background = hsl(seed.hue, Math.min(seed.saturation, 14), isLight ? 99 : 8);
+  const foreground = hsl(seed.hue, Math.min(seed.saturation, 18), isLight ? 10 : 94);
+  const card = hsl(seed.hue, Math.min(seed.saturation, 12), isLight ? 100 : 12);
+  const primary = foregroundColor(
+    {
+      hue: seed.hue,
+      saturation: primarySaturation,
+      lightness: isLight ? 42 : 66,
+    },
+    background,
+    isLight ? -1 : 1
+  );
+  const secondary = hsl(seed.hue, Math.min(seed.saturation, 30), isLight ? 92 : 21);
+  const accentColor = hsl(accent.hue, accentSaturation, isLight ? 44 : 67);
+  const muted = hsl(seed.hue, Math.min(seed.saturation, 14), isLight ? 95 : 17);
+  const destructive = hsl(0, isLight ? 72 : 68, isLight ? 43 : 64);
+  const warning = hsl(38, 92, isLight ? 40 : 66);
+  const success = hsl(142, 62, isLight ? 32 : 58);
+  const info = hsl(214, 78, isLight ? 42 : 67);
+
+  return {
+    background,
+    foreground,
+    card,
+    cardForeground: contrastingText(card),
+    popover: card,
+    popoverForeground: contrastingText(card),
+    primary,
+    primaryForeground: contrastingText(primary),
+    secondary,
+    secondaryForeground: contrastingText(secondary),
+    muted,
+    mutedForeground: isLight
+      ? hsl(seed.hue, Math.min(seed.saturation, 18), 34)
+      : hsl(seed.hue, Math.min(seed.saturation, 18), 68),
+    accent: accentColor,
+    accentForeground: contrastingText(accentColor),
+    destructive,
+    destructiveForeground: contrastingText(destructive),
+    border: hsl(seed.hue, Math.min(seed.saturation, 18), isLight ? 84 : 27),
+    input: hsl(seed.hue, Math.min(seed.saturation, 18), isLight ? 84 : 27),
+    ring: primary,
+    warning,
+    warningForeground: contrastingText(warning),
+    success,
+    successForeground: contrastingText(success),
+    info,
+    infoForeground: contrastingText(info),
+  };
+};
+
+export const getAccessibilityReport = (theme) => {
+  const pairs = [
+    ['Background text', 'background', 'foreground'],
+    ['Card text', 'card', 'cardForeground'],
+    ['Primary action', 'primary', 'primaryForeground'],
+    ['Secondary action', 'secondary', 'secondaryForeground'],
+    ['Accent action', 'accent', 'accentForeground'],
+    ['Destructive action', 'destructive', 'destructiveForeground'],
+    ['Username link', 'background', 'primary'],
+    ['Message metadata', 'background', 'mutedForeground'],
+  ];
+
+  return ['light', 'dark'].flatMap((mode) =>
+    pairs.map(([label, background, foreground]) => {
+      const ratio = contrastRatio(
+        theme.schemes[mode][background],
+        theme.schemes[mode][foreground]
+      );
+      return {
+        label: `${mode === 'light' ? 'Light' : 'Dark'} ${label}`,
+        ratio: Number(ratio.toFixed(2)),
+        passes: ratio >= MINIMUM_TEXT_CONTRAST,
+      };
+    })
+  );
+};
+
+export const isValidTheme = (theme) => {
+  if (!theme?.schemes?.light || !theme?.schemes?.dark) return false;
+  return getAccessibilityReport(theme).every((result) => result.passes);
+};
+
+/**
+ * Updates one semantic token in one color mode. Background/action tokens
+ * repair their paired text token automatically, so manual palette editing
+ * keeps the generated theme accessible rather than bypassing validation.
+ */
+export const applyThemePaletteChange = (baseTheme, { mode, token, value }) => {
+  const color = normalizeHex(value);
+  if (!color || !['light', 'dark'].includes(mode) || !baseTheme?.schemes?.[mode]) {
+    return null;
+  }
+
+  const scheme = baseTheme.schemes[mode];
+  if (!(token in scheme)) return null;
+  const nextScheme = { ...scheme, [token]: color };
+  const pairedForeground = TOKEN_FOREGROUNDS[token];
+
+  if (pairedForeground) {
+    nextScheme[pairedForeground] = contrastingText(color);
+  }
+
+  if (token === 'primary') {
+    const primary = foregroundColor(
+      hexToHsl(color),
+      nextScheme.background,
+      mode === 'light' ? -1 : 1
+    );
+    nextScheme.primary = primary;
+    nextScheme.primaryForeground = contrastingText(primary);
+    nextScheme.ring = primary;
+  }
+
+  return {
+    ...baseTheme,
+    schemes: { ...baseTheme.schemes, [mode]: nextScheme },
+  };
+};
+
+/**
+ * Applies an intentional refinement without regenerating the entire palette.
+ * This is deliberately separate from initial theme generation: a request such
+ * as "make the corners rounder" must never alter the existing color tokens.
+ */
+export const applyThemeRefinement = (baseTheme, options = {}) => {
+  if (!baseTheme) return null;
+  const primary = normalizeHex(options.primaryHex);
+  const accent = normalizeHex(options.accentHex);
+  const radius = THEME_RADII.includes(options.radius)
+    ? options.radius
+    : baseTheme.radius;
+  const fontFamily = Object.values(FONT_STACKS).includes(options.fontFamily)
+    ? options.fontFamily
+    : baseTheme.typography?.default?.fontFamily;
+
+  const refineScheme = (scheme, mode) => {
+    const nextScheme = { ...scheme };
+    if (primary) {
+      const primaryColor = foregroundColor(
+        hexToHsl(primary),
+        scheme.background,
+        mode === 'light' ? -1 : 1
+      );
+      nextScheme.primary = primaryColor;
+      nextScheme.primaryForeground = contrastingText(primaryColor);
+      nextScheme.ring = primaryColor;
+    }
+    if (accent) {
+      nextScheme.accent = accent;
+      nextScheme.accentForeground = contrastingText(accent);
+    }
+    return nextScheme;
+  };
+
+  return {
+    ...baseTheme,
+    radius,
+    typography: fontFamily
+      ? {
+          ...baseTheme.typography,
+          default: { ...baseTheme.typography?.default, fontFamily },
+        }
+      : baseTheme.typography,
+    schemes: {
+      ...baseTheme.schemes,
+      light: refineScheme(baseTheme.schemes.light, 'light'),
+      dark: refineScheme(baseTheme.schemes.dark, 'dark'),
+    },
+  };
+};
+
+/**
+ * Creates a complete EmbeddedChat theme from two validated brand colors.
+ * Generated foreground tokens are selected by computed WCAG contrast, not by
+ * a model, so a provider cannot introduce inaccessible or arbitrary CSS values.
+ */
+const generateThemeFromColor = (primaryHex, baseTheme, options = {}) => {
+  const primary = hexToHsl(primaryHex);
+  if (!primary || !baseTheme) return null;
+
+  const accent = hexToHsl(options.accentHex) ?? {
+    ...primary,
+    hue: (primary.hue + 30) % 360,
+  };
+  const radius = THEME_RADII.includes(options.radius)
+    ? options.radius
+    : baseTheme.radius;
+  const fontFamily = Object.values(FONT_STACKS).includes(options.fontFamily)
+    ? options.fontFamily
+    : baseTheme.typography?.default?.fontFamily;
+
+  return {
+    ...baseTheme,
+    radius,
+    typography: fontFamily
+      ? {
+          ...baseTheme.typography,
+          default: { ...baseTheme.typography?.default, fontFamily },
+        }
+      : baseTheme.typography,
+    schemes: {
+      light: semanticScheme(primary, accent, 'light'),
+      dark: semanticScheme(primary, accent, 'dark'),
+    },
+  };
+};
+
+export default generateThemeFromColor;

--- a/packages/layout_editor/src/lib/generateThemeFromColor.test.js
+++ b/packages/layout_editor/src/lib/generateThemeFromColor.test.js
@@ -1,0 +1,245 @@
+import test from 'node:test';
+import assert from 'node:assert/strict';
+import DefaultTheme from '../theme/DefaultTheme.js';
+import generateThemeFromColor, {
+  applyThemeRefinement,
+  applyThemePaletteChange,
+  colorToHex,
+  getAccessibilityReport,
+  isValidTheme,
+  normalizeHex,
+} from './generateThemeFromColor.js';
+import {
+  applyExplicitInitialIntent,
+  createLocalSuggestion,
+  limitRefinementSuggestion,
+  requestThemeSuggestion,
+  validateThemeSuggestion,
+} from './themeGenerationService.js';
+
+test('normalizes accepted three and six digit hex colors', () => {
+  assert.equal(normalizeHex('abc'), '#aabbcc');
+  assert.equal(normalizeHex('#0F10aa'), '#0f10aa');
+  assert.equal(normalizeHex('blue'), null);
+});
+
+test('converts generated HSL tokens to color input values', () => {
+  assert.equal(colorToHex('hsl(0, 0%, 100%)'), '#ffffff');
+  assert.equal(colorToHex('hsl(0, 0%, 0%)'), '#000000');
+  assert.equal(colorToHex('not-a-color'), null);
+});
+
+test('generates complete accessible light and dark EmbeddedChat schemes', () => {
+  const theme = generateThemeFromColor('#2563eb', DefaultTheme, {
+    accentHex: '#f97316',
+    radius: '0.5rem',
+  });
+  const report = getAccessibilityReport(theme);
+
+  assert.equal(theme.radius, '0.5rem');
+  assert.ok(theme.schemes.light.primary);
+  assert.ok(theme.schemes.dark.primary);
+  assert.equal(report.length, 16);
+  assert.ok(report.every((result) => result.passes));
+});
+
+test('keeps saturated dark-mode primary actions above the AA contrast threshold', () => {
+  const theme = generateThemeFromColor('#000f94', DefaultTheme);
+  const darkPrimary = getAccessibilityReport(theme).find(
+    (result) => result.label === 'Dark Primary action'
+  );
+
+  assert.ok(darkPrimary.passes);
+  assert.ok(darkPrimary.ratio >= 4.5);
+});
+
+test('refinement only changes requested theme tokens', () => {
+  const original = generateThemeFromColor('#2563eb', DefaultTheme, {
+    accentHex: '#f97316',
+  });
+  const refined = applyThemeRefinement(original, { radius: '1.5rem' });
+
+  assert.equal(refined.radius, '1.5rem');
+  assert.deepEqual(refined.schemes, original.schemes);
+  assert.deepEqual(refined.typography, original.typography);
+});
+
+test('color refinement does not replace unrelated semantic tokens', () => {
+  const original = generateThemeFromColor('#2563eb', DefaultTheme, {
+    accentHex: '#f97316',
+  });
+  const refined = applyThemeRefinement(original, { primaryHex: '#dc2626' });
+
+  assert.notEqual(refined.schemes.light.primary, original.schemes.light.primary);
+  assert.notEqual(refined.schemes.dark.primary, original.schemes.dark.primary);
+  assert.equal(refined.schemes.light.accent, original.schemes.light.accent);
+  assert.equal(refined.schemes.dark.background, original.schemes.dark.background);
+  assert.ok(getAccessibilityReport(refined).every((result) => result.passes));
+});
+
+test('palette changes only update the selected mode and repair paired text', () => {
+  const original = generateThemeFromColor('#2563eb', DefaultTheme);
+  const refined = applyThemePaletteChange(original, {
+    mode: 'dark',
+    token: 'accent',
+    value: '#ffffff',
+  });
+
+  assert.equal(refined.schemes.dark.accent, '#ffffff');
+  assert.equal(refined.schemes.dark.accentForeground, 'hsl(0, 0%, 0%)');
+  assert.equal(refined.schemes.light.accent, original.schemes.light.accent);
+  assert.ok(isValidTheme(refined));
+});
+
+test('generated usernames and timestamps are readable on both chat backgrounds', () => {
+  const theme = generateThemeFromColor('#0003e5', DefaultTheme);
+  const metadataChecks = getAccessibilityReport(theme).filter((result) =>
+    /Username link|Message metadata/.test(result.label)
+  );
+
+  assert.equal(metadataChecks.length, 4);
+  assert.ok(metadataChecks.every((result) => result.passes));
+});
+
+test('only allows a narrow provider response contract', () => {
+  assert.deepEqual(
+    validateThemeSuggestion({
+      primaryHex: '#123456',
+      accentHex: '#abcdef',
+      radius: '0.25rem',
+      mode: 'dark',
+      fontFamily: 'Arial, Helvetica, sans-serif',
+      messageView: undefined,
+      displayName: undefined,
+      arbitraryCss: 'url(javascript:alert(1))',
+    }),
+    {
+      primaryHex: '#123456',
+      accentHex: '#abcdef',
+      radius: '0.25rem',
+      mode: 'dark',
+      fontFamily: 'Arial, Helvetica, sans-serif',
+      messageView: undefined,
+      displayName: undefined,
+    }
+  );
+  assert.throws(() => validateThemeSuggestion({ primaryHex: 'invalid' }));
+});
+
+test('local fallback extracts developer-provided theme intent without network access', () => {
+  assert.deepEqual(
+    createLocalSuggestion('A dark purple theme with amber accent and rounded corners'),
+    {
+      primaryHex: '#a855f7',
+      accentHex: '#f59e0b',
+      radius: '0.5rem',
+      fontFamily: undefined,
+      mode: 'dark',
+      messageView: undefined,
+      displayName: undefined,
+    }
+  );
+});
+
+test('initial prompts enforce explicit visual intent over an adapter response', () => {
+  assert.deepEqual(
+    applyExplicitInitialIntent(
+      {
+        primaryHex: '#ef4444',
+        accentHex: '#22c55e',
+        radius: '0rem',
+        fontFamily: 'Georgia, "Times New Roman", serif',
+        mode: 'light',
+      },
+      'violet theme with light blue accents, dark theme, pill shaped corners, professional font'
+    ),
+    {
+      primaryHex: '#8b5cf6',
+      accentHex: '#3b82f6',
+      radius: '1.5rem',
+      fontFamily: 'Arial, Helvetica, sans-serif',
+      mode: 'dark',
+    }
+  );
+});
+
+test('local follow-ups only return tokens that the developer asked to change', () => {
+  assert.deepEqual(
+    createLocalSuggestion('make it pill-shaped and light', {
+      preserveExisting: true,
+    }),
+    {
+      primaryHex: undefined,
+      accentHex: undefined,
+      radius: '1.5rem',
+      fontFamily: undefined,
+      mode: 'light',
+      messageView: undefined,
+      displayName: undefined,
+    }
+  );
+});
+
+test('initial prompts apply explicit message view intent', () => {
+  assert.equal(
+    applyExplicitInitialIntent(
+      { messageView: 'flat' },
+      'cool violet with blue accent, square shaped corners, dark theme, mono font, bubble type message view'
+    ).messageView,
+    'bubble'
+  );
+});
+
+test('model follow-ups cannot overwrite token types that were not requested', () => {
+  assert.deepEqual(
+    limitRefinementSuggestion(
+      {
+        primaryHex: '#ef4444',
+        accentHex: '#22c55e',
+        radius: '1.5rem',
+        fontFamily: 'Georgia, "Times New Roman", serif',
+        mode: 'light',
+      },
+      'Keep the palette and make the corners pill-shaped'
+    ),
+    { radius: '1.5rem' }
+  );
+});
+
+test('an explicit light or dark mode refinement overrides an adapter response', () => {
+  assert.deepEqual(
+    limitRefinementSuggestion(
+      { mode: 'dark', primaryHex: '#ef4444' },
+      'Switch to light theme'
+    ),
+    { mode: 'light' }
+  );
+  assert.deepEqual(
+    limitRefinementSuggestion(
+      { mode: 'light', accentHex: '#22c55e' },
+      'Switch to dark theme'
+    ),
+    { mode: 'dark' }
+  );
+});
+
+test('explicit corner and font refinements override an adapter response', () => {
+  assert.deepEqual(
+    limitRefinementSuggestion(
+      { radius: '0rem', fontFamily: 'Arial, Helvetica, sans-serif' },
+      'Make the corners pill-shaped and use a serif font'
+    ),
+    { radius: '1.5rem', fontFamily: 'Georgia, "Times New Roman", serif' }
+  );
+});
+
+test('does not allow direct Ollama connections to non-local hosts', async () => {
+  await assert.rejects(
+    requestThemeSuggestion({
+      description: 'blue theme',
+      baseUrl: 'http://theme.example.com',
+      model: 'gemma4',
+    }),
+    /restricted to your local machine/
+  );
+});

--- a/packages/layout_editor/src/lib/themeExport.js
+++ b/packages/layout_editor/src/lib/themeExport.js
@@ -1,0 +1,18 @@
+const serializeTheme = (theme) => JSON.stringify(theme, null, 2);
+
+export const copyThemeToClipboard = async (theme) => {
+  if (!navigator.clipboard?.writeText) {
+    throw new Error('Clipboard access is unavailable in this browser.');
+  }
+  await navigator.clipboard.writeText(serializeTheme(theme));
+};
+
+export const downloadTheme = (theme, fileName = 'embeddedchat-theme.json') => {
+  const blob = new Blob([serializeTheme(theme)], { type: 'application/json' });
+  const url = URL.createObjectURL(blob);
+  const anchor = document.createElement('a');
+  anchor.href = url;
+  anchor.download = fileName;
+  anchor.click();
+  URL.revokeObjectURL(url);
+};

--- a/packages/layout_editor/src/lib/themeGenerationService.js
+++ b/packages/layout_editor/src/lib/themeGenerationService.js
@@ -272,15 +272,22 @@ const requestAdapterSuggestion = async ({
     throw new Error(`${THEME_PROVIDERS[provider].label} requires an API key.`);
   }
 
-  const adapter = provider === 'gemini'
-    ? new GeminiAdapter({ apiKey: apiKey.trim(), model, baseUrl })
-    : new OpenAIAdapter({ apiKey: apiKey.trim(), model, baseUrl });
+  const Adapter = provider === 'gemini' ? GeminiAdapter : OpenAIAdapter;
+  const adapter = new Adapter({
+    apiKey: apiKey.trim(),
+    model,
+    baseUrl,
+    tasks: { composer: { temperature: 0, maxTokens: 300 } },
+  });
   const response = await adapter.sendPrompt(
     {
       roomId: 'layout-editor',
       userId: 'theme-generator',
       history: [],
-      metadata: { composerTransformation: true },
+      // The adapter's generic composer task provides a deterministic,
+      // short-form request profile. The prompt below still defines the
+      // theme-specific JSON contract.
+      metadata: { task: 'composer' },
     },
     getAdapterPrompt(description, context, preserveExisting)
   );

--- a/packages/layout_editor/src/lib/themeGenerationService.js
+++ b/packages/layout_editor/src/lib/themeGenerationService.js
@@ -1,0 +1,372 @@
+import {
+  FONT_STACKS,
+  THEME_RADII,
+  normalizeHex,
+} from './generateThemeFromColor.js';
+import { GeminiAdapter, OpenAIAdapter } from '@embeddedchat/ai-adapter';
+
+export const THEME_PROVIDERS = {
+  ollama: { label: 'Ollama (local)', model: 'gemma4' },
+  openai: { label: 'OpenAI', model: 'gpt-4o', baseUrl: 'https://api.openai.com/v1' },
+  gemini: {
+    label: 'Google Gemini',
+    model: 'gemini-2.0-flash',
+    baseUrl: 'https://generativelanguage.googleapis.com',
+  },
+  fallback: { label: 'Deterministic fallback' },
+};
+
+const NAMED_COLORS = {
+  red: '#ef4444', orange: '#f97316', amber: '#f59e0b', yellow: '#eab308',
+  green: '#22c55e', teal: '#14b8a6', cyan: '#06b6d4', blue: '#3b82f6',
+  indigo: '#6366f1', violet: '#8b5cf6', purple: '#a855f7', pink: '#ec4899',
+  rose: '#f43f5e', slate: '#64748b', gray: '#6b7280', black: '#0f172a',
+};
+
+export const THEME_SUGGESTION_SCHEMA = {
+  type: 'object',
+  properties: {
+    primaryHex: { type: 'string', pattern: '^#[0-9a-fA-F]{6}$' },
+    accentHex: { type: 'string', pattern: '^#[0-9a-fA-F]{6}$' },
+    radius: { enum: THEME_RADII },
+    fontFamily: { enum: Object.values(FONT_STACKS) },
+    mode: { enum: ['light', 'dark'] },
+    messageView: { enum: ['flat', 'bubble'] },
+    displayName: { enum: ['normal', 'colorize'] },
+  },
+  required: ['primaryHex'],
+  additionalProperties: false,
+};
+
+const REFINEMENT_SUGGESTION_SCHEMA = {
+  ...THEME_SUGGESTION_SCHEMA,
+  required: [],
+};
+
+const findColors = (description) => {
+  const hexes = description.match(/#(?:[a-f\d]{3}|[a-f\d]{6})\b/gi) ?? [];
+  const names = description.toLowerCase().match(/[a-z]+/g)
+    ?.map((word) => NAMED_COLORS[word]).filter(Boolean) ?? [];
+  return [...hexes, ...names].map(normalizeHex).filter(Boolean);
+};
+
+const inferRadius = (description) => {
+  const prompt = description.toLowerCase();
+  if (/\b(pill|fully rounded|very rounded|circular)\b/.test(prompt)) return '1.5rem';
+  if (/\b(rounded|round)\b/.test(prompt)) return '0.5rem';
+  if (/\b(subtle|soft corners?|slightly rounded)\b/.test(prompt)) return '0.25rem';
+  if (/\b(sharp|flat|square|squared|angular|no radius)\b/.test(prompt)) return '0rem';
+  return undefined;
+};
+
+const inferFontFamily = (description) => {
+  const prompt = description.toLowerCase();
+  if (/\b(serif|editorial|traditional)\b/.test(prompt)) return FONT_STACKS.serif;
+  if (/\b(mono|monospace|developer|code|technical)\b/.test(prompt)) return FONT_STACKS.mono;
+  if (/\b(sans|minimal|modern|friendly|professional|corporate)\b/.test(prompt)) return FONT_STACKS.sans;
+  return undefined;
+};
+
+const inferMode = (description) => {
+  const prompt = description.toLowerCase();
+  const requestedMode = prompt.match(
+    /\b(?:switch|change|set|turn)\s+(?:it\s+)?to\s+(light|dark)\b/
+  );
+  if (requestedMode) return requestedMode[1];
+
+  const namedThemeMode = prompt.match(/\b(light|dark)\s+(?:mode|theme)\b/);
+  if (namedThemeMode) return namedThemeMode[1];
+  if (/\b(dark|night)\b/.test(prompt)) return 'dark';
+  if (/\b(light|bright|day)\b/.test(prompt)) return 'light';
+  return undefined;
+};
+
+const inferMessageView = (description) => {
+  const prompt = description.toLowerCase();
+  if (/\b(bubble|bubbled)\b/.test(prompt)) return 'bubble';
+  if (/\bflat\b/.test(prompt)) return 'flat';
+  return undefined;
+};
+
+const inferDisplayName = (description) => {
+  const prompt = description.toLowerCase();
+  if (/\b(colorize|colorized|colourize|colourized)\b/.test(prompt)) {
+    return 'colorize';
+  }
+  if (/\bnormal\b.*\b(display name|username)|\b(display name|username)\b.*\bnormal\b/.test(prompt)) {
+    return 'normal';
+  }
+  return undefined;
+};
+
+const requestedRefinementFields = (description) => {
+  const prompt = description.toLowerCase();
+  const fields = new Set();
+  const preservesPalette =
+    /\b(keep|retain|preserve)\s+(?:the\s+)?(?:colou?rs?|palette|brand|primary|accent)\b/.test(
+      prompt
+    );
+
+  if (
+    findColors(description).length ||
+    (!preservesPalette &&
+      /\b(colou?r|palette|brand|primary|accent|hue|saturation|warmer|cooler|lighten|darken)\b/.test(
+        prompt
+      ))
+  ) {
+    fields.add('primaryHex');
+    fields.add('accentHex');
+  }
+  if (
+    inferRadius(description) ||
+    /\b(radius|corner|corners)\b/.test(prompt)
+  ) fields.add('radius');
+  if (
+    inferFontFamily(description) ||
+    /\b(font|typeface|typography)\b/.test(prompt)
+  ) fields.add('fontFamily');
+  if (/\b(dark|light)\s+(mode|theme)\b|\bswitch\s+to\s+(dark|light)\b/.test(prompt)) {
+    fields.add('mode');
+  }
+  if (/\b(message view|message type|bubble|flat)\b/.test(prompt)) {
+    fields.add('messageView');
+  }
+  if (/\b(display name|username|colorize|colourize)\b/.test(prompt)) {
+    fields.add('displayName');
+  }
+  return fields;
+};
+
+export const limitRefinementSuggestion = (suggestion, description) => {
+  const allowedFields = requestedRefinementFields(description);
+  const limitedSuggestion = Object.fromEntries(
+    Object.entries(suggestion).filter(([key, value]) =>
+      allowedFields.has(key) && value !== undefined
+    )
+  );
+
+  // Direct style requests are commands, not creative suggestions. An adapter
+  // may misread the surrounding conversation, so deterministic local parsing
+  // always takes precedence for shape, typography, and mode.
+  const requestedSuggestion = createLocalSuggestion(description, {
+    preserveExisting: true,
+  });
+  ['radius', 'fontFamily', 'mode', 'messageView', 'displayName'].forEach((field) => {
+    if (allowedFields.has(field) && requestedSuggestion[field]) {
+      limitedSuggestion[field] = requestedSuggestion[field];
+    }
+  });
+
+  return limitedSuggestion;
+};
+
+export const validateThemeSuggestion = (value, { allowPartial = false } = {}) => {
+  if (!value || typeof value !== 'object') {
+    throw new Error('Ollama returned an invalid theme response.');
+  }
+  const primaryHex = normalizeHex(value.primaryHex ?? value.primaryColor);
+  const accentHex = normalizeHex(value.accentHex ?? value.accentColor);
+  if (!primaryHex && !allowPartial) {
+    throw new Error('Ollama did not return a valid primaryHex color.');
+  }
+
+  return {
+    primaryHex: primaryHex ?? undefined,
+    accentHex: accentHex ?? undefined,
+    radius: THEME_RADII.includes(value.radius) ? value.radius : undefined,
+    fontFamily: Object.values(FONT_STACKS).includes(value.fontFamily)
+      ? value.fontFamily
+      : undefined,
+    mode: value.mode === 'dark' || value.mode === 'light' ? value.mode : undefined,
+    messageView: ['flat', 'bubble'].includes(value.messageView)
+      ? value.messageView
+      : undefined,
+    displayName: ['normal', 'colorize'].includes(value.displayName)
+      ? value.displayName
+      : undefined,
+  };
+};
+
+export const createLocalSuggestion = (description, { preserveExisting = false } = {}) => {
+  const colors = findColors(description);
+  return {
+    primaryHex: colors[0] ?? (preserveExisting ? undefined : '#2563eb'),
+    accentHex: colors[1] ?? undefined,
+    radius: inferRadius(description),
+    fontFamily: inferFontFamily(description),
+    mode: inferMode(description),
+    messageView: inferMessageView(description),
+    displayName: inferDisplayName(description),
+  };
+};
+
+export const applyExplicitInitialIntent = (suggestion, description) => {
+  const explicit = createLocalSuggestion(description);
+  const colors = findColors(description);
+  return {
+    ...suggestion,
+    ...(colors[0] ? { primaryHex: explicit.primaryHex } : {}),
+    ...(colors[1] ? { accentHex: explicit.accentHex } : {}),
+    ...(explicit.radius ? { radius: explicit.radius } : {}),
+    ...(explicit.fontFamily ? { fontFamily: explicit.fontFamily } : {}),
+    ...(explicit.mode ? { mode: explicit.mode } : {}),
+    ...(explicit.messageView ? { messageView: explicit.messageView } : {}),
+    ...(explicit.displayName ? { displayName: explicit.displayName } : {}),
+  };
+};
+
+const getLocalOllamaUrl = (baseUrl) => {
+  let url;
+  try {
+    url = new URL(baseUrl);
+  } catch {
+    throw new Error('Enter a valid local Ollama URL.');
+  }
+  const isLocalHost = ['localhost', '127.0.0.1', '[::1]'].includes(url.hostname);
+  if (!isLocalHost) {
+    throw new Error('Direct Ollama access is restricted to your local machine.');
+  }
+  return `${url.toString().replace(/\/$/, '')}/api/generate`;
+};
+
+const getPrompt = (description, context, preserveExisting) => `
+You create EmbeddedChat theme suggestions for developers.
+Return only JSON matching the supplied schema.
+${preserveExisting
+    ? 'This is a refinement: include only properties the latest request explicitly changes. Omit every unchanged property.'
+    : 'Create a complete initial theme suggestion.'}
+
+Existing instructions:\n${context || 'None'}
+
+Latest request:\n${description}`;
+
+const getAdapterPrompt = (description, context, preserveExisting) => `${getPrompt(
+  description,
+  context,
+  preserveExisting
+)}
+
+JSON schema:
+${JSON.stringify(
+  preserveExisting ? REFINEMENT_SUGGESTION_SCHEMA : THEME_SUGGESTION_SCHEMA
+)}`;
+
+const parseResponseText = (text) => {
+  const json = text
+    .trim()
+    .replace(/^```(?:json)?\s*/i, '')
+    .replace(/\s*```$/, '');
+  return JSON.parse(json);
+};
+
+const requestAdapterSuggestion = async ({
+  provider,
+  model,
+  baseUrl,
+  apiKey,
+  description,
+  context,
+  preserveExisting,
+}) => {
+  if (!apiKey?.trim()) {
+    throw new Error(`${THEME_PROVIDERS[provider].label} requires an API key.`);
+  }
+
+  const adapter = provider === 'gemini'
+    ? new GeminiAdapter({ apiKey: apiKey.trim(), model, baseUrl })
+    : new OpenAIAdapter({ apiKey: apiKey.trim(), model, baseUrl });
+  const response = await adapter.sendPrompt(
+    {
+      roomId: 'layout-editor',
+      userId: 'theme-generator',
+      history: [],
+      metadata: { composerTransformation: true },
+    },
+    getAdapterPrompt(description, context, preserveExisting)
+  );
+
+  const suggestion = validateThemeSuggestion(parseResponseText(response.text), {
+    allowPartial: preserveExisting,
+  });
+  return {
+    ...(preserveExisting
+      ? limitRefinementSuggestion(suggestion, description)
+      : applyExplicitInitialIntent(suggestion, description)),
+    source: provider,
+  };
+};
+
+export const requestThemeSuggestion = async ({
+  description,
+  context,
+  provider = 'ollama',
+  baseUrl,
+  model,
+  apiKey,
+  preserveExisting = false,
+  signal,
+}) => {
+  if (provider === 'fallback') {
+    return {
+      ...createLocalSuggestion(description, { preserveExisting }),
+      source: 'fallback',
+    };
+  }
+
+  if (provider !== 'ollama') {
+    try {
+      return await requestAdapterSuggestion({
+        provider,
+        model,
+        baseUrl,
+        apiKey,
+        description,
+        context,
+        preserveExisting,
+      });
+    } catch (error) {
+      throw new Error(error.message || 'The AI adapter could not generate a theme.');
+    }
+  }
+
+  const ollamaUrl = getLocalOllamaUrl(baseUrl);
+  let response;
+  try {
+    response = await fetch(ollamaUrl, {
+      method: 'POST',
+      headers: { 'Content-Type': 'application/json' },
+      signal,
+      body: JSON.stringify({
+        model,
+        prompt: getPrompt(description, context, preserveExisting),
+        format: preserveExisting
+          ? REFINEMENT_SUGGESTION_SCHEMA
+          : THEME_SUGGESTION_SCHEMA,
+        options: { temperature: 0 },
+        stream: false,
+      }),
+    });
+  } catch (error) {
+    if (error.name === 'AbortError') throw error;
+    throw new Error('Could not reach Ollama. Start it locally or use the fallback.');
+  }
+
+  if (!response.ok) {
+    throw new Error(`Ollama request failed (${response.status}). Check the model name.`);
+  }
+
+  const result = await response.json();
+  try {
+    const suggestion = validateThemeSuggestion(parseResponseText(result.response), {
+      allowPartial: preserveExisting,
+    });
+    return {
+      ...(preserveExisting
+        ? limitRefinementSuggestion(suggestion, description)
+        : applyExplicitInitialIntent(suggestion, description)),
+      source: 'ollama',
+    };
+  } catch {
+    throw new Error('Ollama returned an invalid theme response. Try the request again.');
+  }
+};

--- a/packages/layout_editor/src/views/ChatHeader/ChatHeader.jsx
+++ b/packages/layout_editor/src/views/ChatHeader/ChatHeader.jsx
@@ -19,7 +19,8 @@ import SurfaceMenu from '../../components/SurfaceMenu/SurfaceMenu';
 import useHeaderItemsStore from '../../store/headerItemsStore';
 
 const ChatHeader = () => {
-  const styles = getChatHeaderStyles(useTheme());
+  const theme = useTheme();
+  const styles = getChatHeaderStyles(theme);
   const { surfaceItems, menuItems, setSurfaceItems, setMenuItems } =
     useHeaderItemsStore((state) => ({
       surfaceItems: state.surfaceItems,
@@ -235,7 +236,11 @@ const ChatHeader = () => {
     <Box css={styles.chatHeaderParent}>
       <Box css={styles.chatHeaderChild}>
         <Box css={styles.channelDescription}>
-          <Icon name="hash" size="1.25rem" />
+          <Icon
+            name="hash"
+            size="1.25rem"
+            color={theme.theme.colors.foreground}
+          />
           <Box>
             <Heading
               level={3}

--- a/packages/layout_editor/src/views/ChatHeader/ChatHeader.styles.js
+++ b/packages/layout_editor/src/views/ChatHeader/ChatHeader.styles.js
@@ -21,6 +21,7 @@ export const getChatHeaderStyles = ({ theme, mode }) => {
       background-color: ${mode === 'light'
         ? darken(theme.colors.background, 0.03)
         : lighten(theme.colors.background, 1)};
+      color: ${theme.colors.foreground};
       width: 100%;
       z-index: 1200;
       display: flex;

--- a/packages/layout_editor/src/views/Message/Message.styles.js
+++ b/packages/layout_editor/src/views/Message/Message.styles.js
@@ -145,7 +145,7 @@ export const getMessageHeaderStyles = ({ theme }) => {
     `,
 
     userName: css`
-      color: ${theme.colors.accentForeground};
+      color: ${theme.colors.primary};
       font-weight: 700;
       letter-spacing: 0rem;
       font-size: 0.875rem;
@@ -171,7 +171,7 @@ export const getMessageHeaderStyles = ({ theme }) => {
     `,
 
     userActions: css`
-      color: ${theme.colors.accentForeground};
+      color: ${theme.colors.primary};
       letter-spacing: 0rem;
       font-size: 0.875rem;
       line-height: 1.25rem;
@@ -182,7 +182,7 @@ export const getMessageHeaderStyles = ({ theme }) => {
     `,
 
     timestamp: css`
-      color: ${theme.colors.accentForeground};
+      color: ${theme.colors.mutedForeground};
       overflow: hidden;
       text-overflow: ellipsis;
       white-space: nowrap;

--- a/packages/layout_editor/src/views/ThemeLab/AIThemePanel.jsx
+++ b/packages/layout_editor/src/views/ThemeLab/AIThemePanel.jsx
@@ -1,0 +1,763 @@
+import React, { useCallback, useEffect, useRef, useState } from 'react';
+import {
+  Box,
+  StaticSelect,
+  useTheme,
+  useToastBarDispatch,
+} from '@embeddedchat/ui-elements';
+import generateThemeFromColor, {
+  applyThemeRefinement,
+  applyThemePaletteChange,
+  colorToHex,
+  getAccessibilityReport,
+  isValidTheme,
+  normalizeHex,
+} from '../../lib/generateThemeFromColor';
+import {
+  requestThemeSuggestion,
+  THEME_PROVIDERS,
+} from '../../lib/themeGenerationService';
+import { copyThemeToClipboard, downloadTheme } from '../../lib/themeExport';
+import { getAIThemePanelStyles } from './AIThemePanel.styles';
+import ColorPicker from './ColorPicker';
+import {
+  DISPLAY_NAME_OPTIONS,
+  FONT_FAMILY_OPTIONS,
+  MESSAGE_VIEW_OPTIONS,
+} from './themeOptions';
+import useLayoutStore from '../../store/layoutStore';
+
+const SWATCH_KEYS = [
+  { key: 'background', label: 'Background' },
+  { key: 'card', label: 'Card' },
+  { key: 'primary', label: 'Primary' },
+  { key: 'accent', label: 'Accent' },
+  { key: 'foreground', label: 'Text' },
+];
+
+const RADIUS_OPTIONS = [
+  ['0rem', 'Square'],
+  ['0.25rem', 'Soft'],
+  ['0.5rem', 'Round'],
+  ['1.5rem', 'Pill'],
+];
+
+const PALETTE_GROUPS = [
+  {
+    label: 'Surfaces',
+    tokens: [
+      ['background', 'Background'], ['foreground', 'Text'],
+      ['card', 'Card'], ['cardForeground', 'Card text'],
+      ['popover', 'Popover'], ['popoverForeground', 'Popover text'],
+      ['border', 'Border'], ['input', 'Input border'], ['ring', 'Focus ring'],
+    ],
+  },
+  {
+    label: 'Actions',
+    tokens: [
+      ['primary', 'Primary'], ['primaryForeground', 'Primary text'],
+      ['secondary', 'Secondary'], ['secondaryForeground', 'Secondary text'],
+      ['accent', 'Accent'], ['accentForeground', 'Accent text'],
+      ['muted', 'Muted'], ['mutedForeground', 'Muted text'],
+    ],
+  },
+  {
+    label: 'Feedback',
+    tokens: [
+      ['destructive', 'Destructive'], ['destructiveForeground', 'Destructive text'],
+      ['warning', 'Warning'], ['warningForeground', 'Warning text'],
+      ['success', 'Success'], ['successForeground', 'Success text'],
+      ['info', 'Info'], ['infoForeground', 'Info text'],
+    ],
+  },
+];
+
+const DEFAULT_OLLAMA_URL =
+  import.meta.env.VITE_OLLAMA_BASE_URL ?? 'http://localhost:11434';
+const DEFAULT_OLLAMA_MODEL = import.meta.env.VITE_OLLAMA_MODEL ?? 'gemma4';
+const REQUEST_TIMEOUT_MS = 15_000;
+
+const mergeSuggestions = (previous, next) =>
+  Object.fromEntries(
+    Object.entries({ ...previous, ...next }).filter(
+      ([key, value]) => key !== 'source' && value !== undefined
+    )
+  );
+
+const AIThemePanel = () => {
+  const { theme, mode, setTheme, setMode } = useTheme();
+  const { messageView, displayName, setMessageView, setDisplayName } =
+    useLayoutStore((state) => ({
+      messageView: state.messageView,
+      displayName: state.displayName,
+      setMessageView: state.setMessageView,
+      setDisplayName: state.setDisplayName,
+    }));
+  const styles = getAIThemePanelStyles(theme);
+  const dispatchToastMessage = useToastBarDispatch();
+  const [open, setOpen] = useState(false);
+  const [prompt, setPrompt] = useState('');
+  const [provider, setProvider] = useState('ollama');
+  const [ollamaUrl, setOllamaUrl] = useState(DEFAULT_OLLAMA_URL);
+  const [ollamaModel, setOllamaModel] = useState(DEFAULT_OLLAMA_MODEL);
+  const [cloudUrl, setCloudUrl] = useState('');
+  const [cloudModel, setCloudModel] = useState('');
+  const [apiKey, setApiKey] = useState('');
+  const [candidate, setCandidate] = useState(null);
+  const [followUp, setFollowUp] = useState('');
+  const [visiblePalettePicker, setVisiblePalettePicker] = useState(null);
+  const [paletteMode, setPaletteMode] = useState(mode);
+  const [draftHistory, setDraftHistory] = useState([]);
+  const [isGenerating, setIsGenerating] = useState(false);
+  const [status, setStatus] = useState('Describe a brand direction to create a reviewable theme draft.');
+  const originalThemeRef = useRef(null);
+  const controllerRef = useRef(null);
+  const paletteEditRef = useRef(null);
+  const palettePickerRef = useRef(null);
+
+  const endPaletteEdit = useCallback(() => {
+    paletteEditRef.current = null;
+  }, []);
+
+  useEffect(
+    () => () => {
+      controllerRef.current?.abort();
+    },
+    []
+  );
+
+  useEffect(() => {
+    const handleClickOutside = (event) => {
+      if (palettePickerRef.current && !palettePickerRef.current.contains(event.target)) {
+        setVisiblePalettePicker(null);
+        endPaletteEdit();
+      }
+    };
+    document.addEventListener('mousedown', handleClickOutside);
+    return () => document.removeEventListener('mousedown', handleClickOutside);
+  }, [endPaletteEdit]);
+
+  const createDraft = useCallback(async ({
+    description,
+    context = [],
+    baseTheme,
+    previousSuggestion,
+    variants,
+  }) => {
+    if (!description || isGenerating) return null;
+    const controller = new AbortController();
+    const timeout = window.setTimeout(
+      () => controller.abort(),
+      REQUEST_TIMEOUT_MS
+    );
+    controllerRef.current = controller;
+    setIsGenerating(true);
+    setStatus('Creating a theme draft…');
+
+    try {
+      const suggestion = await requestThemeSuggestion({
+        description,
+        context: context.length ? context.join('\n') : undefined,
+        provider,
+        baseUrl: provider === 'ollama' ? ollamaUrl.trim() : cloudUrl.trim(),
+        model: provider === 'ollama' ? ollamaModel.trim() : cloudModel.trim(),
+        apiKey,
+        preserveExisting: Boolean(previousSuggestion),
+        signal: controller.signal,
+      });
+      const mergedSuggestion = mergeSuggestions(previousSuggestion, suggestion);
+      const generatedTheme = previousSuggestion
+        ? applyThemeRefinement(baseTheme, suggestion)
+        : generateThemeFromColor(
+            mergedSuggestion.primaryHex,
+            baseTheme,
+            mergedSuggestion
+          );
+      if (!generatedTheme || !isValidTheme(generatedTheme)) {
+        throw new Error('The generated theme did not pass accessibility validation.');
+      }
+
+      const generatedMode = mergedSuggestion.mode ?? mode;
+      const nextCandidate = {
+        theme: generatedTheme,
+        mode: generatedMode,
+        source: suggestion.source,
+        report: getAccessibilityReport(generatedTheme),
+        suggestion: mergedSuggestion,
+        context: [...context, description],
+        variants: {
+          messageView: mergedSuggestion.messageView ?? variants.messageView,
+          displayName: mergedSuggestion.displayName ?? variants.displayName,
+        },
+      };
+      setStatus(
+        suggestion.source === 'fallback'
+          ? 'Fallback draft ready. Select an adapter for model-assisted suggestions.'
+          : `${THEME_PROVIDERS[suggestion.source].label} draft ready. Review it before applying.`
+      );
+      return nextCandidate;
+    } catch (error) {
+      const message = error.name === 'AbortError'
+        ? 'Generation timed out or was cancelled. Try again or check your theme service.'
+        : error.message;
+      setStatus(message);
+      dispatchToastMessage({ type: 'error', message });
+    } finally {
+      window.clearTimeout(timeout);
+      controllerRef.current = null;
+      setIsGenerating(false);
+    }
+  }, [apiKey, cloudModel, cloudUrl, dispatchToastMessage, isGenerating, mode, ollamaModel, ollamaUrl, provider]);
+
+  const handleProviderChange = useCallback((nextProvider) => {
+    setProvider(nextProvider);
+    const configuration = THEME_PROVIDERS[nextProvider];
+    if (nextProvider === 'ollama') {
+      setOllamaModel(configuration.model);
+      return;
+    }
+    if (nextProvider !== 'fallback') {
+      setCloudModel(configuration.model);
+      setCloudUrl(configuration.baseUrl);
+    }
+  }, []);
+
+  const handleGenerate = useCallback(async () => {
+    const nextCandidate = await createDraft({
+      description: prompt.trim(),
+      baseTheme: theme,
+      variants: { messageView, displayName },
+    });
+    if (!nextCandidate) return;
+    setCandidate(nextCandidate);
+    setPaletteMode(nextCandidate.mode);
+    setDraftHistory([]);
+    setFollowUp('');
+    paletteEditRef.current = null;
+  }, [createDraft, displayName, messageView, prompt, theme]);
+
+  const handleFollowUp = useCallback(async () => {
+    if (!candidate || !followUp.trim()) return;
+    const nextCandidate = await createDraft({
+      description: followUp.trim(),
+      context: candidate.context,
+      baseTheme: candidate.theme,
+      previousSuggestion: candidate.suggestion,
+      variants: candidate.variants,
+    });
+    if (!nextCandidate) return;
+    setDraftHistory((history) => [candidate, ...history].slice(0, 5));
+    setCandidate(nextCandidate);
+    setPaletteMode(nextCandidate.mode);
+    setFollowUp('');
+    paletteEditRef.current = null;
+  }, [candidate, createDraft, followUp]);
+
+  const handleUndoDraft = useCallback(() => {
+    if (!draftHistory.length) return;
+    const [previous, ...remainingHistory] = draftHistory;
+    setCandidate(previous);
+    setPaletteMode(previous.mode);
+    setDraftHistory(remainingHistory);
+    setFollowUp('');
+    paletteEditRef.current = null;
+    setStatus('Restored the previous draft revision.');
+  }, [draftHistory]);
+
+  const handleCancel = useCallback(() => {
+    controllerRef.current?.abort();
+  }, []);
+
+  const handleApply = useCallback(() => {
+    if (!candidate) return;
+    if (!originalThemeRef.current) {
+      originalThemeRef.current = { theme, mode };
+    }
+    setTheme(candidate.theme);
+    setMode(candidate.mode);
+    setMessageView(candidate.variants.messageView);
+    setDisplayName(candidate.variants.displayName);
+    setStatus('Theme applied. Export the JSON when you are ready to use it in your website.');
+    dispatchToastMessage({ type: 'success', message: 'Accessible theme applied.' });
+  }, [
+    candidate,
+    dispatchToastMessage,
+    mode,
+    setDisplayName,
+    setMessageView,
+    setMode,
+    setTheme,
+    theme,
+  ]);
+
+  const handleReset = useCallback(() => {
+    if (!originalThemeRef.current) return;
+    setTheme(originalThemeRef.current.theme);
+    setMode(originalThemeRef.current.mode);
+    originalThemeRef.current = null;
+    setCandidate(null);
+    setStatus('Restored the theme that was active before this generator was used.');
+    dispatchToastMessage({ type: 'success', message: 'Theme restored.' });
+  }, [dispatchToastMessage, setMode, setTheme]);
+
+  const handleCopy = useCallback(async () => {
+    const exportableTheme = candidate
+      ? {
+          ...candidate.theme,
+          variants: {
+            Message: candidate.variants.messageView,
+            MessageHeader: candidate.variants.displayName,
+          },
+        }
+      : theme;
+    try {
+      await copyThemeToClipboard(exportableTheme);
+      dispatchToastMessage({ type: 'success', message: 'Theme JSON copied to clipboard.' });
+    } catch (error) {
+      dispatchToastMessage({ type: 'error', message: error.message });
+    }
+  }, [candidate, dispatchToastMessage, theme]);
+
+  const handleDownload = useCallback(() => {
+    const exportableTheme = candidate
+      ? {
+          ...candidate.theme,
+          variants: {
+            Message: candidate.variants.messageView,
+            MessageHeader: candidate.variants.displayName,
+          },
+        }
+      : theme;
+    downloadTheme(exportableTheme);
+    dispatchToastMessage({ type: 'success', message: 'Theme JSON downloaded.' });
+  }, [candidate, dispatchToastMessage, theme]);
+
+  const beginPaletteEdit = useCallback(() => {
+    if (!candidate || paletteEditRef.current === candidate) return;
+    setDraftHistory((history) => [candidate, ...history].slice(0, 5));
+    paletteEditRef.current = candidate;
+  }, [candidate]);
+
+  const handlePaletteChange = useCallback((token, value) => {
+    const color = normalizeHex(value);
+    if (!candidate || !color) return;
+
+    const nextTheme = applyThemePaletteChange(candidate.theme, {
+      mode: paletteMode,
+      token,
+      value: color,
+    });
+    if (!nextTheme || !isValidTheme(nextTheme)) {
+      setStatus('That color would fail accessibility validation. Try a different value or adjust its paired text token.');
+      return;
+    }
+
+    const suggestionKey = token === 'primary'
+      ? 'primaryHex'
+      : token === 'accent'
+        ? 'accentHex'
+        : null;
+
+    setCandidate({
+      ...candidate,
+      theme: nextTheme,
+      report: getAccessibilityReport(nextTheme),
+      suggestion: suggestionKey
+        ? { ...candidate.suggestion, [suggestionKey]: color }
+        : candidate.suggestion,
+    });
+    setStatus('Palette adjusted. All light and dark contrast checks still pass.');
+  }, [candidate, paletteMode]);
+
+  const handleStyleChange = useCallback((options) => {
+    if (!candidate) return;
+    const nextTheme = applyThemeRefinement(candidate.theme, options);
+    if (!nextTheme || !isValidTheme(nextTheme)) return;
+
+    setDraftHistory((history) => [candidate, ...history].slice(0, 5));
+    setCandidate({
+      ...candidate,
+      theme: nextTheme,
+      report: getAccessibilityReport(nextTheme),
+      suggestion: { ...candidate.suggestion, ...options },
+    });
+    setStatus('Draft style updated.');
+  }, [candidate]);
+
+  const handleVariantChange = useCallback((variant, value) => {
+    if (!candidate || candidate.variants[variant] === value) return;
+    setDraftHistory((history) => [candidate, ...history].slice(0, 5));
+    setCandidate({
+      ...candidate,
+      variants: { ...candidate.variants, [variant]: value },
+    });
+    setStatus('Draft layout updated.');
+  }, [candidate]);
+
+  const previewScheme = candidate?.theme.schemes[candidate.mode];
+  const editableScheme = candidate?.theme.schemes[paletteMode];
+
+  return (
+    <Box css={styles.panel}>
+      <button
+        type="button"
+        css={styles.header}
+        onClick={() => setOpen((value) => !value)}
+        aria-expanded={open}
+        aria-controls="ai-theme-generator-panel"
+      >
+        <Box css={styles.headerTitle}>
+          <span aria-hidden="true">✦</span>
+          <span>AI Theme Generator</span>
+          <span css={styles.badge}>Beta</span>
+        </Box>
+        <span aria-hidden="true">{open ? '▲' : '▼'}</span>
+      </button>
+
+      {open && (
+        <Box id="ai-theme-generator-panel" css={styles.body}>
+          <p css={styles.intro}>
+            Generate an accessible EmbeddedChat theme, then tune it before applying.
+          </p>
+
+          <Box css={styles.sourceRow}>
+            <label css={styles.providerLabel} htmlFor="theme-generator-provider">
+              AI adapter
+            </label>
+            <select
+              id="theme-generator-provider"
+              css={styles.providerSelect}
+              value={provider}
+              onChange={(event) => handleProviderChange(event.target.value)}
+            >
+              {Object.entries(THEME_PROVIDERS).map(([key, configuration]) => (
+                <option key={key} value={key}>{configuration.label}</option>
+              ))}
+            </select>
+            <span css={styles.sourceHint}>
+              {provider === 'ollama'
+                ? 'No API key or proxy required.'
+                : provider === 'fallback'
+                  ? 'No AI request is made.'
+                  : 'Credentials remain in memory and are never saved.'}
+            </span>
+          </Box>
+
+          {provider !== 'fallback' && (
+            <details css={styles.settingsDisclosure}>
+              <summary>Connection settings</summary>
+              {provider === 'ollama' && (
+                <Box css={styles.providerSettings}>
+              <label css={styles.fieldLabel} htmlFor="theme-generator-ollama-url">
+                Ollama URL
+              </label>
+              <input
+                id="theme-generator-ollama-url"
+                css={styles.input}
+                value={ollamaUrl}
+                onChange={(event) => setOllamaUrl(event.target.value)}
+                placeholder="http://localhost:11434"
+                inputMode="url"
+              />
+              <label css={styles.fieldLabel} htmlFor="theme-generator-ollama-model">
+                Ollama model
+              </label>
+              <input
+                id="theme-generator-ollama-model"
+                css={styles.input}
+                value={ollamaModel}
+                onChange={(event) => setOllamaModel(event.target.value)}
+                placeholder="gemma4"
+              />
+              <p css={styles.hint}>
+                Localhost only. Configure OLLAMA_ORIGINS if your browser reports CORS.
+              </p>
+                </Box>
+              )}
+
+              {provider !== 'ollama' && (
+                <Box css={styles.providerSettings}>
+              <label css={styles.fieldLabel} htmlFor="theme-generator-cloud-url">
+                API base URL
+              </label>
+              <input
+                id="theme-generator-cloud-url"
+                css={styles.input}
+                value={cloudUrl}
+                onChange={(event) => setCloudUrl(event.target.value)}
+                inputMode="url"
+              />
+              <label css={styles.fieldLabel} htmlFor="theme-generator-cloud-model">
+                Model
+              </label>
+              <input
+                id="theme-generator-cloud-model"
+                css={styles.input}
+                value={cloudModel}
+                onChange={(event) => setCloudModel(event.target.value)}
+              />
+              <label css={styles.fieldLabel} htmlFor="theme-generator-api-key">
+                API key
+              </label>
+              <input
+                id="theme-generator-api-key"
+                type="password"
+                css={styles.input}
+                value={apiKey}
+                onChange={(event) => setApiKey(event.target.value)}
+                autoComplete="off"
+              />
+              <p css={styles.hint}>
+                This key is held only for this editor session.
+              </p>
+                </Box>
+              )}
+            </details>
+          )}
+
+          <Box>
+            <label css={styles.fieldLabel} htmlFor="theme-generator-prompt">
+              Theme direction
+            </label>
+            <textarea
+              id="theme-generator-prompt"
+              css={styles.textarea}
+              value={prompt}
+              onChange={(event) => setPrompt(event.target.value)}
+              placeholder='e.g. "warm amber with violet accents, rounded, dark, professional"'
+              rows={3}
+            />
+          </Box>
+
+          {(isGenerating || candidate || status !== 'Describe a brand direction to create a reviewable theme draft.') && (
+            <Box css={styles.status} role="status" aria-live="polite">
+              {isGenerating && <span css={styles.dot} aria-hidden="true" />}
+              {status}
+            </Box>
+          )}
+
+          {previewScheme && (
+            <Box css={styles.preview}>
+              <Box css={styles.previewHeader}>
+                <span css={styles.fieldLabel}>Draft · {candidate.mode}</span>
+                <span css={candidate.source === 'fallback' ? styles.localChip : styles.ollamaChip}>
+                  {THEME_PROVIDERS[candidate.source]?.label ?? 'Fallback'}
+                </span>
+              </Box>
+              <Box css={styles.swatchRow}>
+                {SWATCH_KEYS.map(({ key, label }) => (
+                  <Box key={key} css={styles.swatchItem}>
+                    <Box
+                      css={styles.swatchColor}
+                      style={{ backgroundColor: previewScheme[key] }}
+                      aria-label={`${label}: ${previewScheme[key]}`}
+                    />
+                    <span css={styles.swatchLabel}>{label}</span>
+                  </Box>
+                ))}
+              </Box>
+              <Box css={styles.styleControls}>
+                <Box css={styles.styleControl}>
+                  <span css={styles.fieldLabel}>Corner shape</span>
+                  <Box css={styles.styleOptionRow}>
+                    {RADIUS_OPTIONS.map(([value, label]) => (
+                      <button
+                        type="button"
+                        key={value}
+                        css={candidate.theme.radius === value ? styles.styleOptionActive : styles.styleOption}
+                        onClick={() => handleStyleChange({ radius: value })}
+                      >
+                        {label}
+                      </button>
+                    ))}
+                  </Box>
+                </Box>
+                <Box css={styles.styleControl}>
+                  <span css={styles.fieldLabel}>Typeface</span>
+                  <Box css={styles.fontSelect}>
+                    <StaticSelect
+                      options={FONT_FAMILY_OPTIONS}
+                      placeholder="Choose font"
+                      value={candidate.theme.typography?.default?.fontFamily}
+                      onSelect={(fontFamily) => handleStyleChange({ fontFamily })}
+                    />
+                  </Box>
+                </Box>
+                <Box css={styles.styleControl}>
+                  <span css={styles.fieldLabel}>Message view</span>
+                  <Box css={styles.styleOptionRow}>
+                    {MESSAGE_VIEW_OPTIONS.map(({ value, label }) => (
+                      <button
+                        type="button"
+                        key={value}
+                        css={candidate.variants.messageView === value ? styles.styleOptionActive : styles.styleOption}
+                        onClick={() => handleVariantChange('messageView', value)}
+                      >
+                        {label}
+                      </button>
+                    ))}
+                  </Box>
+                </Box>
+                <Box css={styles.styleControl}>
+                  <span css={styles.fieldLabel}>Display name</span>
+                  <Box css={styles.styleOptionRow}>
+                    {DISPLAY_NAME_OPTIONS.map(({ value, label }) => (
+                      <button
+                        type="button"
+                        key={value}
+                        css={candidate.variants.displayName === value ? styles.styleOptionActive : styles.styleOption}
+                        onClick={() => handleVariantChange('displayName', value)}
+                      >
+                        {label}
+                      </button>
+                    ))}
+                  </Box>
+                </Box>
+              </Box>
+              <details css={styles.paletteEditor}>
+                <summary>Customize palette</summary>
+                <Box css={styles.paletteEditorHeader}>
+                  <span css={styles.fieldLabel}>Editing tokens</span>
+                  <Box css={styles.paletteModeToggle} role="group" aria-label="Palette mode">
+                    {['light', 'dark'].map((nextMode) => (
+                      <button
+                        type="button"
+                        key={nextMode}
+                        css={paletteMode === nextMode ? styles.paletteModeActive : styles.paletteModeButton}
+                        onClick={() => {
+                          setPaletteMode(nextMode);
+                          setVisiblePalettePicker(null);
+                          endPaletteEdit();
+                        }}
+                      >
+                        {nextMode}
+                      </button>
+                    ))}
+                  </Box>
+                </Box>
+                <Box css={styles.paletteControls} ref={palettePickerRef}>
+                  {PALETTE_GROUPS.map(({ label: groupLabel, tokens }) => (
+                    <details key={groupLabel} css={styles.paletteGroup}>
+                      <summary>{groupLabel}</summary>
+                      <Box css={styles.paletteTokenGrid}>
+                        {tokens.map(([token, label]) => {
+                          const value = editableScheme[token];
+                          const pickerId = `${paletteMode}-${token}`;
+                          return (
+                            <Box key={token} css={styles.paletteControl}>
+                              <button
+                                type="button"
+                                css={styles.colorPickerTrigger}
+                                style={{ backgroundColor: value }}
+                                onClick={() => {
+                                  beginPaletteEdit();
+                                  setVisiblePalettePicker((visible) =>
+                                    visible === pickerId ? null : pickerId
+                                  );
+                                }}
+                                aria-label={`Choose ${label.toLowerCase()} color`}
+                                aria-expanded={visiblePalettePicker === pickerId}
+                              />
+                              <span>{label}</span>
+                              <code css={styles.colorCode}>{colorToHex(value) ?? value}</code>
+                              {visiblePalettePicker === pickerId && (
+                                <Box css={styles.colorPickerPopup}>
+                                  <ColorPicker
+                                    color={value}
+                                    onChange={(updatedColor) =>
+                                      handlePaletteChange(token, updatedColor.hex)
+                                    }
+                                  />
+                                </Box>
+                              )}
+                            </Box>
+                          );
+                        })}
+                      </Box>
+                    </details>
+                  ))}
+                </Box>
+                <p css={styles.hint}>
+                  Paired text colors are repaired automatically; unsafe changes are rejected.
+                </p>
+              </details>
+            </Box>
+          )}
+
+          {candidate && (
+            <Box css={styles.followUp}>
+              <label css={styles.fieldLabel} htmlFor="theme-generator-follow-up">
+                Refine this draft
+              </label>
+              <textarea
+                id="theme-generator-follow-up"
+                css={styles.followUpInput}
+                value={followUp}
+                onChange={(event) => setFollowUp(event.target.value)}
+                placeholder='e.g. "Keep the colors, make it more rounded and use a serif font"'
+                rows={2}
+                disabled={isGenerating}
+              />
+              <Box css={styles.followUpActions}>
+                <button
+                  type="button"
+                  css={styles.secondaryBtn}
+                  onClick={handleFollowUp}
+                  disabled={!followUp.trim() || isGenerating}
+                >
+                  Refine draft
+                </button>
+                {draftHistory.length > 0 && (
+                  <button type="button" css={styles.textBtn} onClick={handleUndoDraft}>
+                    Undo revision ({draftHistory.length})
+                  </button>
+                )}
+              </Box>
+              <p css={styles.hint}>
+                Revisions retain the existing tokens unless you ask to change them.
+              </p>
+            </Box>
+          )}
+
+          <Box css={styles.btnRow}>
+            {isGenerating ? (
+              <button type="button" css={styles.secondaryBtn} onClick={handleCancel}>
+                Cancel
+              </button>
+            ) : (
+              <button
+                type="button"
+                css={styles.generateBtn}
+                onClick={handleGenerate}
+                disabled={!prompt.trim()}
+              >
+                {candidate ? 'Start new draft' : 'Generate draft'}
+              </button>
+            )}
+            {candidate && !isGenerating && (
+              <button type="button" css={styles.applyBtn} onClick={handleApply}>
+                Apply draft
+              </button>
+            )}
+          </Box>
+
+          <Box css={styles.exportRow}>
+            <button type="button" css={styles.textBtn} onClick={handleCopy}>
+              Copy JSON
+            </button>
+            <button type="button" css={styles.textBtn} onClick={handleDownload}>
+              Download JSON
+            </button>
+            {originalThemeRef.current && (
+              <button type="button" css={styles.textBtn} onClick={handleReset}>
+                Restore previous
+              </button>
+            )}
+          </Box>
+        </Box>
+      )}
+    </Box>
+  );
+};
+
+export default AIThemePanel;

--- a/packages/layout_editor/src/views/ThemeLab/AIThemePanel.styles.js
+++ b/packages/layout_editor/src/views/ThemeLab/AIThemePanel.styles.js
@@ -1,0 +1,588 @@
+import { css } from '@emotion/react';
+
+export const getAIThemePanelStyles = (theme) => ({
+  panel: css`
+    border: 1px solid ${theme.colors.border};
+    border-radius: ${theme.radius};
+    overflow: hidden;
+  `,
+
+  header: css`
+    width: 100%;
+    display: flex;
+    align-items: center;
+    justify-content: space-between;
+    padding: 0.7rem 0.75rem;
+    border: 0;
+    background: ${theme.colors.card};
+    color: ${theme.colors.cardForeground};
+    cursor: pointer;
+    font: inherit;
+    text-align: left;
+
+    &:focus-visible {
+      outline: 2px solid ${theme.colors.ring};
+      outline-offset: -2px;
+    }
+  `,
+
+  headerTitle: css`
+    display: flex;
+    align-items: center;
+    gap: 0.45rem;
+    font-size: 0.875rem;
+    font-weight: 700;
+  `,
+
+  badge: css`
+    padding: 0.12rem 0.38rem;
+    border-radius: 999px;
+    background: ${theme.colors.accent};
+    color: ${theme.colors.accentForeground};
+    font-size: 0.62rem;
+    font-weight: 700;
+    letter-spacing: 0.04em;
+    text-transform: uppercase;
+  `,
+
+  body: css`
+    display: flex;
+    flex-direction: column;
+    gap: 0.65rem;
+    padding: 0.75rem;
+    background: ${theme.colors.background};
+  `,
+
+  intro: css`
+    margin: 0;
+    color: ${theme.colors.mutedForeground};
+    font-size: 0.76rem;
+    line-height: 1.45;
+  `,
+
+  sourceRow: css`
+    display: flex;
+    flex-wrap: wrap;
+    align-items: center;
+    justify-content: space-between;
+    gap: 0.35rem;
+    padding: 0.35rem 0;
+  `,
+
+  providerLabel: css`
+    display: flex;
+    align-items: center;
+    gap: 0.4rem;
+    color: ${theme.colors.foreground};
+    font-size: 0.76rem;
+    font-weight: 600;
+  `,
+
+  providerSelect: css`
+    min-width: 10rem;
+    padding: 0.35rem 0.45rem;
+    border: 1px solid ${theme.colors.input};
+    border-radius: ${theme.radius};
+    background: ${theme.colors.background};
+    color: ${theme.colors.foreground};
+    font: inherit;
+    font-size: 0.76rem;
+
+    &:focus-visible {
+      outline: 2px solid ${theme.colors.ring};
+      outline-offset: 1px;
+    }
+  `,
+
+  sourceHint: css`
+    color: ${theme.colors.mutedForeground};
+    font-size: 0.68rem;
+  `,
+
+  settingsDisclosure: css`
+    padding: 0.45rem 0.55rem;
+    border: 1px solid ${theme.colors.border};
+    border-radius: ${theme.radius};
+    background: ${theme.colors.card};
+
+    > summary {
+      color: ${theme.colors.mutedForeground};
+      cursor: pointer;
+      font-size: 0.7rem;
+      font-weight: 600;
+    }
+
+    &[open] > summary {
+      margin-bottom: 0.55rem;
+      color: ${theme.colors.foreground};
+    }
+  `,
+
+  fieldLabel: css`
+    display: block;
+    margin-bottom: 0.3rem;
+    color: ${theme.colors.mutedForeground};
+    font-size: 0.68rem;
+    font-weight: 700;
+    letter-spacing: 0.05em;
+    text-transform: uppercase;
+  `,
+
+  input: css`
+    box-sizing: border-box;
+    width: 100%;
+    padding: 0.45rem 0.55rem;
+    border: 1px solid ${theme.colors.input};
+    border-radius: ${theme.radius};
+    background: ${theme.colors.background};
+    color: ${theme.colors.foreground};
+    font: inherit;
+    font-size: 0.78rem;
+
+    &:focus-visible {
+      outline: 2px solid ${theme.colors.ring};
+      outline-offset: 1px;
+    }
+  `,
+
+  textarea: css`
+    box-sizing: border-box;
+    width: 100%;
+    min-height: 4.5rem;
+    resize: vertical;
+    padding: 0.45rem 0.55rem;
+    border: 1px solid ${theme.colors.input};
+    border-radius: ${theme.radius};
+    background: ${theme.colors.background};
+    color: ${theme.colors.foreground};
+    font: inherit;
+    font-size: 0.78rem;
+    line-height: 1.45;
+
+    &:focus-visible {
+      outline: 2px solid ${theme.colors.ring};
+      outline-offset: 1px;
+    }
+  `,
+
+  hint: css`
+    margin: 0.3rem 0 0;
+    color: ${theme.colors.mutedForeground};
+    font-size: 0.68rem;
+    line-height: 1.4;
+  `,
+
+  providerSettings: css`
+    display: flex;
+    flex-direction: column;
+    gap: 0.35rem;
+  `,
+
+  status: css`
+    display: flex;
+    align-items: center;
+    gap: 0.4rem;
+    color: ${theme.colors.mutedForeground};
+    font-size: 0.7rem;
+    line-height: 1.4;
+  `,
+
+  preview: css`
+    padding: 0.7rem;
+    border: 1px solid ${theme.colors.border};
+    border-radius: ${theme.radius};
+    background: ${theme.colors.card};
+  `,
+
+  previewHeader: css`
+    display: flex;
+    align-items: center;
+    justify-content: space-between;
+    gap: 0.5rem;
+  `,
+
+  swatchRow: css`
+    display: grid;
+    grid-template-columns: repeat(5, minmax(0, 1fr));
+    gap: 0.35rem;
+  `,
+
+  swatchItem: css`
+    display: flex;
+    min-width: 0;
+    flex-direction: column;
+    align-items: center;
+    gap: 0.22rem;
+  `,
+
+  swatchColor: css`
+    width: 100%;
+    height: 1.35rem;
+    border: 1px solid ${theme.colors.border};
+    border-radius: calc(${theme.radius} / 1.5);
+  `,
+
+  swatchLabel: css`
+    overflow: hidden;
+    max-width: 100%;
+    color: ${theme.colors.mutedForeground};
+    font-size: 0.6rem;
+    text-overflow: ellipsis;
+    white-space: nowrap;
+  `,
+
+  styleControls: css`
+    display: grid;
+    grid-template-columns: repeat(2, minmax(0, 1fr));
+    gap: 0.45rem;
+    margin-top: 0.6rem;
+  `,
+
+  styleControl: css`
+    min-width: 0;
+  `,
+
+  fontSelect: css`
+    position: relative;
+    z-index: 3;
+
+    .ec-static-select {
+      width: 100%;
+      min-width: 0;
+    }
+
+    .ec-static-select > div:first-of-type {
+      min-height: 0;
+      padding: 0.15rem 0.35rem;
+      font-size: 0.68rem;
+    }
+  `,
+
+  styleOptionRow: css`
+    display: flex;
+    overflow: hidden;
+    border: 1px solid ${theme.colors.border};
+    border-radius: calc(${theme.radius} / 1.5);
+  `,
+
+  styleOption: css`
+    flex: 1;
+    min-width: 0;
+    padding: 0.3rem 0.18rem;
+    border: 0;
+    background: transparent;
+    color: ${theme.colors.mutedForeground};
+    cursor: pointer;
+    font: inherit;
+    font-size: 0.62rem;
+  `,
+
+  styleOptionActive: css`
+    flex: 1;
+    min-width: 0;
+    padding: 0.3rem 0.18rem;
+    border: 0;
+    background: ${theme.colors.primary};
+    color: ${theme.colors.primaryForeground};
+    cursor: pointer;
+    font: inherit;
+    font-size: 0.62rem;
+    font-weight: 700;
+  `,
+
+  paletteEditor: css`
+    margin-top: 0.7rem;
+    padding: 0.55rem;
+    border: 1px solid ${theme.colors.border};
+    border-radius: calc(${theme.radius} / 1.5);
+    background: ${theme.colors.background};
+
+    > summary {
+      color: ${theme.colors.foreground};
+      cursor: pointer;
+      font-size: 0.72rem;
+      font-weight: 700;
+    }
+
+    &[open] > summary {
+      margin-bottom: 0.6rem;
+    }
+  `,
+
+  paletteEditorHeader: css`
+    display: flex;
+    align-items: center;
+    justify-content: space-between;
+    gap: 0.5rem;
+  `,
+
+  paletteModeToggle: css`
+    display: inline-flex;
+    overflow: hidden;
+    border: 1px solid ${theme.colors.border};
+    border-radius: calc(${theme.radius} / 1.5);
+  `,
+
+  paletteModeButton: css`
+    padding: 0.22rem 0.42rem;
+    border: 0;
+    background: transparent;
+    color: ${theme.colors.mutedForeground};
+    cursor: pointer;
+    font: inherit;
+    font-size: 0.62rem;
+    text-transform: capitalize;
+  `,
+
+  paletteModeActive: css`
+    padding: 0.22rem 0.42rem;
+    border: 0;
+    background: ${theme.colors.primary};
+    color: ${theme.colors.primaryForeground};
+    cursor: pointer;
+    font: inherit;
+    font-size: 0.62rem;
+    text-transform: capitalize;
+  `,
+
+  paletteControls: css`
+    display: flex;
+    flex-direction: column;
+    gap: 0.45rem;
+  `,
+
+  paletteGroup: css`
+    border: 1px solid ${theme.colors.border};
+    border-radius: calc(${theme.radius} / 1.5);
+    background: ${theme.colors.background};
+
+    > summary {
+      padding: 0.4rem 0.45rem;
+      color: ${theme.colors.foreground};
+      cursor: pointer;
+      font-size: 0.68rem;
+      font-weight: 700;
+    }
+  `,
+
+  paletteTokenGrid: css`
+    display: grid;
+    grid-template-columns: repeat(2, minmax(0, 1fr));
+    gap: 0.4rem;
+    padding: 0 0.4rem 0.4rem;
+  `,
+
+  paletteControl: css`
+    position: relative;
+    display: grid;
+    grid-template-columns: auto minmax(0, 1fr);
+    align-items: center;
+    gap: 0.35rem;
+    min-width: 0;
+    padding: 0.38rem;
+    border: 1px solid ${theme.colors.border};
+    border-radius: calc(${theme.radius} / 1.5);
+    color: ${theme.colors.foreground};
+    font-size: 0.68rem;
+    font-weight: 600;
+  `,
+
+  colorPickerTrigger: css`
+    width: 1.5rem;
+    height: 1.5rem;
+    padding: 0;
+    border: 1px solid ${theme.colors.border};
+    border-radius: calc(${theme.radius} / 1.5);
+    cursor: pointer;
+
+    &:focus-visible {
+      outline: 2px solid ${theme.colors.ring};
+      outline-offset: 2px;
+    }
+  `,
+
+  colorPickerPopup: css`
+    position: absolute;
+    top: calc(100% + 0.35rem);
+    left: 0;
+    z-index: 2;
+    box-shadow: ${theme.shadows[2]};
+
+    .saturation-white,
+    .saturation-black,
+    .hue-horizontal {
+      cursor: pointer;
+    }
+  `,
+
+  colorCode: css`
+    grid-column: 1 / -1;
+    overflow: hidden;
+    color: ${theme.colors.mutedForeground};
+    font-family: ui-monospace, SFMono-Regular, Menlo, monospace;
+    font-size: 0.62rem;
+    text-overflow: ellipsis;
+    white-space: nowrap;
+  `,
+
+  accentPreview: css`
+    margin-top: 0.55rem;
+    padding: 0.35rem 0.55rem;
+    border-radius: calc(${theme.radius} / 1.5);
+    font-size: 0.7rem;
+    font-weight: 700;
+    text-align: center;
+  `,
+
+  ollamaChip: css`
+    padding: 0.15rem 0.4rem;
+    border-radius: 999px;
+    background: ${theme.colors.info};
+    color: ${theme.colors.infoForeground};
+    font-size: 0.64rem;
+    font-weight: 600;
+  `,
+
+  localChip: css`
+    padding: 0.15rem 0.4rem;
+    border-radius: 999px;
+    background: ${theme.colors.muted};
+    color: ${theme.colors.mutedForeground};
+    font-size: 0.64rem;
+    font-weight: 600;
+  `,
+
+  passedReport: css`
+    margin-top: 0.65rem;
+    color: ${theme.colors.successForeground};
+    font-size: 0.7rem;
+    line-height: 1.4;
+  `,
+
+  failedReport: css`
+    margin-top: 0.65rem;
+    color: ${theme.colors.destructive};
+    font-size: 0.7rem;
+    line-height: 1.4;
+  `,
+
+  followUp: css`
+    padding: 0.55rem 0 0;
+    border-top: 1px solid ${theme.colors.border};
+  `,
+
+  followUpInput: css`
+    box-sizing: border-box;
+    width: 100%;
+    min-height: 3.2rem;
+    resize: vertical;
+    padding: 0.45rem 0.55rem;
+    border: 1px solid ${theme.colors.input};
+    border-radius: ${theme.radius};
+    background: ${theme.colors.background};
+    color: ${theme.colors.foreground};
+    font: inherit;
+    font-size: 0.78rem;
+    line-height: 1.45;
+
+    &:focus-visible {
+      outline: 2px solid ${theme.colors.ring};
+      outline-offset: 1px;
+    }
+  `,
+
+  followUpActions: css`
+    display: flex;
+    align-items: center;
+    gap: 0.65rem;
+    margin-top: 0.45rem;
+
+    > button:first-of-type {
+      width: auto;
+    }
+  `,
+
+  btnRow: css`
+    display: flex;
+    gap: 0.45rem;
+  `,
+
+  generateBtn: css`
+    flex: 1;
+    padding: 0.48rem 0.7rem;
+    border: 0;
+    border-radius: ${theme.radius};
+    background: ${theme.colors.primary};
+    color: ${theme.colors.primaryForeground};
+    cursor: pointer;
+    font: inherit;
+    font-size: 0.76rem;
+    font-weight: 700;
+
+    &:disabled {
+      cursor: not-allowed;
+      opacity: 0.55;
+    }
+  `,
+
+  applyBtn: css`
+    flex: 1;
+    padding: 0.48rem 0.7rem;
+    border: 0;
+    border-radius: ${theme.radius};
+    background: ${theme.colors.success};
+    color: ${theme.colors.successForeground};
+    cursor: pointer;
+    font: inherit;
+    font-size: 0.76rem;
+    font-weight: 700;
+  `,
+
+  secondaryBtn: css`
+    width: 100%;
+    padding: 0.48rem 0.7rem;
+    border: 1px solid ${theme.colors.border};
+    border-radius: ${theme.radius};
+    background: transparent;
+    color: ${theme.colors.foreground};
+    cursor: pointer;
+    font: inherit;
+    font-size: 0.76rem;
+  `,
+
+  exportRow: css`
+    display: flex;
+    flex-wrap: wrap;
+    gap: 0.55rem;
+  `,
+
+  textBtn: css`
+    padding: 0;
+    border: 0;
+    background: transparent;
+    color: ${theme.colors.primary};
+    cursor: pointer;
+    font: inherit;
+    font-size: 0.7rem;
+    font-weight: 600;
+    text-decoration: underline;
+  `,
+
+  dot: css`
+    width: 0.5rem;
+    height: 0.5rem;
+    border-radius: 50%;
+    background: ${theme.colors.primary};
+    animation: ai-theme-pulse 1s ease-in-out infinite;
+
+    @media (prefers-reduced-motion: reduce) {
+      animation: none;
+    }
+
+    @keyframes ai-theme-pulse {
+      50% {
+        opacity: 0.3;
+      }
+    }
+  `,
+});

--- a/packages/layout_editor/src/views/ThemeLab/ColorManager.jsx
+++ b/packages/layout_editor/src/views/ThemeLab/ColorManager.jsx
@@ -6,19 +6,9 @@ import React, {
   useMemo,
 } from 'react';
 import { Box, useTheme } from '@embeddedchat/ui-elements';
-import { ChromePicker } from 'react-color';
 import { getColorMangerStyles } from './ThemeLab.styles';
 import debounce from 'lodash/debounce';
-
-const ColorPicker = ({ color, onChange }) => {
-  return (
-    <ChromePicker
-      color={color}
-      disableAlpha={true}
-      onChange={(updatedColor) => onChange(updatedColor.hsl)}
-    />
-  );
-};
+import ColorPicker from './ColorPicker';
 
 const ColorManager = () => {
   const { theme, mode, setTheme } = useTheme();
@@ -100,7 +90,7 @@ const ColorManager = () => {
             <Box css={styles.colorPicker} ref={pickerRef}>
               <ColorPicker
                 color={value}
-                onChange={(newColor) => handleColorChange(key, newColor)}
+                onChange={(newColor) => handleColorChange(key, newColor.hsl)}
               />
             </Box>
           )}

--- a/packages/layout_editor/src/views/ThemeLab/ColorPicker.jsx
+++ b/packages/layout_editor/src/views/ThemeLab/ColorPicker.jsx
@@ -1,0 +1,8 @@
+import React from 'react';
+import { ChromePicker } from 'react-color';
+
+const ColorPicker = ({ color, onChange }) => (
+  <ChromePicker color={color} disableAlpha={true} onChange={onChange} />
+);
+
+export default ColorPicker;

--- a/packages/layout_editor/src/views/ThemeLab/FontManager.jsx
+++ b/packages/layout_editor/src/views/ThemeLab/FontManager.jsx
@@ -1,36 +1,12 @@
 import React, { useState } from 'react';
 import { Box, StaticSelect, useTheme } from '@embeddedchat/ui-elements';
 import { getFontManagerStyles } from './ThemeLab.styles';
+import { FONT_FAMILY_OPTIONS } from './themeOptions';
 
 const FontManager = () => {
   const themeObj = useTheme();
   const styles = getFontManagerStyles(themeObj);
   const { theme, setTheme } = themeObj;
-
-  const fontFamilyOptions = [
-    { label: 'Arial', value: 'Arial, sans-serif' },
-    { label: 'Arial Black', value: '"Arial Black", Gadget, sans-serif' },
-    { label: 'Comic Sans MS', value: '"Comic Sans MS", cursive, sans-serif' },
-    { label: 'Courier New', value: '"Courier New", Courier, monospace' },
-    { label: 'Georgia', value: 'Georgia, serif' },
-    { label: 'Helvetica', value: 'Helvetica, sans-serif' },
-    { label: 'Impact', value: 'Impact, Charcoal, sans-serif' },
-    { label: 'Lucida Console', value: '"Lucida Console", Monaco, monospace' },
-    {
-      label: 'Lucida Sans Unicode',
-      value: '"Lucida Sans Unicode", "Lucida Grande", sans-serif',
-    },
-    {
-      label: 'Palatino Linotype',
-      value: '"Palatino Linotype", "Book Antiqua", Palatino, serif',
-    },
-    { label: 'Tahoma', value: 'Tahoma, Geneva, sans-serif' },
-    { label: 'Times New Roman', value: "'Times New Roman', serif" },
-    { label: 'Trebuchet MS', value: '"Trebuchet MS", Helvetica, sans-serif' },
-    { label: 'Verdana', value: 'Verdana, Geneva, sans-serif' },
-    { label: 'MS Sans Serif', value: '"MS Sans Serif", Geneva, sans-serif' },
-    { label: 'MS Serif', value: '"MS Serif", "New York", serif' },
-  ];
 
   const fontSizeOptions = [
     { label: 'Small', value: 12 },
@@ -105,7 +81,7 @@ const FontManager = () => {
           <b>Font Family</b>
         </Box>
         <StaticSelect
-          options={fontFamilyOptions}
+          options={FONT_FAMILY_OPTIONS}
           style={{ position: 'absolute', top: '16px', right: 0, zIndex: 2 }}
           placeholder="Choose"
           value={fontFamily}

--- a/packages/layout_editor/src/views/ThemeLab/LayoutSetting.jsx
+++ b/packages/layout_editor/src/views/ThemeLab/LayoutSetting.jsx
@@ -6,6 +6,10 @@ import SurfaceItem from '../../components/SurfaceMenu/SurfaceItem';
 import useHeaderItemsStore from '../../store/headerItemsStore';
 import useMessageItemsStore from '../../store/messageItemsStore';
 import useChatInputItemsStore from '../../store/chatInputItemsStore';
+import {
+  DISPLAY_NAME_OPTIONS,
+  MESSAGE_VIEW_OPTIONS,
+} from './themeOptions';
 
 const LayoutSetting = () => {
   const styles = getLayoutSettings(useTheme());
@@ -17,30 +21,6 @@ const LayoutSetting = () => {
       displayName: state.displayName,
       setDisplayName: state.setDisplayName,
     }));
-
-  const messageViewOptions = [
-    {
-      label: 'Flat',
-      value: 'flat',
-    },
-
-    {
-      label: 'Bubble',
-      value: 'bubble',
-    },
-  ];
-
-  const displayNameOptions = [
-    {
-      label: 'Normal',
-      value: 'normal',
-    },
-
-    {
-      label: 'Colorize',
-      value: 'colorize',
-    },
-  ];
 
   const {
     surfaceItems: headerSurfaceItems,
@@ -422,7 +402,7 @@ const LayoutSetting = () => {
             <b>Message View</b>
           </Box>
           <StaticSelect
-            options={messageViewOptions}
+            options={MESSAGE_VIEW_OPTIONS}
             style={{
               position: 'absolute',
               top: '16px',
@@ -440,7 +420,7 @@ const LayoutSetting = () => {
             <b>Display Name</b>
           </Box>
           <StaticSelect
-            options={displayNameOptions}
+            options={DISPLAY_NAME_OPTIONS}
             style={{ position: 'absolute', top: '16px', right: 0 }}
             placeholder="Choose"
             value={displayName}

--- a/packages/layout_editor/src/views/ThemeLab/ThemeSetting.jsx
+++ b/packages/layout_editor/src/views/ThemeLab/ThemeSetting.jsx
@@ -3,6 +3,7 @@ import { Box, StaticSelect, useTheme } from '@embeddedchat/ui-elements';
 import { getPaletteSettings } from './ThemeLab.styles';
 import ColorManager from './ColorManager';
 import FontManager from './FontManager';
+import AIThemePanel from './AIThemePanel';
 
 const ThemeSetting = () => {
   const themeObject = useTheme();
@@ -54,6 +55,7 @@ const ThemeSetting = () => {
         <h3>Typography</h3>
         <FontManager />
       </Box>
+      <AIThemePanel />
     </Box>
   );
 };

--- a/packages/layout_editor/src/views/ThemeLab/themeOptions.js
+++ b/packages/layout_editor/src/views/ThemeLab/themeOptions.js
@@ -1,0 +1,34 @@
+export const FONT_FAMILY_OPTIONS = [
+  { label: 'Arial', value: 'Arial, sans-serif' },
+  { label: 'Arial Black', value: '"Arial Black", Gadget, sans-serif' },
+  { label: 'Comic Sans MS', value: '"Comic Sans MS", cursive, sans-serif' },
+  { label: 'Courier New', value: '"Courier New", Courier, monospace' },
+  { label: 'Georgia', value: 'Georgia, serif' },
+  { label: 'Helvetica', value: 'Helvetica, sans-serif' },
+  { label: 'Impact', value: 'Impact, Charcoal, sans-serif' },
+  { label: 'Lucida Console', value: '"Lucida Console", Monaco, monospace' },
+  {
+    label: 'Lucida Sans Unicode',
+    value: '"Lucida Sans Unicode", "Lucida Grande", sans-serif',
+  },
+  {
+    label: 'Palatino Linotype',
+    value: '"Palatino Linotype", "Book Antiqua", Palatino, serif',
+  },
+  { label: 'Tahoma', value: 'Tahoma, Geneva, sans-serif' },
+  { label: 'Times New Roman', value: "'Times New Roman', serif" },
+  { label: 'Trebuchet MS', value: '"Trebuchet MS", Helvetica, sans-serif' },
+  { label: 'Verdana', value: 'Verdana, Geneva, sans-serif' },
+  { label: 'MS Sans Serif', value: '"MS Sans Serif", Geneva, sans-serif' },
+  { label: 'MS Serif', value: '"MS Serif", "New York", serif' },
+];
+
+export const MESSAGE_VIEW_OPTIONS = [
+  { label: 'Flat', value: 'flat' },
+  { label: 'Bubble', value: 'bubble' },
+];
+
+export const DISPLAY_NAME_OPTIONS = [
+  { label: 'Normal', value: 'normal' },
+  { label: 'Colorize', value: 'colorize' },
+];

--- a/packages/react/src/views/ChatHeader/ChatHeader.js
+++ b/packages/react/src/views/ChatHeader/ChatHeader.js
@@ -561,6 +561,7 @@ const ChatHeader = ({
           {menuOptions.length > 0 && <Menu options={menuOptions} />}
         </Box>
       </Box>
+
       {isThreadOpen && (
         <DynamicHeader
           title={threadMainMessage}

--- a/packages/ui-elements/src/components/Button/Button.styles.js
+++ b/packages/ui-elements/src/components/Button/Button.styles.js
@@ -84,7 +84,9 @@ const getButtonStyles = (theme) => {
       }
       &.ghost {
         background: none;
-        color: ${theme.colors[`${type}`] || theme.colors.accentForeground};
+        color: ${type === 'default'
+          ? theme.colors.foreground
+          : theme.colors[`${type}`] || theme.colors.foreground};
         border: none;
       }
       &.disabled.ghost {

--- a/yarn.lock
+++ b/yarn.lock
@@ -20501,6 +20501,7 @@ __metadata:
   dependencies:
     "@dnd-kit/core": ^6.1.0
     "@dnd-kit/sortable": ^8.0.0
+    "@embeddedchat/ai-adapter": "workspace:*"
     "@embeddedchat/markups": "workspace:^"
     "@embeddedchat/ui-elements": "workspace:^"
     "@emotion/babel-preset-css-prop": ^11.11.0


### PR DESCRIPTION
# feat(layout-editor): add developer AI theme generator

## Acceptance Criteria fulfillment

- [x] Add a developer-only AI Theme Generator to the Layout Editor with direct local Ollama support, optional OpenAI/Gemini adapters, and an offline deterministic fallback. No proxy is required.
- [x] Support theme generation, focused follow-up refinements, undo, palette editing, typography, corner shape, message view, display-name variants, apply/reset, and JSON copy/download.
- [x] Generate accessible light and dark theme schemes, preserve readable chat metadata and controls, and document local setup and CORS configuration.
- [x] Reuses existing Layout Editor color-picker and configuration options



## Video/Screenshots


https://github.com/user-attachments/assets/46e32153-6dfc-49ae-978b-35d5f4d22451



## PR Test Details

**Note**: The PR will be ready for live testing at https://rocketchat.github.io/EmbeddedChat/pulls/pr-<pr_number> after approval. Contributors are requested to replace `<pr_number>` with the actual PR number.