### PR TITLE
fix(react): remove stray parenthesis rendered in ImageGallery

### DIFF
--- a/packages/react/src/views/ImageGallery/ImageGallery.js
+++ b/packages/react/src/views/ImageGallery/ImageGallery.js
@@ -109,7 +109,6 @@ const ImageGallery = ({ currentFileId, setShowGallery }) => {
                 </SwiperSlide>
               ))}
             </Swiper>
-            )
           </Box>
         )}
       </Box>


### PR DESCRIPTION
## Description
The `ImageGallery` view had a stray `)` inside the swiper container, right after the closing `</Swiper>` tag. In JSX this bare character is rendered as a literal text node, so a `)` was showing below the image slider in the gallery overlay. Removing it fixes the stray character with no behavior change.

## Acceptance Criteria fulfillment
- [x] Removed the stray `)` text node in `ImageGallery.js`
- [x] No functional/behavior change to the gallery

## PR Test Details
Open a chat with image attachments, click an image to open the Image Gallery — the stray `)` no longer appears next to the slider.
