### PR TITLE
fix(react): correct 'conatiner' typo to 'container' in ReportMessage

### DIFF
--- a/packages/react/src/views/ReportMessage/MessageReportWindow.js
+++ b/packages/react/src/views/ReportMessage/MessageReportWindow.js
@@ -17,7 +17,7 @@ const MessageReportWindow = ({ messageId, message }) => {
       messageId={messageId}
       message={message}
     >
-      <Box css={styles.conatiner}>
+      <Box css={styles.container}>
         <Input
           textArea
           placeholder="Why do you want to report this message?"

--- a/packages/react/src/views/ReportMessage/ReportMessage.styles.js
+++ b/packages/react/src/views/ReportMessage/ReportMessage.styles.js
@@ -1,7 +1,7 @@
 import { css } from '@emotion/react';
 
 const styles = {
-  conatiner: css`
+  container: css`
     display: flex;
     justify-content: center;
     flex-direction: column;


### PR DESCRIPTION
## Description
The `ReportMessage` styles object defined its style key as `conatiner` (misspelled), and `MessageReportWindow` consumed it as `styles.conatiner`. This corrects the typo to `container` in both the definition and its usage. Purely a rename — no behavior change, since both the definition and the single consumer are updated together.

## Acceptance Criteria fulfillment
- [x] Renamed `conatiner` -> `container` in `ReportMessage.styles.js`
- [x] Updated the usage in `MessageReportWindow.js` to match
- [x] No functional/behavior change (only the affected style key was renamed)

## PR Test Details
Open a message's "Report" dialog — the report window renders exactly as before; only the internal style key name is corrected.
