### PR TITLE
fix(react): close thread view when its parent message is deleted

### DIFF
--- a/packages/react/src/store/messageStore.js
+++ b/packages/react/src/store/messageStore.js
@@ -59,9 +59,17 @@ const useMessageStore = create((set, get) => ({
       }));
     }
     if (message) {
+      const isThreadMainMessage = get().threadMainMessage?._id === messageId;
       return set((state) => ({
         deletedMessage: message,
         messages: cloneArray(state.messages).filter((m) => m._id !== messageId),
+        // If the deleted message is the parent of the open thread, close the
+        // thread so it doesn't keep showing a message that no longer exists.
+        ...(isThreadMainMessage && {
+          isThreadOpen: false,
+          threadMainMessage: null,
+          threadMessages: [],
+        }),
       }));
     }
   },


### PR DESCRIPTION
## Description
Fixes the state leak described in #1080. When the parent message of an open thread was deleted, `messageStore.removeMessage` removed the message from the main list (and from thread replies) but never checked whether the deleted message was the thread's `threadMainMessage`. As a result the Thread View stayed open, showing a stale copy of a message that no longer exists.

This updates `removeMessage` so that when the deleted message is the current `threadMainMessage`, the thread state is reset (`isThreadOpen: false`, `threadMainMessage: null`, `threadMessages: []`) in the same update — mirroring what `closeThread` already does. Since `removeMessage` is wired to the message-delete listener, this works for deletions from EmbeddedChat as well as from other clients.

## Acceptance Criteria fulfillment
- [x] Deleting a thread's parent message now closes the Thread View
- [x] Thread state is cleared from the store when the parent is removed
- [x] Deleting an unrelated message leaves the open thread untouched (guarded by the `threadMainMessage?._id === messageId` check)

## PR Test Details
1. Open a chat, open a message's thread.
2. Delete that parent message (from EmbeddedChat or another client).
3. The parent disappears from the main list **and** the Thread View now closes automatically instead of showing stale data.

Fixes #1080
