### PR TITLE
fix(docs): add alt text to homepage logo image

### DIFF
--- a/packages/docs/src/pages/index.js
+++ b/packages/docs/src/pages/index.js
@@ -14,7 +14,7 @@ function HomepageHeader() {
   return (
     <header className={clsx("hero hero--primary", styles.heroBanner)}>
       <div className="container">
-        <img src={logo} />
+        <img src={logo} alt={`${siteConfig.title} logo`} />
         <Heading as="h1" className="hero__title">
           {siteConfig.title}
         </Heading>


### PR DESCRIPTION
## Description
The homepage hero `<img>` in the docs site had no `alt` attribute. This adds a meaningful `alt` (`"<siteTitle> logo"`) so screen-reader users get a description of the logo. No visual change.

## Acceptance Criteria fulfillment
- [x] Added `alt` text to the homepage logo image in `packages/docs/src/pages/index.js`
- [x] No visual/behavior change

## PR Test Details
Open the docs homepage — the logo renders exactly as before, and now exposes accessible `alt` text.
